### PR TITLE
Adding dividends and stock splits support

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -49,7 +49,9 @@ private object YFinanceGateway {
     def getChart(ticker: Ticker, interval: Interval, range: Range): F[YFinanceQueryResult] = {
       val req =
         basicRequest.get(
-          ApiEndpoint.addPath(ticker.show).withParams(("interval", interval.show), ("range", range.show))
+          ApiEndpoint
+            .addPath(ticker.show)
+            .withParams(("interval", interval.show), ("range", range.show), ("events", "div,split"))
         )
 
       sendRequest(req, parseContent)
@@ -68,7 +70,8 @@ private object YFinanceGateway {
             .withParams(
               ("interval", interval.show),
               ("period1", since.toEpochSecond.show),
-              ("period2", until.toEpochSecond.show)
+              ("period2", until.toEpochSecond.show),
+              ("events", "div,split")
             )
         )
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ChartResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ChartResult.scala
@@ -4,10 +4,52 @@ import org.coinductive.yfinance4s.models.ChartResult.Quote
 
 import java.time.ZonedDateTime
 
-final case class ChartResult(quotes: List[Quote])
+/** Historical chart data with OHLCV quotes and corporate actions.
+  *
+  * This is the primary result type for historical price data queries. It includes both price/volume data and any
+  * dividend or split events that occurred during the requested time period.
+  *
+  * @param quotes
+  *   List of OHLCV price quotes, sorted chronologically.
+  * @param dividends
+  *   List of dividend events within the chart period, sorted chronologically.
+  * @param splits
+  *   List of stock split events within the chart period, sorted chronologically.
+  */
+final case class ChartResult(
+    quotes: List[Quote],
+    dividends: List[DividendEvent] = List.empty,
+    splits: List[SplitEvent] = List.empty
+) {
+
+  /** Returns corporate actions as a combined object.
+    */
+  def corporateActions: CorporateActions = CorporateActions(dividends, splits)
+
+  /** Whether any corporate actions occurred during this chart period.
+    */
+  def hasCorporateActions: Boolean = dividends.nonEmpty || splits.nonEmpty
+}
 
 object ChartResult {
 
+  /** A single OHLCV price quote.
+    *
+    * @param datetime
+    *   The timestamp for this quote (typically market close time).
+    * @param close
+    *   Closing price.
+    * @param open
+    *   Opening price.
+    * @param volume
+    *   Trading volume (number of shares traded).
+    * @param high
+    *   Highest price during the period.
+    * @param low
+    *   Lowest price during the period.
+    * @param adjclose
+    *   Adjusted closing price (accounts for dividends and splits).
+    */
   final case class Quote(
       datetime: ZonedDateTime,
       close: Double,

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/CorporateActions.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/CorporateActions.scala
@@ -1,0 +1,50 @@
+package org.coinductive.yfinance4s.models
+
+/** Aggregates all corporate actions for a ticker within a time period.
+  *
+  * Corporate actions are significant events initiated by a company that affect its shareholders, such as dividend
+  * payments and stock splits.
+  *
+  * @param dividends
+  *   List of dividend events, sorted chronologically by ex-date.
+  * @param splits
+  *   List of stock split events, sorted chronologically by ex-date.
+  */
+final case class CorporateActions(
+    dividends: List[DividendEvent],
+    splits: List[SplitEvent]
+) {
+
+  /** Whether there are any corporate actions in this result.
+    */
+  def isEmpty: Boolean = dividends.isEmpty && splits.isEmpty
+
+  /** Whether there are any corporate actions in this result.
+    */
+  def nonEmpty: Boolean = !isEmpty
+
+  /** Total sum of all dividend amounts.
+    */
+  def totalDividendAmount: Double = dividends.map(_.amount).sum
+
+  /** Cumulative split factor over the period. Multiply a pre-period share count by this factor to get post-period
+    * equivalent.
+    */
+  def cumulativeSplitFactor: Double =
+    if (splits.isEmpty) 1.0 else splits.map(_.factor).product
+
+  /** Number of dividend payments.
+    */
+  def dividendCount: Int = dividends.size
+
+  /** Number of stock splits.
+    */
+  def splitCount: Int = splits.size
+}
+
+object CorporateActions {
+
+  /** Empty corporate actions with no dividends or splits.
+    */
+  val empty: CorporateActions = CorporateActions(List.empty, List.empty)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/DividendEvent.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/DividendEvent.scala
@@ -1,0 +1,52 @@
+package org.coinductive.yfinance4s.models
+
+import org.coinductive.yfinance4s.models.YFinanceQueryResult.DividendEventRaw
+
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
+
+/** Represents a dividend payment event for a stock.
+  *
+  * @param exDate
+  *   The ex-dividend date. Shareholders who own the stock before this date are entitled to receive the dividend.
+  * @param amount
+  *   The dividend amount per share in the stock's trading currency.
+  */
+final case class DividendEvent(
+    exDate: ZonedDateTime,
+    amount: Double
+) {
+
+  /** Returns the dividend yield relative to a given share price.
+    *
+    * @param sharePrice
+    *   The share price to calculate yield against
+    * @return
+    *   The dividend yield as a decimal (e.g., 0.005 for 0.5%)
+    */
+  def yieldAt(sharePrice: Double): Double =
+    if (sharePrice > 0) amount / sharePrice else 0.0
+}
+
+object DividendEvent {
+
+  /** Creates a DividendEvent from the raw API response data.
+    *
+    * @param timestampKey
+    *   The string key from the dividends map (Unix timestamp)
+    * @param raw
+    *   The raw dividend event from Yahoo Finance API
+    * @return
+    *   A DividendEvent with proper ZonedDateTime conversion
+    */
+  private[yfinance4s] def fromRaw(timestampKey: String, raw: DividendEventRaw): DividendEvent = {
+    val epochSeconds = timestampKey.toLong
+    DividendEvent(
+      exDate = ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC),
+      amount = raw.amount
+    )
+  }
+
+  /** Ordering for DividendEvent by ex-date (chronological).
+    */
+  implicit val ordering: Ordering[DividendEvent] = Ordering.by(_.exDate.toInstant)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/SplitEvent.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/SplitEvent.scala
@@ -1,0 +1,66 @@
+package org.coinductive.yfinance4s.models
+
+import org.coinductive.yfinance4s.models.YFinanceQueryResult.SplitEventRaw
+
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
+
+/** Represents a stock split event.
+  *
+  * A stock split changes the number of shares outstanding while maintaining the same total market capitalization. In a
+  * 4:1 split, each shareholder receives 4 new shares for every 1 share they held.
+  *
+  * @param exDate
+  *   The effective date of the stock split.
+  * @param numerator
+  *   Number of new shares received.
+  * @param denominator
+  *   Number of old shares exchanged.
+  * @param splitRatio
+  *   Human-readable ratio string (e.g., "4:1" for a 4-for-1 split).
+  */
+final case class SplitEvent(
+    exDate: ZonedDateTime,
+    numerator: Int,
+    denominator: Int,
+    splitRatio: String
+) {
+
+  /** The split factor as a decimal ratio. For a 4:1 split, this returns 4.0. For a 1:10 reverse split, this returns
+    * 0.1.
+    */
+  def factor: Double = numerator.toDouble / denominator.toDouble
+
+  /** Whether this is a forward split (increasing share count). A forward split has numerator > denominator.
+    */
+  def isForwardSplit: Boolean = numerator > denominator
+
+  /** Whether this is a reverse split (decreasing share count). A reverse split has numerator < denominator.
+    */
+  def isReverseSplit: Boolean = numerator < denominator
+}
+
+object SplitEvent {
+
+  /** Creates a SplitEvent from the raw API response data.
+    *
+    * @param timestampKey
+    *   The string key from the splits map (Unix timestamp)
+    * @param raw
+    *   The raw split event from Yahoo Finance API
+    * @return
+    *   A SplitEvent with proper ZonedDateTime conversion
+    */
+  private[yfinance4s] def fromRaw(timestampKey: String, raw: SplitEventRaw): SplitEvent = {
+    val epochSeconds = timestampKey.toLong
+    SplitEvent(
+      exDate = ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC),
+      numerator = raw.numerator,
+      denominator = raw.denominator,
+      splitRatio = raw.splitRatio
+    )
+  }
+
+  /** Ordering for SplitEvent by ex-date (chronological).
+    */
+  implicit val ordering: Ordering[SplitEvent] = Ordering.by(_.exDate.toInstant)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceQueryResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceQueryResult.scala
@@ -16,7 +16,11 @@ private[yfinance4s] object YFinanceQueryResult {
     implicit val decoder: Decoder[Chart] = deriveDecoder
   }
 
-  private[yfinance4s] final case class InstrumentData(timestamp: List[Long], indicators: Indicators)
+  private[yfinance4s] final case class InstrumentData(
+      timestamp: List[Long],
+      indicators: Indicators,
+      events: Option[Events]
+  )
 
   private[yfinance4s] object InstrumentData {
     implicit val decoder: Decoder[InstrumentData] = deriveDecoder
@@ -44,5 +48,35 @@ private[yfinance4s] object YFinanceQueryResult {
 
   private[yfinance4s] object AdjClose {
     implicit val decoder: Decoder[AdjClose] = deriveDecoder
+  }
+
+  // Event models for dividends and stock splits
+  private[yfinance4s] final case class Events(
+      dividends: Option[Map[String, DividendEventRaw]],
+      splits: Option[Map[String, SplitEventRaw]]
+  )
+
+  private[yfinance4s] object Events {
+    implicit val decoder: Decoder[Events] = deriveDecoder
+  }
+
+  private[yfinance4s] final case class DividendEventRaw(
+      amount: Double,
+      date: Long
+  )
+
+  private[yfinance4s] object DividendEventRaw {
+    implicit val decoder: Decoder[DividendEventRaw] = deriveDecoder
+  }
+
+  private[yfinance4s] final case class SplitEventRaw(
+      date: Long,
+      numerator: Int,
+      denominator: Int,
+      splitRatio: String
+  )
+
+  private[yfinance4s] object SplitEventRaw {
+    implicit val decoder: Decoder[SplitEventRaw] = deriveDecoder
   }
 }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/CorporateActionsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/CorporateActionsSpec.scala
@@ -1,0 +1,80 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.{Interval, Range, Ticker}
+
+import scala.concurrent.duration._
+
+class CorporateActionsSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  test("getCorporateActions should return combined dividends and splits") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getCorporateActions(Ticker("AAPL"), Interval.`1Day`, Range.`5Years`).map { actionsOpt =>
+        assert(actionsOpt.isDefined, "Result should be defined for AAPL")
+        val actions = actionsOpt.get
+
+        // AAPL should have both dividends and possibly splits in 5 years
+        assert(actions.nonEmpty, "Should have at least some corporate actions")
+        assert(actions.dividends.nonEmpty, "AAPL should have dividends in 5 years")
+
+        // Validate helper methods
+        assert(actions.dividendCount == actions.dividends.size)
+        assert(actions.splitCount == actions.splits.size)
+        assert(actions.totalDividendAmount > 0, "Total dividend amount should be positive")
+      }
+    }
+  }
+
+  test("getCorporateActions cumulative split factor should calculate correctly") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getCorporateActions(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { actionsOpt =>
+        actionsOpt.foreach { actions =>
+          val cumulativeFactor = actions.cumulativeSplitFactor
+
+          if (actions.splits.nonEmpty) {
+            // Should be product of individual factors
+            val expectedFactor = actions.splits.map(_.factor).product
+            assert(
+              Math.abs(cumulativeFactor - expectedFactor) < 0.001,
+              s"Cumulative factor $cumulativeFactor should equal product $expectedFactor"
+            )
+          } else {
+            // No splits = factor of 1
+            assert(cumulativeFactor == 1.0, "No splits should mean factor of 1.0")
+          }
+        }
+      }
+    }
+  }
+
+  test("getChart should include corporate actions in ChartResult") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getChart(Ticker("AAPL"), Interval.`1Day`, Range.`1Year`).map { chartOpt =>
+        assert(chartOpt.isDefined, "Chart should be defined for AAPL")
+        val chart = chartOpt.get
+
+        // Verify quotes exist
+        assert(chart.quotes.nonEmpty, "Should have price quotes")
+
+        // Verify dividends are populated
+        assert(chart.dividends.nonEmpty, "AAPL should have dividends embedded in chart")
+
+        // Verify hasCorporateActions helper
+        assert(chart.hasCorporateActions, "hasCorporateActions should be true")
+
+        // Verify corporateActions helper method
+        val actions = chart.corporateActions
+        assertEquals(actions.dividends, chart.dividends)
+        assertEquals(actions.splits, chart.splits)
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/DividendsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/DividendsSpec.scala
@@ -1,0 +1,78 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.{Interval, Range, Ticker}
+
+import java.time.ZonedDateTime
+import scala.concurrent.duration._
+
+class DividendsSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  test("getDividends should return dividends for a dividend-paying stock (AAPL)") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getDividends(Ticker("AAPL"), Interval.`1Day`, Range.`1Year`).map { dividendsOpt =>
+        assert(dividendsOpt.isDefined, "Result should be defined for AAPL")
+        val dividends = dividendsOpt.get
+
+        // AAPL pays quarterly dividends
+        assert(dividends.nonEmpty, "AAPL should have at least one dividend in the past year")
+
+        // Validate dividend structure
+        dividends.foreach { div =>
+          assert(div.amount > 0.0, s"Dividend amount should be positive: ${div.amount}")
+          assert(
+            div.exDate.isBefore(ZonedDateTime.now()) || div.exDate.isEqual(ZonedDateTime.now()),
+            s"Ex-date should not be in the future: ${div.exDate}"
+          )
+        }
+
+        // Verify chronological ordering
+        val dates = dividends.map(_.exDate.toInstant)
+        assert(dates == dates.sorted, "Dividends should be chronologically sorted")
+      }
+    }
+  }
+
+  test("getDividends with date range should filter appropriately") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val now = ZonedDateTime.now()
+      val sixMonthsAgo = now.minusMonths(6)
+
+      client.getDividends(Ticker("AAPL"), Interval.`1Day`, sixMonthsAgo, now).map { dividendsOpt =>
+        assert(dividendsOpt.isDefined, "Result should be defined")
+        val dividends = dividendsOpt.get
+
+        dividends.foreach { div =>
+          assert(
+            !div.exDate.isBefore(sixMonthsAgo.minusDays(1)),
+            s"Dividend date ${div.exDate} should be after ${sixMonthsAgo}"
+          )
+          assert(
+            !div.exDate.isAfter(now.plusDays(1)),
+            s"Dividend date ${div.exDate} should be before ${now}"
+          )
+        }
+      }
+    }
+  }
+
+  test("getDividends should handle Max range for full dividend history") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getDividends(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { dividendsOpt =>
+        assert(dividendsOpt.isDefined, "Result should be defined")
+        val dividends = dividendsOpt.get
+
+        // Apple has been paying dividends since 2012, should have many records
+        assert(dividends.size >= 20, s"AAPL should have extensive dividend history: ${dividends.size}")
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/SplitsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/SplitsSpec.scala
@@ -1,0 +1,75 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.{Interval, Range, Ticker}
+
+import scala.concurrent.duration._
+
+class SplitsSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  test("getSplits should return splits for a stock with split history (AAPL)") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { splitsOpt =>
+        assert(splitsOpt.isDefined, "Result should be defined for AAPL")
+        val splits = splitsOpt.get
+
+        // Apple has had multiple splits historically
+        assert(splits.nonEmpty, "AAPL should have split history")
+
+        // Validate split structure
+        splits.foreach { split =>
+          assert(split.numerator > 0, s"Numerator should be positive: ${split.numerator}")
+          assert(split.denominator > 0, s"Denominator should be positive: ${split.denominator}")
+          assert(split.splitRatio.nonEmpty, "Split ratio should not be empty")
+          assert(split.splitRatio.contains(":"), s"Split ratio should contain colon: ${split.splitRatio}")
+        }
+
+        // Verify chronological ordering
+        val dates = splits.map(_.exDate.toInstant)
+        assert(dates == dates.sorted, "Splits should be chronologically sorted")
+      }
+    }
+  }
+
+  test("getSplits should identify forward and reverse splits correctly") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { splitsOpt =>
+        splitsOpt.foreach { splits =>
+          splits.foreach { split =>
+            // Apple's splits have been forward splits
+            if (split.isForwardSplit) {
+              assert(split.factor > 1.0, "Forward split factor should be > 1")
+            }
+            if (split.isReverseSplit) {
+              assert(split.factor < 1.0, "Reverse split factor should be < 1")
+            }
+          }
+        }
+      }
+    }
+  }
+
+  test("getSplits should return empty list for stocks without splits in range") {
+    YFinanceClient.resource[IO](config).use { client =>
+      // Use a short range where most stocks won't have splits
+      client.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.`1Month`).map { splitsOpt =>
+        assert(splitsOpt.isDefined, "Result should be defined")
+        // Likely empty for 1 month, but structure should be valid
+        splitsOpt.foreach { splits =>
+          splits.foreach { split =>
+            assert(split.numerator > 0)
+            assert(split.denominator > 0)
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CorporateActionsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CorporateActionsSpec.scala
@@ -1,0 +1,106 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.{CorporateActions, DividendEvent, SplitEvent}
+
+import java.time.{ZoneOffset, ZonedDateTime}
+
+class CorporateActionsSpec extends FunSuite {
+
+  test("empty should have no dividends or splits") {
+    val empty = CorporateActions.empty
+    assert(empty.isEmpty)
+    assert(!empty.nonEmpty)
+    assertEquals(empty.dividends, List.empty)
+    assertEquals(empty.splits, List.empty)
+  }
+
+  test("isEmpty should return true when both lists are empty") {
+    val actions = CorporateActions(List.empty, List.empty)
+    assert(actions.isEmpty)
+    assert(!actions.nonEmpty)
+  }
+
+  test("isEmpty should return false when dividends exist") {
+    val dividend = DividendEvent(
+      exDate = ZonedDateTime.now(),
+      amount = 0.24
+    )
+    val actions = CorporateActions(List(dividend), List.empty)
+    assert(!actions.isEmpty)
+    assert(actions.nonEmpty)
+  }
+
+  test("isEmpty should return false when splits exist") {
+    val split = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 4,
+      denominator = 1,
+      splitRatio = "4:1"
+    )
+    val actions = CorporateActions(List.empty, List(split))
+    assert(!actions.isEmpty)
+    assert(actions.nonEmpty)
+  }
+
+  test("totalDividendAmount should sum all dividend amounts") {
+    val dividends = List(
+      DividendEvent(ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), 0.24),
+      DividendEvent(ZonedDateTime.of(2024, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC), 0.24),
+      DividendEvent(ZonedDateTime.of(2024, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC), 0.25),
+      DividendEvent(ZonedDateTime.of(2024, 10, 1, 0, 0, 0, 0, ZoneOffset.UTC), 0.25)
+    )
+    val actions = CorporateActions(dividends, List.empty)
+
+    assert(Math.abs(actions.totalDividendAmount - 0.98) < 0.001)
+  }
+
+  test("totalDividendAmount should return 0 when no dividends") {
+    val actions = CorporateActions(List.empty, List.empty)
+    assertEquals(actions.totalDividendAmount, 0.0)
+  }
+
+  test("cumulativeSplitFactor should return 1.0 when no splits") {
+    val actions = CorporateActions(List.empty, List.empty)
+    assertEquals(actions.cumulativeSplitFactor, 1.0)
+  }
+
+  test("cumulativeSplitFactor should return single split factor") {
+    val split = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 4,
+      denominator = 1,
+      splitRatio = "4:1"
+    )
+    val actions = CorporateActions(List.empty, List(split))
+    assertEquals(actions.cumulativeSplitFactor, 4.0)
+  }
+
+  test("cumulativeSplitFactor should multiply multiple split factors") {
+    val splits = List(
+      SplitEvent(ZonedDateTime.of(2014, 6, 9, 0, 0, 0, 0, ZoneOffset.UTC), 7, 1, "7:1"),
+      SplitEvent(ZonedDateTime.of(2020, 8, 31, 0, 0, 0, 0, ZoneOffset.UTC), 4, 1, "4:1")
+    )
+    val actions = CorporateActions(List.empty, splits)
+    assertEquals(actions.cumulativeSplitFactor, 28.0)
+  }
+
+  test("dividendCount should return correct count") {
+    val dividends = List(
+      DividendEvent(ZonedDateTime.now(), 0.24),
+      DividendEvent(ZonedDateTime.now(), 0.24),
+      DividendEvent(ZonedDateTime.now(), 0.24)
+    )
+    val actions = CorporateActions(dividends, List.empty)
+    assertEquals(actions.dividendCount, 3)
+  }
+
+  test("splitCount should return correct count") {
+    val splits = List(
+      SplitEvent(ZonedDateTime.now(), 7, 1, "7:1"),
+      SplitEvent(ZonedDateTime.now(), 4, 1, "4:1")
+    )
+    val actions = CorporateActions(List.empty, splits)
+    assertEquals(actions.splitCount, 2)
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
@@ -1,0 +1,70 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.DividendEvent
+import org.coinductive.yfinance4s.models.YFinanceQueryResult.DividendEventRaw
+
+import java.time.{ZoneOffset, ZonedDateTime}
+
+class DividendEventSpec extends FunSuite {
+
+  test("fromRaw should convert timestamp to ZonedDateTime correctly") {
+    val raw = DividendEventRaw(amount = 0.24, date = 1704067200L)
+    val event = DividendEvent.fromRaw("1704067200", raw)
+
+    assertEquals(event.amount, 0.24)
+    assertEquals(event.exDate.getYear, 2024)
+    assertEquals(event.exDate.getMonthValue, 1)
+    assertEquals(event.exDate.getDayOfMonth, 1)
+    assertEquals(event.exDate.getZone, ZoneOffset.UTC)
+  }
+
+  test("yieldAt should calculate dividend yield correctly") {
+    val event = DividendEvent(
+      exDate = ZonedDateTime.now(),
+      amount = 0.24
+    )
+
+    // $0.24 dividend on $100 stock = 0.24% yield
+    val yieldValue = event.yieldAt(100.0)
+    assert(Math.abs(yieldValue - 0.0024) < 0.0001)
+  }
+
+  test("yieldAt should return 0 for zero share price") {
+    val event = DividendEvent(
+      exDate = ZonedDateTime.now(),
+      amount = 0.24
+    )
+
+    assertEquals(event.yieldAt(0.0), 0.0)
+  }
+
+  test("yieldAt should return 0 for negative share price") {
+    val event = DividendEvent(
+      exDate = ZonedDateTime.now(),
+      amount = 0.24
+    )
+
+    assertEquals(event.yieldAt(-10.0), 0.0)
+  }
+
+  test("ordering should sort by exDate chronologically") {
+    val event1 = DividendEvent(
+      exDate = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+      amount = 0.20
+    )
+    val event2 = DividendEvent(
+      exDate = ZonedDateTime.of(2024, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+      amount = 0.22
+    )
+    val event3 = DividendEvent(
+      exDate = ZonedDateTime.of(2024, 7, 1, 0, 0, 0, 0, ZoneOffset.UTC),
+      amount = 0.24
+    )
+
+    val unsorted = List(event2, event3, event1)
+    val sorted = unsorted.sorted
+
+    assertEquals(sorted, List(event1, event2, event3))
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
@@ -1,0 +1,100 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.SplitEvent
+import org.coinductive.yfinance4s.models.YFinanceQueryResult.SplitEventRaw
+
+import java.time.{ZoneOffset, ZonedDateTime}
+
+class SplitEventSpec extends FunSuite {
+
+  test("fromRaw should convert timestamp correctly") {
+    val raw = SplitEventRaw(
+      date = 1598832000L,
+      numerator = 4,
+      denominator = 1,
+      splitRatio = "4:1"
+    )
+    val event = SplitEvent.fromRaw("1598832000", raw)
+
+    assertEquals(event.numerator, 4)
+    assertEquals(event.denominator, 1)
+    assertEquals(event.splitRatio, "4:1")
+    assertEquals(event.exDate.getYear, 2020)
+    assertEquals(event.exDate.getMonthValue, 8)
+  }
+
+  test("factor should calculate split ratio as decimal for forward split") {
+    val forward4to1 = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 4,
+      denominator = 1,
+      splitRatio = "4:1"
+    )
+    assertEquals(forward4to1.factor, 4.0)
+  }
+
+  test("factor should calculate split ratio as decimal for reverse split") {
+    val reverse1to10 = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 1,
+      denominator = 10,
+      splitRatio = "1:10"
+    )
+    assertEquals(reverse1to10.factor, 0.1)
+  }
+
+  test("isForwardSplit should identify forward splits") {
+    val forwardSplit = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 4,
+      denominator = 1,
+      splitRatio = "4:1"
+    )
+    assert(forwardSplit.isForwardSplit)
+    assert(!forwardSplit.isReverseSplit)
+  }
+
+  test("isReverseSplit should identify reverse splits") {
+    val reverseSplit = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 1,
+      denominator = 10,
+      splitRatio = "1:10"
+    )
+    assert(reverseSplit.isReverseSplit)
+    assert(!reverseSplit.isForwardSplit)
+  }
+
+  test("equal numerator and denominator should be neither forward nor reverse") {
+    val noChange = SplitEvent(
+      exDate = ZonedDateTime.now(),
+      numerator = 1,
+      denominator = 1,
+      splitRatio = "1:1"
+    )
+    assert(!noChange.isForwardSplit)
+    assert(!noChange.isReverseSplit)
+    assertEquals(noChange.factor, 1.0)
+  }
+
+  test("ordering should sort by exDate chronologically") {
+    val event1 = SplitEvent(
+      exDate = ZonedDateTime.of(2014, 6, 9, 0, 0, 0, 0, ZoneOffset.UTC),
+      numerator = 7,
+      denominator = 1,
+      splitRatio = "7:1"
+    )
+    val event2 = SplitEvent(
+      exDate = ZonedDateTime.of(2020, 8, 31, 0, 0, 0, 0, ZoneOffset.UTC),
+      numerator = 4,
+      denominator = 1,
+      splitRatio = "4:1"
+    )
+
+    val unsorted = List(event2, event1)
+    val sorted = unsorted.sorted
+
+    assertEquals(sorted, List(event1, event2))
+  }
+}


### PR DESCRIPTION
Implementing corporate actions feature to fetch dividend and stock split history from Yahoo Finance API.

New domain models:
- DividendEvent: dividend payments with amount, date, and yield calculation
- SplitEvent: stock splits with ratio, factor, and forward/reverse detection
- CorporateActions: aggregates dividends and splits with helper methods

New client methods:
- getDividends(ticker, interval, range/dates)
- getSplits(ticker, interval, range/dates)
- getCorporateActions(ticker, interval, range/dates)

Changes:
- Adding events=div,split parameter to Gateway API requests
- Extending YFinanceQueryResult with Events decoder for API response
- Adding dividends/splits fields to ChartResult with corporateActions helper
- Adding unit tests for domain model logic
- Adding integration tests validating real API data (AAPL)