### PR TITLE
Adding options chain data support with Yahoo Finance authentication

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceAuth.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceAuth.scala
@@ -1,0 +1,166 @@
+package org.coinductive.yfinance4s
+
+import cats.effect.{Async, Ref, Resource}
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import retry.{RetryPolicies, RetryPolicy, Sleep}
+import sttp.client3.*
+import sttp.model.Header
+
+import scala.concurrent.duration.FiniteDuration
+
+final case class YFinanceCredentials(
+    cookies: List[String],
+    crumb: String
+)
+
+sealed trait YFinanceAuth[F[_]] {
+  def getCredentials: F[YFinanceCredentials]
+  def refreshCredentials: F[YFinanceCredentials]
+}
+
+private object YFinanceAuth {
+
+  private val CookiePrimeUrl = uri"https://fc.yahoo.com/"
+  private val CrumbUrl = uri"https://query1.finance.yahoo.com/v1/test/getcrumb"
+
+  private val BrowserHeaders: List[Header] = List(
+    Header(
+      "User-Agent",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+    ),
+    Header(
+      "Accept",
+      "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8"
+    ),
+    Header("Accept-Language", "en-US,en;q=0.9"),
+    Header("Accept-Encoding", "gzip, deflate, br"),
+    Header("Sec-Ch-Ua", "\"Not A(Brand\";v=\"99\", \"Google Chrome\";v=\"121\", \"Chromium\";v=\"121\""),
+    Header("Sec-Ch-Ua-Mobile", "?0"),
+    Header("Sec-Ch-Ua-Platform", "\"Windows\""),
+    Header("Sec-Fetch-Dest", "document"),
+    Header("Sec-Fetch-Mode", "navigate"),
+    Header("Sec-Fetch-Site", "none"),
+    Header("Sec-Fetch-User", "?1"),
+    Header("Upgrade-Insecure-Requests", "1")
+  )
+
+  private val CrumbHeaders: List[Header] = List(
+    Header(
+      "User-Agent",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+    ),
+    Header("Accept", "*/*"),
+    Header("Accept-Language", "en-US,en;q=0.9"),
+    Header("Sec-Ch-Ua", "\"Not A(Brand\";v=\"99\", \"Google Chrome\";v=\"121\", \"Chromium\";v=\"121\""),
+    Header("Sec-Ch-Ua-Mobile", "?0"),
+    Header("Sec-Ch-Ua-Platform", "\"Windows\""),
+    Header("Sec-Fetch-Dest", "empty"),
+    Header("Sec-Fetch-Mode", "cors"),
+    Header("Sec-Fetch-Site", "same-site"),
+    Header("Origin", "https://finance.yahoo.com"),
+    Header("Referer", "https://finance.yahoo.com/")
+  )
+
+  private val ApiHeaders: List[Header] = List(
+    Header(
+      "User-Agent",
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36"
+    ),
+    Header("Accept", "application/json"),
+    Header("Accept-Language", "en-US,en;q=0.9"),
+    Header("Sec-Ch-Ua", "\"Not A(Brand\";v=\"99\", \"Google Chrome\";v=\"121\", \"Chromium\";v=\"121\""),
+    Header("Sec-Ch-Ua-Mobile", "?0"),
+    Header("Sec-Ch-Ua-Platform", "\"Windows\""),
+    Header("Sec-Fetch-Dest", "empty"),
+    Header("Sec-Fetch-Mode", "cors"),
+    Header("Sec-Fetch-Site", "same-site"),
+    Header("Origin", "https://finance.yahoo.com"),
+    Header("Referer", "https://finance.yahoo.com/")
+  )
+
+  def resource[F[_]: Async](
+      connectTimeout: FiniteDuration,
+      readTimeout: FiniteDuration,
+      retries: Int
+  ): Resource[F, YFinanceAuth[F]] =
+    PlatformSttpBackend.resource[F](connectTimeout, readTimeout).evalMap { backend =>
+      val retryPolicy = RetryPolicies.limitRetries[F](retries)
+      Ref.of[F, Option[YFinanceCredentials]](None).map { credentialsRef =>
+        new YFinanceAuthImpl[F](backend, retryPolicy, credentialsRef)
+      }
+    }
+
+  private final class YFinanceAuthImpl[F[_]](
+      sttpBackend: SttpBackend[F, Any],
+      retryPolicy: RetryPolicy[F],
+      credentialsRef: Ref[F, Option[YFinanceCredentials]]
+  )(implicit F: Async[F], S: Sleep[F])
+      extends YFinanceAuth[F] {
+
+    override def getCredentials: F[YFinanceCredentials] =
+      credentialsRef.get.flatMap {
+        case Some(creds) => F.pure(creds)
+        case None        => refreshCredentials
+      }
+
+    override def refreshCredentials: F[YFinanceCredentials] =
+      for {
+        cookies <- primeCookies
+        crumb <- fetchCrumb(cookies)
+        creds = YFinanceCredentials(cookies, crumb)
+        _ <- credentialsRef.set(Some(creds))
+      } yield creds
+
+    private def primeCookies: F[List[String]] = {
+      val request = basicRequest
+        .get(CookiePrimeUrl)
+        .headers(BrowserHeaders *)
+        .followRedirects(true)
+        .response(asString)
+
+      retry
+        .retryingOnAllErrors(policy = retryPolicy, (_: Throwable, _) => F.unit) {
+          request.send(sttpBackend)
+        }
+        .map { response =>
+          response.headers
+            .filter(_.name.equalsIgnoreCase("Set-Cookie"))
+            .map(_.value)
+            .map(extractCookieNameValue)
+            .toList
+        }
+    }
+
+    private def fetchCrumb(cookies: List[String]): F[String] = {
+      val cookieHeader = cookies.mkString("; ")
+      val request = basicRequest
+        .get(CrumbUrl)
+        .headers(CrumbHeaders *)
+        .header("Cookie", cookieHeader)
+        .followRedirects(true)
+        .response(asString)
+
+      retry
+        .retryingOnAllErrors(policy = retryPolicy, (_: Throwable, _) => F.unit) {
+          request.send(sttpBackend)
+        }
+        .flatMap { response =>
+          response.body match {
+            case Right(crumb) if !crumb.contains("Too Many Requests") && crumb.nonEmpty =>
+              F.pure(crumb.trim)
+            case Right(errorBody) =>
+              F.raiseError(new Exception(s"Failed to fetch crumb: $errorBody"))
+            case Left(error) =>
+              F.raiseError(new Exception(s"Failed to fetch crumb: $error"))
+          }
+        }
+    }
+
+    private def extractCookieNameValue(setCookie: String): String = {
+      setCookie.split(";").headOption.getOrElse(setCookie)
+    }
+  }
+
+  def apiHeaders: List[Header] = ApiHeaders
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ContractSize.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ContractSize.scala
@@ -1,0 +1,20 @@
+package org.coinductive.yfinance4s.models
+
+import cats.Show
+import enumeratum.*
+
+sealed abstract class ContractSize(val value: String, val multiplier: Int) extends EnumEntry
+
+object ContractSize extends Enum[ContractSize] {
+  case object Regular extends ContractSize("REGULAR", 100)
+  case object Mini extends ContractSize("MINI", 10)
+
+  val values: IndexedSeq[ContractSize] = findValues
+
+  def fromString(s: String): ContractSize = s.toUpperCase match {
+    case "MINI" => Mini
+    case _      => Regular
+  }
+
+  implicit val show: Show[ContractSize] = Show.show(_.value)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/FullOptionChain.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/FullOptionChain.scala
@@ -1,0 +1,51 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+final case class FullOptionChain(
+    underlyingSymbol: String,
+    underlyingPrice: Option[Double],
+    expirationDates: List[LocalDate],
+    chains: Map[LocalDate, OptionChain]
+) {
+
+  def nearestExpiration: Option[LocalDate] =
+    expirationDates.sorted.headOption
+
+  def nearestChain: Option[OptionChain] =
+    nearestExpiration.flatMap(chains.get)
+
+  def chainsWithinDays(days: Int): List[OptionChain] = {
+    val cutoff = LocalDate.now().plusDays(days)
+    expirationDates
+      .filter(_.isBefore(cutoff))
+      .flatMap(chains.get)
+      .sorted
+  }
+
+  def chainFor(date: LocalDate): Option[OptionChain] = chains.get(date)
+
+  def allChainsSorted: List[OptionChain] =
+    expirationDates.sorted.flatMap(chains.get)
+
+  def expirationCount: Int = expirationDates.size
+
+  def daysToNearestExpiration: Option[Long] =
+    nearestExpiration.map { exp =>
+      java.time.temporal.ChronoUnit.DAYS.between(LocalDate.now(), exp)
+    }
+}
+
+object FullOptionChain {
+  def apply(
+      underlyingSymbol: String,
+      underlyingPrice: Option[Double],
+      expirationDates: List[LocalDate],
+      chain: OptionChain
+  ): FullOptionChain = FullOptionChain(
+    underlyingSymbol = underlyingSymbol,
+    underlyingPrice = underlyingPrice,
+    expirationDates = expirationDates,
+    chains = Map(chain.expirationDate -> chain)
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/OptionChain.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/OptionChain.scala
@@ -1,0 +1,64 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+final case class OptionChain(
+    expirationDate: LocalDate,
+    calls: List[OptionContract],
+    puts: List[OptionContract],
+    strikes: List[Double],
+    hasMiniOptions: Boolean
+) {
+
+  def allContracts: List[OptionContract] = (calls ++ puts).sorted
+
+  def callAtStrike(strike: Double): Option[OptionContract] =
+    calls.find(_.strike == strike)
+
+  def putAtStrike(strike: Double): Option[OptionContract] =
+    puts.find(_.strike == strike)
+
+  def straddleAtStrike(strike: Double): Option[(OptionContract, OptionContract)] =
+    for {
+      call <- callAtStrike(strike)
+      put <- putAtStrike(strike)
+    } yield (call, put)
+
+  def atmStrike(underlyingPrice: Double): Option[Double] =
+    strikes.minByOption(s => math.abs(s - underlyingPrice))
+
+  def itmCalls: List[OptionContract] = calls.filter(_.inTheMoney)
+
+  def otmCalls: List[OptionContract] = calls.filterNot(_.inTheMoney)
+
+  def itmPuts: List[OptionContract] = puts.filter(_.inTheMoney)
+
+  def otmPuts: List[OptionContract] = puts.filterNot(_.inTheMoney)
+
+  def totalCallVolume: Long = calls.flatMap(_.volume).sum
+
+  def totalPutVolume: Long = puts.flatMap(_.volume).sum
+
+  def putCallRatio: Option[Double] = {
+    val callVol = totalCallVolume
+    if (callVol > 0) Some(totalPutVolume.toDouble / callVol) else None
+  }
+
+  def totalCallOpenInterest: Long = calls.flatMap(_.openInterest).sum
+
+  def totalPutOpenInterest: Long = puts.flatMap(_.openInterest).sum
+
+  def activeStrikeCount: Int = strikes.size
+}
+
+object OptionChain {
+  val empty: OptionChain = OptionChain(
+    expirationDate = LocalDate.of(1970, 1, 1),
+    calls = List.empty,
+    puts = List.empty,
+    strikes = List.empty,
+    hasMiniOptions = false
+  )
+
+  implicit val ordering: Ordering[OptionChain] = Ordering.by(_.expirationDate)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/OptionContract.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/OptionContract.scala
@@ -1,0 +1,56 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.{LocalDate, ZonedDateTime}
+
+final case class OptionContract(
+    contractSymbol: String,
+    optionType: OptionType,
+    strike: Double,
+    expiration: LocalDate,
+    currency: String,
+    lastPrice: Option[Double],
+    change: Option[Double],
+    percentChange: Option[Double],
+    bid: Option[Double],
+    ask: Option[Double],
+    volume: Option[Long],
+    openInterest: Option[Long],
+    impliedVolatility: Option[Double],
+    inTheMoney: Boolean,
+    lastTradeDate: Option[ZonedDateTime],
+    contractSize: ContractSize
+) {
+
+  def spread: Option[Double] = for {
+    b <- bid
+    a <- ask
+  } yield a - b
+
+  def midPrice: Option[Double] = for {
+    b <- bid
+    a <- ask
+  } yield (a + b) / 2.0
+
+  def spreadPercent: Option[Double] = for {
+    s <- spread
+    m <- midPrice if m > 0
+  } yield (s / m) * 100.0
+
+  def intrinsicValue(underlyingPrice: Double): Double = optionType match {
+    case OptionType.Call => math.max(0.0, underlyingPrice - strike)
+    case OptionType.Put  => math.max(0.0, strike - underlyingPrice)
+  }
+
+  def extrinsicValue(underlyingPrice: Double): Option[Double] = {
+    val price = midPrice.orElse(lastPrice)
+    price.map(_ - intrinsicValue(underlyingPrice))
+  }
+
+  def multiplier: Int = contractSize.multiplier
+
+  def notionalValue: Option[Double] = midPrice.orElse(lastPrice).map(_ * multiplier)
+}
+
+object OptionContract {
+  implicit val ordering: Ordering[OptionContract] = Ordering.by(c => (c.strike, c.optionType.ordinal))
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/OptionType.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/OptionType.scala
@@ -1,0 +1,18 @@
+package org.coinductive.yfinance4s.models
+
+import cats.Show
+import enumeratum.*
+
+sealed abstract class OptionType(val ordinal: Int) extends EnumEntry
+
+object OptionType extends Enum[OptionType] {
+  case object Call extends OptionType(0)
+  case object Put extends OptionType(1)
+
+  val values: IndexedSeq[OptionType] = findValues
+
+  implicit val show: Show[OptionType] = Show.show {
+    case Call => "call"
+    case Put  => "put"
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceOptionsResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceOptionsResult.scala
@@ -1,0 +1,77 @@
+package org.coinductive.yfinance4s.models
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+private[yfinance4s] final case class YFinanceOptionsResult(optionChain: OptionChainResponse)
+
+private[yfinance4s] object YFinanceOptionsResult {
+  implicit val decoder: Decoder[YFinanceOptionsResult] = deriveDecoder
+}
+
+private[yfinance4s] final case class OptionChainResponse(
+    result: List[OptionDataRaw],
+    error: Option[String]
+)
+
+private[yfinance4s] object OptionChainResponse {
+  implicit val decoder: Decoder[OptionChainResponse] = deriveDecoder
+}
+
+private[yfinance4s] final case class OptionDataRaw(
+    underlyingSymbol: String,
+    expirationDates: List[Long],
+    strikes: List[Double],
+    hasMiniOptions: Boolean,
+    quote: Option[UnderlyingQuoteRaw],
+    options: List[OptionsContainerRaw]
+)
+
+private[yfinance4s] object OptionDataRaw {
+  implicit val decoder: Decoder[OptionDataRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class UnderlyingQuoteRaw(
+    regularMarketPrice: Option[Double],
+    bid: Option[Double],
+    ask: Option[Double],
+    bidSize: Option[Int],
+    askSize: Option[Int]
+)
+
+private[yfinance4s] object UnderlyingQuoteRaw {
+  implicit val decoder: Decoder[UnderlyingQuoteRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class OptionsContainerRaw(
+    expirationDate: Long,
+    hasMiniOptions: Boolean,
+    calls: List[OptionContractRaw],
+    puts: List[OptionContractRaw]
+)
+
+private[yfinance4s] object OptionsContainerRaw {
+  implicit val decoder: Decoder[OptionsContainerRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class OptionContractRaw(
+    contractSymbol: String,
+    strike: Double,
+    currency: String,
+    lastPrice: Option[Double],
+    change: Option[Double],
+    percentChange: Option[Double],
+    volume: Option[Long],
+    openInterest: Option[Long],
+    bid: Option[Double],
+    ask: Option[Double],
+    contractSize: Option[String],
+    expiration: Long,
+    lastTradeDate: Option[Long],
+    impliedVolatility: Option[Double],
+    inTheMoney: Boolean
+)
+
+private[yfinance4s] object OptionContractRaw {
+  implicit val decoder: Decoder[OptionContractRaw] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/OptionsChainSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/OptionsChainSpec.scala
@@ -1,0 +1,123 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.*
+
+import scala.concurrent.duration.*
+import java.time.LocalDate
+
+class OptionsChainSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  val testTicker: Ticker = Ticker("AAPL")
+
+  test("getOptionExpirations should return sorted list of expiration dates for AAPL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getOptionExpirations(testTicker).map { expirationsOpt =>
+        assert(expirationsOpt.isDefined, "Expirations should be defined for AAPL")
+
+        val expirations = expirationsOpt.get
+        assert(expirations.nonEmpty, "AAPL should have available expirations")
+
+        val dates = expirations
+        assert(dates == dates.sorted, "Expirations should be chronologically sorted")
+
+        val today = LocalDate.now()
+        assert(
+          expirations.forall(d => !d.isBefore(today)),
+          "All expirations should be today or in the future"
+        )
+      }
+    }
+  }
+
+  test("getOptionChain should return valid chain for nearest expiration") {
+    YFinanceClient.resource[IO](config).use { client =>
+      for {
+        expirationsOpt <- client.getOptionExpirations(testTicker)
+        _ = assert(expirationsOpt.isDefined, "Need expirations to test chain")
+        expirations = expirationsOpt.get
+        nearestExpiration = expirations.head
+
+        chainOpt <- client.getOptionChain(testTicker, nearestExpiration)
+      } yield {
+        assert(chainOpt.isDefined, s"Chain should exist for $nearestExpiration")
+
+        val chain = chainOpt.get
+        assertEquals(chain.expirationDate, nearestExpiration)
+        assert(chain.calls.nonEmpty, "Should have call options")
+        assert(chain.puts.nonEmpty, "Should have put options")
+        assert(chain.strikes.nonEmpty, "Should have strikes")
+
+        assert(
+          chain.strikes == chain.strikes.sorted,
+          "Strikes should be sorted ascending"
+        )
+
+        chain.calls.foreach { call =>
+          assertEquals(call.optionType, OptionType.Call)
+          assert(call.strike > 0, "Strike should be positive")
+          assert(call.contractSymbol.nonEmpty, "Contract symbol should exist")
+        }
+
+        chain.puts.foreach { put =>
+          assertEquals(put.optionType, OptionType.Put)
+          assert(put.strike > 0, "Strike should be positive")
+        }
+      }
+    }
+  }
+
+  test("getFullOptionChain should return complete data for AAPL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getFullOptionChain(testTicker).map { fullChainOpt =>
+        assert(fullChainOpt.isDefined, "Full chain should be defined")
+
+        val fullChain = fullChainOpt.get
+        assertEquals(fullChain.underlyingSymbol, "AAPL")
+        assert(fullChain.underlyingPrice.isDefined, "Should have underlying price")
+        assert(fullChain.underlyingPrice.get > 0, "Price should be positive")
+
+        assert(fullChain.expirationDates.nonEmpty, "Should have expirations")
+        assert(fullChain.chains.nonEmpty, "Should have at least one chain")
+
+        val nearestExp = fullChain.nearestExpiration
+        assert(nearestExp.isDefined, "Should have nearest expiration")
+        assert(
+          fullChain.chains.contains(nearestExp.get),
+          "Should have chain for nearest expiration"
+        )
+
+        val nearestChain = fullChain.nearestChain
+        assert(nearestChain.isDefined, "Should get nearest chain")
+        assert(nearestChain.get.calls.nonEmpty || nearestChain.get.puts.nonEmpty)
+      }
+    }
+  }
+
+  test("implied volatility should be in reasonable range (converted to percentage)") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getFullOptionChain(testTicker).map { fullChainOpt =>
+        assert(fullChainOpt.isDefined)
+
+        val chain = fullChainOpt.get.nearestChain.get
+        val ivValues = chain.allContracts.flatMap(_.impliedVolatility)
+
+        assert(ivValues.nonEmpty, "Should have IV values")
+
+        ivValues.foreach { iv =>
+          assert(iv > 0, s"IV should be positive: $iv")
+          assert(iv < 1000, s"IV should be less than 1000%: $iv")
+        }
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
Implementing options chain fetching from Yahoo Finance API (v7/finance/options), including cookie/crumb authentication required by the endpoint.

New public API methods on YFinanceClient:
- getOptionExpirations(ticker): List available expiration dates
- getOptionChain(ticker, date): Get calls/puts for specific expiration
- getFullOptionChain(ticker): Get nearest chain with all expirations

New models:
- OptionContract: Single option with strike, bid/ask, IV, Greeks helpers
- OptionChain: Calls/puts for one expiration with analysis methods
- FullOptionChain: All expirations with underlying price
- OptionType (Call/Put) and ContractSize (Regular/Mini) enums

Authentication (YFinanceAuth):
- Primes session cookies via fc.yahoo.com
- Fetches crumb token from /v1/test/getcrumb
- Uses browser-like headers (Sec-Ch-*, Sec-Fetch-*, etc.)