### PR TITLE
Adding financial statements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ val circeV = "0.14.5"
 val sttpV = "3.10.1"
 val catsRetryV = "3.1.3"
 val enumeratumV = "1.7.5"
+val chimneyV = "1.8.2"
 val jsoupV = "1.18.3"
 val munitCatsEffectV = "1.0.7"
 
@@ -28,7 +29,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) => Seq("-Ymacro-annotations", "-Xsource:3")
-        case Some((3, _)) => Seq("-Yretain-trees")
+        case Some((3, _)) => Seq("-Yretain-trees", "-Xmax-inlines:64")
         case _            => Seq.empty
       }
     },
@@ -44,6 +45,7 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "com.softwaremill.sttp.client3" %%% "core" % sttpV,
       "com.github.cb372" %%% "cats-retry" % catsRetryV,
       "com.beachape" %%% "enumeratum" % enumeratumV,
+      "io.scalaland" %%% "chimney" % chimneyV,
       "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectV % Test,
     )
   )

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/BalanceSheet.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/BalanceSheet.scala
@@ -1,0 +1,154 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+/** Balance sheet data for a reporting period.
+  *
+  * All monetary values are in the company's reporting currency.
+  *
+  * @param reportDate
+  *   The fiscal period end date
+  * @param periodType
+  *   The period type (e.g., "12M" for annual, "3M" for quarterly)
+  * @param currencyCode
+  *   The currency of monetary values (e.g., "USD")
+  */
+final case class BalanceSheet(
+    reportDate: LocalDate,
+    periodType: String,
+    currencyCode: String,
+    // Assets - Current
+    totalAssets: Option[Double],
+    currentAssets: Option[Double],
+    cashAndCashEquivalents: Option[Double],
+    shortTermInvestments: Option[Double],
+    accountsReceivable: Option[Double],
+    inventory: Option[Double],
+    otherCurrentAssets: Option[Double],
+    // Assets - Non-Current
+    totalNonCurrentAssets: Option[Double],
+    netPpe: Option[Double],
+    grossPpe: Option[Double],
+    accumulatedDepreciation: Option[Double],
+    goodwill: Option[Double],
+    otherIntangibleAssets: Option[Double],
+    longTermInvestments: Option[Double],
+    otherNonCurrentAssets: Option[Double],
+    // Liabilities - Current
+    currentLiabilities: Option[Double],
+    accountsPayable: Option[Double],
+    currentDebt: Option[Double],
+    otherCurrentLiabilities: Option[Double],
+    // Liabilities - Non-Current
+    totalNonCurrentLiabilities: Option[Double],
+    longTermDebt: Option[Double],
+    otherNonCurrentLiabilities: Option[Double],
+    // Total Liabilities
+    totalLiabilities: Option[Double],
+    totalDebt: Option[Double],
+    netDebt: Option[Double],
+    // Stockholders Equity
+    stockholdersEquity: Option[Double],
+    commonStock: Option[Double],
+    additionalPaidInCapital: Option[Double],
+    retainedEarnings: Option[Double],
+    treasuryStock: Option[Double],
+    // Share Information
+    sharesIssued: Option[Double],
+    ordinarySharesNumber: Option[Double],
+    // Derived Metrics from API
+    workingCapital: Option[Double],
+    tangibleBookValue: Option[Double],
+    investedCapital: Option[Double]
+) extends Ordered[BalanceSheet] {
+
+  /** Compare by report date (descending - most recent first) */
+  def compare(that: BalanceSheet): Int = that.reportDate.compareTo(this.reportDate)
+
+  // --- Derived Metrics ---
+
+  /** Current ratio: Current Assets / Current Liabilities */
+  def currentRatio: Option[Double] =
+    for {
+      ca <- currentAssets
+      cl <- currentLiabilities if cl != 0
+    } yield ca / cl
+
+  /** Quick ratio: (Current Assets - Inventory) / Current Liabilities */
+  def quickRatio: Option[Double] =
+    for {
+      ca <- currentAssets
+      inv <- inventory.orElse(Some(0.0))
+      cl <- currentLiabilities if cl != 0
+    } yield (ca - inv) / cl
+
+  /** Debt to equity ratio: Total Debt / Stockholders Equity */
+  def debtToEquity: Option[Double] =
+    for {
+      debt <- totalDebt
+      equity <- stockholdersEquity if equity != 0
+    } yield debt / equity
+
+  /** Debt to assets ratio: Total Debt / Total Assets */
+  def debtToAssets: Option[Double] =
+    for {
+      debt <- totalDebt
+      assets <- totalAssets if assets != 0
+    } yield debt / assets
+
+  /** Book value per share: Stockholders Equity / Shares Outstanding */
+  def bookValuePerShare: Option[Double] =
+    for {
+      equity <- stockholdersEquity
+      shares <- ordinarySharesNumber if shares != 0
+    } yield equity / shares
+
+  /** Tangible book value per share: Tangible Book Value / Shares Outstanding */
+  def tangibleBookValuePerShare: Option[Double] =
+    for {
+      tbv <- tangibleBookValue
+      shares <- ordinarySharesNumber if shares != 0
+    } yield tbv / shares
+}
+
+object BalanceSheet {
+
+  /** Key fields to request from the API (without timescale prefix) */
+  val apiKeys: List[String] = List(
+    "TotalAssets",
+    "CurrentAssets",
+    "CashAndCashEquivalents",
+    "OtherShortTermInvestments",
+    "AccountsReceivable",
+    "Inventory",
+    "OtherCurrentAssets",
+    "TotalNonCurrentAssets",
+    "NetPPE",
+    "GrossPPE",
+    "AccumulatedDepreciation",
+    "Goodwill",
+    "OtherIntangibleAssets",
+    "LongTermEquityInvestment",
+    "OtherNonCurrentAssets",
+    "CurrentLiabilities",
+    "AccountsPayable",
+    "CurrentDebt",
+    "OtherCurrentLiabilities",
+    "TotalNonCurrentLiabilitiesNetMinorityInterest",
+    "LongTermDebt",
+    "OtherNonCurrentLiabilities",
+    "TotalLiabilitiesNetMinorityInterest",
+    "TotalDebt",
+    "NetDebt",
+    "StockholdersEquity",
+    "CommonStock",
+    "AdditionalPaidInCapital",
+    "RetainedEarnings",
+    "TreasuryStock",
+    "ShareIssued",
+    "OrdinarySharesNumber",
+    "WorkingCapital",
+    "TangibleBookValue",
+    "InvestedCapital"
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/CashFlowStatement.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/CashFlowStatement.scala
@@ -1,0 +1,124 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+/** Cash flow statement data for a reporting period.
+  *
+  * All monetary values are in the company's reporting currency.
+  *
+  * @param reportDate
+  *   The fiscal period end date
+  * @param periodType
+  *   The period type (e.g., "12M" for annual, "3M" for quarterly)
+  * @param currencyCode
+  *   The currency of monetary values (e.g., "USD")
+  */
+final case class CashFlowStatement(
+    reportDate: LocalDate,
+    periodType: String,
+    currencyCode: String,
+    // Operating Activities
+    operatingCashFlow: Option[Double],
+    netIncomeFromContinuingOperations: Option[Double],
+    depreciationAmortizationDepletion: Option[Double],
+    stockBasedCompensation: Option[Double],
+    deferredIncomeTax: Option[Double],
+    changeInWorkingCapital: Option[Double],
+    changeInReceivables: Option[Double],
+    changeInInventory: Option[Double],
+    changeInPayables: Option[Double],
+    // Investing Activities
+    investingCashFlow: Option[Double],
+    capitalExpenditure: Option[Double],
+    purchaseOfInvestment: Option[Double],
+    saleOfInvestment: Option[Double],
+    purchaseOfBusiness: Option[Double],
+    saleOfBusiness: Option[Double],
+    netPpePurchaseAndSale: Option[Double],
+    // Financing Activities
+    financingCashFlow: Option[Double],
+    issuanceOfDebt: Option[Double],
+    repaymentOfDebt: Option[Double],
+    issuanceOfCapitalStock: Option[Double],
+    repurchaseOfCapitalStock: Option[Double],
+    cashDividendsPaid: Option[Double],
+    // Net Change in Cash
+    beginningCashPosition: Option[Double],
+    endCashPosition: Option[Double],
+    changesInCash: Option[Double],
+    effectOfExchangeRateChanges: Option[Double],
+    // Free Cash Flow
+    freeCashFlow: Option[Double]
+) extends Ordered[CashFlowStatement] {
+
+  /** Compare by report date (descending - most recent first) */
+  def compare(that: CashFlowStatement): Int = that.reportDate.compareTo(this.reportDate)
+
+  // --- Derived Metrics ---
+
+  /** Free cash flow (calculated): Operating Cash Flow - Capital Expenditure */
+  def calculatedFreeCashFlow: Option[Double] =
+    for {
+      ocf <- operatingCashFlow
+      capex <- capitalExpenditure
+    } yield ocf - Math.abs(capex)
+
+  /** Free cash flow yield: Free Cash Flow / Market Cap (requires external market cap) */
+  def freeCashFlowYield(marketCap: Double): Option[Double] =
+    freeCashFlow.orElse(calculatedFreeCashFlow).map(_ / marketCap)
+
+  /** Operating cash flow to net income ratio */
+  def cashFlowToNetIncomeRatio: Option[Double] =
+    for {
+      ocf <- operatingCashFlow
+      ni <- netIncomeFromContinuingOperations if ni != 0
+    } yield ocf / ni
+
+  /** Capital expenditure as percentage of operating cash flow */
+  def capexToOperatingCashFlow: Option[Double] =
+    for {
+      capex <- capitalExpenditure
+      ocf <- operatingCashFlow if ocf != 0
+    } yield Math.abs(capex) / ocf
+
+  /** Net debt repayment (positive = paid down debt, negative = took on more debt) */
+  def netDebtChange: Option[Double] =
+    for {
+      repayment <- repaymentOfDebt.orElse(Some(0.0))
+      issuance <- issuanceOfDebt.orElse(Some(0.0))
+    } yield Math.abs(repayment) - Math.abs(issuance)
+}
+
+object CashFlowStatement {
+
+  /** Key fields to request from the API (without timescale prefix) */
+  val apiKeys: List[String] = List(
+    "OperatingCashFlow",
+    "NetIncomeFromContinuingOperations",
+    "DepreciationAmortizationDepletion",
+    "StockBasedCompensation",
+    "DeferredIncomeTax",
+    "ChangeInWorkingCapital",
+    "ChangeInReceivables",
+    "ChangeInInventory",
+    "ChangeInPayable",
+    "InvestingCashFlow",
+    "CapitalExpenditure",
+    "PurchaseOfInvestment",
+    "SaleOfInvestment",
+    "PurchaseOfBusiness",
+    "SaleOfBusiness",
+    "NetPPEPurchaseAndSale",
+    "FinancingCashFlow",
+    "IssuanceOfDebt",
+    "RepaymentOfDebt",
+    "IssuanceOfCapitalStock",
+    "RepurchaseOfCapitalStock",
+    "CashDividendsPaid",
+    "BeginningCashPosition",
+    "EndCashPosition",
+    "ChangesInCash",
+    "EffectOfExchangeRateChanges",
+    "FreeCashFlow"
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/FinancialStatements.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/FinancialStatements.scala
@@ -1,0 +1,94 @@
+package org.coinductive.yfinance4s.models
+
+/** Container for all financial statements of a company.
+  *
+  * @param ticker
+  *   The stock ticker symbol
+  * @param currency
+  *   The primary reporting currency
+  * @param incomeStatements
+  *   Income statements sorted by date (most recent first)
+  * @param balanceSheets
+  *   Balance sheets sorted by date (most recent first)
+  * @param cashFlowStatements
+  *   Cash flow statements sorted by date (most recent first)
+  */
+final case class FinancialStatements(
+    ticker: Ticker,
+    currency: String,
+    incomeStatements: List[IncomeStatement],
+    balanceSheets: List[BalanceSheet],
+    cashFlowStatements: List[CashFlowStatement]
+) {
+
+  /** True if any financial data is available */
+  def nonEmpty: Boolean =
+    incomeStatements.nonEmpty || balanceSheets.nonEmpty || cashFlowStatements.nonEmpty
+
+  /** True if no financial data is available */
+  def isEmpty: Boolean = !nonEmpty
+
+  /** Most recent income statement */
+  def latestIncomeStatement: Option[IncomeStatement] = incomeStatements.headOption
+
+  /** Most recent balance sheet */
+  def latestBalanceSheet: Option[BalanceSheet] = balanceSheets.headOption
+
+  /** Most recent cash flow statement */
+  def latestCashFlowStatement: Option[CashFlowStatement] = cashFlowStatements.headOption
+
+  /** Total number of reporting periods available */
+  def periodCount: Int = Math.max(
+    Math.max(incomeStatements.size, balanceSheets.size),
+    cashFlowStatements.size
+  )
+
+  // --- Cross-Statement Metrics ---
+
+  /** Return on Assets (Net Income / Total Assets) for most recent period */
+  def returnOnAssets: Option[Double] =
+    for {
+      is <- latestIncomeStatement
+      bs <- latestBalanceSheet
+      ni <- is.netIncome
+      assets <- bs.totalAssets if assets != 0
+    } yield ni / assets
+
+  /** Return on Equity (Net Income / Stockholders Equity) for most recent period */
+  def returnOnEquity: Option[Double] =
+    for {
+      is <- latestIncomeStatement
+      bs <- latestBalanceSheet
+      ni <- is.netIncome
+      equity <- bs.stockholdersEquity if equity != 0
+    } yield ni / equity
+
+  /** Asset Turnover (Revenue / Total Assets) for most recent period */
+  def assetTurnover: Option[Double] =
+    for {
+      is <- latestIncomeStatement
+      bs <- latestBalanceSheet
+      rev <- is.totalRevenue
+      assets <- bs.totalAssets if assets != 0
+    } yield rev / assets
+
+  /** Interest Coverage Ratio (EBIT / Interest Expense) for most recent period */
+  def interestCoverage: Option[Double] =
+    for {
+      is <- latestIncomeStatement
+      ebit <- is.ebit
+      interest <- is.interestExpense if interest != 0
+    } yield ebit / Math.abs(interest)
+}
+
+object FinancialStatements {
+
+  /** Empty financial statements */
+  def empty(ticker: Ticker): FinancialStatements = FinancialStatements(
+    ticker = ticker,
+    currency = "USD",
+    incomeStatements = List.empty,
+    balanceSheets = List.empty,
+    cashFlowStatements = List.empty
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/Frequency.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/Frequency.scala
@@ -1,0 +1,23 @@
+package org.coinductive.yfinance4s.models
+
+import enumeratum.*
+
+/** Frequency for financial statement data retrieval.
+  *
+  * @param apiValue
+  *   The value used in the Yahoo Finance API request
+  */
+sealed abstract class Frequency(val apiValue: String) extends EnumEntry
+
+object Frequency extends Enum[Frequency] {
+  val values: IndexedSeq[Frequency] = findValues
+
+  /** Annual financial data (up to 4 years of history) */
+  case object Yearly extends Frequency("annual")
+
+  /** Quarterly financial data (up to 5 quarters of history) */
+  case object Quarterly extends Frequency("quarterly")
+
+  /** Trailing twelve months (TTM) data - only available for income and cash flow statements */
+  case object Trailing extends Frequency("trailing")
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/IncomeStatement.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/IncomeStatement.scala
@@ -1,0 +1,125 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+/** Income statement data for a reporting period.
+  *
+  * All monetary values are in the company's reporting currency. Values are typically in the base unit (e.g., USD, not
+  * millions).
+  *
+  * @param reportDate
+  *   The fiscal period end date
+  * @param periodType
+  *   The period type (e.g., "12M" for annual, "3M" for quarterly)
+  * @param currencyCode
+  *   The currency of monetary values (e.g., "USD")
+  */
+final case class IncomeStatement(
+    reportDate: LocalDate,
+    periodType: String,
+    currencyCode: String,
+    // Revenue
+    totalRevenue: Option[Double],
+    operatingRevenue: Option[Double],
+    costOfRevenue: Option[Double],
+    grossProfit: Option[Double],
+    // Operating Expenses
+    operatingExpense: Option[Double],
+    sellingGeneralAndAdministration: Option[Double],
+    researchAndDevelopment: Option[Double],
+    depreciationAndAmortization: Option[Double],
+    // Operating Income
+    operatingIncome: Option[Double],
+    // Non-Operating Items
+    interestIncome: Option[Double],
+    interestExpense: Option[Double],
+    netInterestIncome: Option[Double],
+    otherIncomeExpense: Option[Double],
+    // Pre-Tax & Tax
+    pretaxIncome: Option[Double],
+    taxProvision: Option[Double],
+    // Net Income
+    netIncome: Option[Double],
+    netIncomeContinuousOperations: Option[Double],
+    netIncomeCommonStockholders: Option[Double],
+    // EPS
+    basicEps: Option[Double],
+    dilutedEps: Option[Double],
+    basicAverageShares: Option[Double],
+    dilutedAverageShares: Option[Double],
+    // EBITDA
+    ebit: Option[Double],
+    ebitda: Option[Double]
+) extends Ordered[IncomeStatement] {
+
+  /** Compare by report date (descending - most recent first) */
+  def compare(that: IncomeStatement): Int = that.reportDate.compareTo(this.reportDate)
+
+  // --- Derived Metrics ---
+
+  /** Gross profit margin: Gross Profit / Total Revenue */
+  def grossMargin: Option[Double] =
+    for {
+      gp <- grossProfit
+      rev <- totalRevenue if rev != 0
+    } yield gp / rev
+
+  /** Operating profit margin: Operating Income / Total Revenue */
+  def operatingMargin: Option[Double] =
+    for {
+      oi <- operatingIncome
+      rev <- totalRevenue if rev != 0
+    } yield oi / rev
+
+  /** Net profit margin: Net Income / Total Revenue */
+  def netMargin: Option[Double] =
+    for {
+      ni <- netIncome
+      rev <- totalRevenue if rev != 0
+    } yield ni / rev
+
+  /** EBITDA margin: EBITDA / Total Revenue */
+  def ebitdaMargin: Option[Double] =
+    for {
+      eb <- ebitda
+      rev <- totalRevenue if rev != 0
+    } yield eb / rev
+
+  /** Effective tax rate: Tax Provision / Pretax Income */
+  def effectiveTaxRate: Option[Double] =
+    for {
+      tax <- taxProvision
+      pretax <- pretaxIncome if pretax != 0
+    } yield tax / pretax
+}
+
+object IncomeStatement {
+
+  /** Key fields to request from the API (without timescale prefix) */
+  val apiKeys: List[String] = List(
+    "TotalRevenue",
+    "OperatingRevenue",
+    "CostOfRevenue",
+    "GrossProfit",
+    "OperatingExpense",
+    "SellingGeneralAndAdministration",
+    "ResearchAndDevelopment",
+    "DepreciationAndAmortizationInIncomeStatement",
+    "OperatingIncome",
+    "InterestIncome",
+    "InterestExpense",
+    "NetInterestIncome",
+    "OtherIncomeExpense",
+    "PretaxIncome",
+    "TaxProvision",
+    "NetIncome",
+    "NetIncomeContinuousOperations",
+    "NetIncomeCommonStockholders",
+    "BasicEPS",
+    "DilutedEPS",
+    "BasicAverageShares",
+    "DilutedAverageShares",
+    "EBIT",
+    "EBITDA"
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceFinancialsResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceFinancialsResult.scala
@@ -1,0 +1,208 @@
+package org.coinductive.yfinance4s.models
+
+import io.circe.{Decoder, Json}
+import io.circe.generic.semiauto.deriveDecoder
+
+import java.time.LocalDate
+import scala.util.Try
+
+/** Raw API response for financial statements from fundamentals-timeseries endpoint.
+  *
+  * The decoder transforms the API's metric-first structure into a date-first structure, grouping all metrics by report
+  * date and using Circe's automatic derivation.
+  */
+private[yfinance4s] final case class YFinanceFinancialsResult(
+    byDate: Map[LocalDate, RawFinancialData]
+)
+
+private[yfinance4s] object YFinanceFinancialsResult {
+  private val DefaultPeriodType = "12M"
+  private val DefaultCurrency = "USD"
+  private val TimescalePrefixPattern = "^(annual|quarterly|trailing)"
+
+  implicit val decoder: Decoder[YFinanceFinancialsResult] = Decoder.instance { c =>
+    for {
+      result <- c.downField("timeseries").downField("result").as[Option[List[Json]]]
+    } yield YFinanceFinancialsResult(parseResult(result.getOrElse(List.empty)))
+  }
+
+  private def parseResult(entries: List[Json]): Map[LocalDate, RawFinancialData] = {
+    val allValues = entries.flatMap(parseEntry)
+
+    allValues
+      .groupBy(_._1)
+      .flatMap { case (date, values) =>
+        val periodType = values.headOption.map(_._4).getOrElse(DefaultPeriodType)
+        val currency = values.headOption.map(_._5).getOrElse(DefaultCurrency)
+
+        val metricsJson = Json.obj(values.map { case (_, key, value, _, _) =>
+          toCamelCase(key) -> Json.fromDoubleOrNull(value)
+        } *)
+
+        for {
+          income <- metricsJson.as[IncomeData].toOption
+          balance <- metricsJson.as[BalanceData].toOption
+          cashFlow <- metricsJson.as[CashFlowData].toOption
+        } yield date -> RawFinancialData(periodType, currency, income, balance, cashFlow)
+      }
+  }
+
+  private def parseEntry(json: Json): List[(LocalDate, String, Double, String, String)] = {
+    val cursor = json.hcursor
+
+    val metricKey = cursor
+      .downField("meta")
+      .downField("type")
+      .as[List[String]]
+      .toOption
+      .flatMap(_.headOption)
+      .map(_.replaceFirst(TimescalePrefixPattern, ""))
+      .getOrElse("")
+
+    val dataFieldName = json.asObject
+      .flatMap(_.keys.find(k => k != "meta" && k != "timestamp"))
+
+    dataFieldName match {
+      case Some(fieldName) =>
+        cursor
+          .downField(fieldName)
+          .as[Option[List[Json]]]
+          .toOption
+          .flatten
+          .getOrElse(List.empty)
+          .flatMap { valueJson =>
+            val vc = valueJson.hcursor
+            for {
+              dateStr <- vc.downField("asOfDate").as[String].toOption
+              date <- Try(LocalDate.parse(dateStr)).toOption
+              rawValue <- vc.downField("reportedValue").downField("raw").as[Double].toOption
+              periodType = vc.downField("periodType").as[String].toOption.getOrElse(DefaultPeriodType)
+              currency = vc.downField("currencyCode").as[String].toOption.getOrElse(DefaultCurrency)
+            } yield (date, metricKey, rawValue, periodType, currency)
+          }
+      case None => List.empty
+    }
+  }
+
+  private def toCamelCase(s: String): String =
+    if (s.isEmpty) s else s.head.toLower + s.tail
+}
+
+/** Container for all financial metrics at a specific reporting date. */
+private[yfinance4s] final case class RawFinancialData(
+    periodType: String,
+    currencyCode: String,
+    income: IncomeData,
+    balance: BalanceData,
+    cashFlow: CashFlowData
+)
+
+/** Income statement data fields. */
+private[yfinance4s] final case class IncomeData(
+    totalRevenue: Option[Double] = None,
+    operatingRevenue: Option[Double] = None,
+    costOfRevenue: Option[Double] = None,
+    grossProfit: Option[Double] = None,
+    operatingExpense: Option[Double] = None,
+    sellingGeneralAndAdministration: Option[Double] = None,
+    researchAndDevelopment: Option[Double] = None,
+    depreciationAndAmortizationInIncomeStatement: Option[Double] = None,
+    operatingIncome: Option[Double] = None,
+    interestIncome: Option[Double] = None,
+    interestExpense: Option[Double] = None,
+    netInterestIncome: Option[Double] = None,
+    otherIncomeExpense: Option[Double] = None,
+    pretaxIncome: Option[Double] = None,
+    taxProvision: Option[Double] = None,
+    netIncome: Option[Double] = None,
+    netIncomeContinuousOperations: Option[Double] = None,
+    netIncomeCommonStockholders: Option[Double] = None,
+    basicEPS: Option[Double] = None,
+    dilutedEPS: Option[Double] = None,
+    basicAverageShares: Option[Double] = None,
+    dilutedAverageShares: Option[Double] = None,
+    eBIT: Option[Double] = None,
+    eBITDA: Option[Double] = None
+)
+
+private[yfinance4s] object IncomeData {
+  implicit val decoder: Decoder[IncomeData] = deriveDecoder
+}
+
+/** Balance sheet data fields. */
+private[yfinance4s] final case class BalanceData(
+    totalAssets: Option[Double] = None,
+    currentAssets: Option[Double] = None,
+    cashAndCashEquivalents: Option[Double] = None,
+    otherShortTermInvestments: Option[Double] = None,
+    accountsReceivable: Option[Double] = None,
+    inventory: Option[Double] = None,
+    otherCurrentAssets: Option[Double] = None,
+    totalNonCurrentAssets: Option[Double] = None,
+    netPPE: Option[Double] = None,
+    grossPPE: Option[Double] = None,
+    accumulatedDepreciation: Option[Double] = None,
+    goodwill: Option[Double] = None,
+    otherIntangibleAssets: Option[Double] = None,
+    longTermEquityInvestment: Option[Double] = None,
+    otherNonCurrentAssets: Option[Double] = None,
+    currentLiabilities: Option[Double] = None,
+    accountsPayable: Option[Double] = None,
+    currentDebt: Option[Double] = None,
+    otherCurrentLiabilities: Option[Double] = None,
+    totalNonCurrentLiabilitiesNetMinorityInterest: Option[Double] = None,
+    longTermDebt: Option[Double] = None,
+    otherNonCurrentLiabilities: Option[Double] = None,
+    totalLiabilitiesNetMinorityInterest: Option[Double] = None,
+    totalDebt: Option[Double] = None,
+    netDebt: Option[Double] = None,
+    stockholdersEquity: Option[Double] = None,
+    commonStock: Option[Double] = None,
+    additionalPaidInCapital: Option[Double] = None,
+    retainedEarnings: Option[Double] = None,
+    treasuryStock: Option[Double] = None,
+    shareIssued: Option[Double] = None,
+    ordinarySharesNumber: Option[Double] = None,
+    workingCapital: Option[Double] = None,
+    tangibleBookValue: Option[Double] = None,
+    investedCapital: Option[Double] = None
+)
+
+private[yfinance4s] object BalanceData {
+  implicit val decoder: Decoder[BalanceData] = deriveDecoder
+}
+
+/** Cash flow statement data fields. */
+private[yfinance4s] final case class CashFlowData(
+    operatingCashFlow: Option[Double] = None,
+    netIncomeFromContinuingOperations: Option[Double] = None,
+    depreciationAmortizationDepletion: Option[Double] = None,
+    stockBasedCompensation: Option[Double] = None,
+    deferredIncomeTax: Option[Double] = None,
+    changeInWorkingCapital: Option[Double] = None,
+    changeInReceivables: Option[Double] = None,
+    changeInInventory: Option[Double] = None,
+    changeInPayable: Option[Double] = None,
+    investingCashFlow: Option[Double] = None,
+    capitalExpenditure: Option[Double] = None,
+    purchaseOfInvestment: Option[Double] = None,
+    saleOfInvestment: Option[Double] = None,
+    purchaseOfBusiness: Option[Double] = None,
+    saleOfBusiness: Option[Double] = None,
+    netPPEPurchaseAndSale: Option[Double] = None,
+    financingCashFlow: Option[Double] = None,
+    issuanceOfDebt: Option[Double] = None,
+    repaymentOfDebt: Option[Double] = None,
+    issuanceOfCapitalStock: Option[Double] = None,
+    repurchaseOfCapitalStock: Option[Double] = None,
+    cashDividendsPaid: Option[Double] = None,
+    beginningCashPosition: Option[Double] = None,
+    endCashPosition: Option[Double] = None,
+    changesInCash: Option[Double] = None,
+    effectOfExchangeRateChanges: Option[Double] = None,
+    freeCashFlow: Option[Double] = None
+)
+
+private[yfinance4s] object CashFlowData {
+  implicit val decoder: Decoder[CashFlowData] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/FinancialStatementsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/FinancialStatementsSpec.scala
@@ -1,0 +1,197 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.{Frequency, Ticker}
+
+import scala.concurrent.duration.*
+
+class FinancialStatementsSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  test("getFinancialStatements should return yearly financial data for AAPL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getFinancialStatements(Ticker("AAPL"), Frequency.Yearly).map { result =>
+        assert(result.isDefined, "Result should be defined for AAPL")
+        val financials = result.get
+
+        assert(financials.nonEmpty, "AAPL should have financial statements")
+
+        // Should have income statements
+        assert(financials.incomeStatements.nonEmpty, "AAPL should have income statements")
+        val latestIncome = financials.incomeStatements.head
+        assert(latestIncome.totalRevenue.isDefined, "AAPL should have total revenue")
+        assert(latestIncome.totalRevenue.get > 0, "Revenue should be positive")
+
+        // Should have balance sheets
+        assert(financials.balanceSheets.nonEmpty, "AAPL should have balance sheets")
+        val latestBalance = financials.balanceSheets.head
+        assert(latestBalance.totalAssets.isDefined, "AAPL should have total assets")
+        assert(latestBalance.totalAssets.get > 0, "Total assets should be positive")
+
+        // Should have cash flow statements
+        assert(financials.cashFlowStatements.nonEmpty, "AAPL should have cash flow statements")
+        val latestCashFlow = financials.cashFlowStatements.head
+        assert(latestCashFlow.operatingCashFlow.isDefined, "AAPL should have operating cash flow")
+      }
+    }
+  }
+
+  test("getFinancialStatements should return quarterly data for MSFT") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getFinancialStatements(Ticker("MSFT"), Frequency.Quarterly).map { result =>
+        assert(result.isDefined, "Result should be defined for MSFT")
+        val financials = result.get
+
+        assert(financials.nonEmpty, "MSFT should have financial statements")
+
+        // Quarterly data should have more periods than yearly
+        assert(financials.incomeStatements.size >= 4, "Should have at least 4 quarterly statements")
+
+        // Verify statements are sorted by date descending
+        val dates = financials.incomeStatements.map(_.reportDate)
+        assert(dates == dates.sorted.reverse, "Statements should be sorted by date descending")
+      }
+    }
+  }
+
+  test("getIncomeStatements should return income data for GOOGL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getIncomeStatements(Ticker("GOOGL")).map { statements =>
+        assert(statements.nonEmpty, "GOOGL should have income statements")
+
+        statements.foreach { stmt =>
+          // Validate basic structure
+          assert(stmt.currencyCode.nonEmpty, "Currency code should not be empty")
+          assert(stmt.periodType.nonEmpty, "Period type should not be empty")
+
+          // Revenue should be present for GOOGL
+          stmt.totalRevenue.foreach { revenue =>
+            assert(revenue > 0, s"Revenue should be positive: $revenue")
+          }
+
+          // Net income should be present
+          stmt.netIncome.foreach { netIncome =>
+            assert(netIncome != 0, "Net income should not be zero")
+          }
+        }
+
+        // Test derived metrics on latest statement
+        val latest = statements.head
+        latest.grossMargin.foreach { margin =>
+          assert(margin > 0 && margin < 1, s"Gross margin should be between 0 and 1: $margin")
+        }
+      }
+    }
+  }
+
+  test("getBalanceSheets should return balance sheet data for NVDA") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getBalanceSheets(Ticker("NVDA")).map { sheets =>
+        assert(sheets.nonEmpty, "NVDA should have balance sheets")
+
+        sheets.foreach { sheet =>
+          // Total assets should be present
+          sheet.totalAssets.foreach { assets =>
+            assert(assets > 0, s"Total assets should be positive: $assets")
+          }
+
+          // Stockholders equity should be present
+          sheet.stockholdersEquity.foreach { equity =>
+            assert(equity > 0, s"Stockholders equity should be positive for NVDA: $equity")
+          }
+        }
+
+        // Test derived metrics on latest sheet
+        val latest = sheets.head
+        latest.currentRatio.foreach { ratio =>
+          assert(ratio > 0, s"Current ratio should be positive: $ratio")
+        }
+        latest.debtToEquity.foreach { ratio =>
+          assert(ratio >= 0, s"Debt to equity should be non-negative: $ratio")
+        }
+      }
+    }
+  }
+
+  test("getCashFlowStatements should return cash flow data for AMZN") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getCashFlowStatements(Ticker("AMZN")).map { statements =>
+        assert(statements.nonEmpty, "AMZN should have cash flow statements")
+
+        statements.foreach { stmt =>
+          // Operating cash flow should be present
+          stmt.operatingCashFlow.foreach { ocf =>
+            assert(ocf != 0, "Operating cash flow should not be zero")
+          }
+        }
+
+        // Test derived metrics on latest statement
+        val latest = statements.head
+        latest.calculatedFreeCashFlow.foreach { fcf =>
+          // FCF can be negative for growth companies, just verify it's calculated
+          assert(!fcf.isNaN, "FCF should not be NaN")
+        }
+      }
+    }
+  }
+
+  test("getFinancialStatements should support trailing frequency") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getFinancialStatements(Ticker("AAPL"), Frequency.Trailing).map { result =>
+        assert(result.isDefined, "Trailing result should be defined for AAPL")
+        val financials = result.get
+
+        // Trailing should have data (TTM - trailing twelve months)
+        assert(financials.nonEmpty, "AAPL should have trailing financial data")
+      }
+    }
+  }
+
+  test("cross-statement metrics should calculate correctly for AAPL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getFinancialStatements(Ticker("AAPL")).map { result =>
+        assert(result.isDefined, "Result should be defined for AAPL")
+        val financials = result.get
+
+        // Test ROA (requires income and balance sheet)
+        financials.returnOnAssets.foreach { roa =>
+          assert(roa > 0 && roa < 1, s"ROA should be reasonable for AAPL: $roa")
+        }
+
+        // Test ROE
+        financials.returnOnEquity.foreach { roe =>
+          assert(roe > 0, s"ROE should be positive for profitable AAPL: $roe")
+        }
+
+        // Test asset turnover
+        financials.assetTurnover.foreach { turnover =>
+          assert(turnover > 0, s"Asset turnover should be positive: $turnover")
+        }
+
+        // Test interest coverage
+        financials.interestCoverage.foreach { coverage =>
+          assert(coverage > 0, s"Interest coverage should be positive for AAPL: $coverage")
+        }
+      }
+    }
+  }
+
+  test("getFinancialStatements should work for stocks without all data") {
+    YFinanceClient.resource[IO](config).use { client =>
+      // Use a company that should have financials
+      client.getFinancialStatements(Ticker("IBM")).map { result =>
+        assert(result.isDefined, "Result should be defined for IBM")
+        // IBM should have at least some financial data
+        val financials = result.get
+        assert(financials.nonEmpty, "IBM should have some financial data")
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/BalanceSheetSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/BalanceSheetSpec.scala
@@ -1,0 +1,128 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.BalanceSheet
+
+import java.time.LocalDate
+
+class BalanceSheetSpec extends FunSuite {
+
+  private val sampleSheet = BalanceSheet(
+    reportDate = LocalDate.of(2024, 9, 28),
+    periodType = "12M",
+    currencyCode = "USD",
+    totalAssets = Some(364980000000.0),
+    currentAssets = Some(152987000000.0),
+    cashAndCashEquivalents = Some(29943000000.0),
+    shortTermInvestments = Some(35228000000.0),
+    accountsReceivable = Some(66243000000.0),
+    inventory = Some(7286000000.0),
+    otherCurrentAssets = Some(14287000000.0),
+    totalNonCurrentAssets = Some(211993000000.0),
+    netPpe = Some(45680000000.0),
+    grossPpe = Some(119681000000.0),
+    accumulatedDepreciation = Some(-74001000000.0),
+    goodwill = None,
+    otherIntangibleAssets = None,
+    longTermInvestments = Some(100544000000.0),
+    otherNonCurrentAssets = Some(65769000000.0),
+    currentLiabilities = Some(176392000000.0),
+    accountsPayable = Some(68960000000.0),
+    currentDebt = Some(20904000000.0),
+    otherCurrentLiabilities = Some(86528000000.0),
+    totalNonCurrentLiabilities = Some(89140000000.0),
+    longTermDebt = Some(85750000000.0),
+    otherNonCurrentLiabilities = Some(3390000000.0),
+    totalLiabilities = Some(265532000000.0),
+    totalDebt = Some(106654000000.0),
+    netDebt = Some(76711000000.0),
+    stockholdersEquity = Some(56950000000.0),
+    commonStock = Some(79850000000.0),
+    additionalPaidInCapital = None,
+    retainedEarnings = Some(-22900000000.0),
+    treasuryStock = None,
+    sharesIssued = Some(15550000000.0),
+    ordinarySharesNumber = Some(15550000000.0),
+    workingCapital = Some(-23405000000.0),
+    tangibleBookValue = Some(56950000000.0),
+    investedCapital = Some(163604000000.0)
+  )
+
+  test("currentRatio should calculate correctly") {
+    val ratio = sampleSheet.currentRatio
+    assert(ratio.isDefined)
+    // 152987000000 / 176392000000 ~ 0.8673
+    assert(Math.abs(ratio.get - 0.8673) < 0.001)
+  }
+
+  test("quickRatio should calculate correctly") {
+    val ratio = sampleSheet.quickRatio
+    assert(ratio.isDefined)
+    // (152987000000 - 7286000000) / 176392000000 ~ 0.8260
+    assert(Math.abs(ratio.get - 0.8260) < 0.001)
+  }
+
+  test("quickRatio should handle missing inventory") {
+    val sheet = sampleSheet.copy(inventory = None)
+    val ratio = sheet.quickRatio
+    assert(ratio.isDefined)
+    // Should treat missing inventory as 0
+    // 152987000000 / 176392000000 ~ 0.8673
+    assert(Math.abs(ratio.get - 0.8673) < 0.001)
+  }
+
+  test("debtToEquity should calculate correctly") {
+    val ratio = sampleSheet.debtToEquity
+    assert(ratio.isDefined)
+    // 106654000000 / 56950000000 ~ 1.8727
+    assert(Math.abs(ratio.get - 1.8727) < 0.001)
+  }
+
+  test("debtToAssets should calculate correctly") {
+    val ratio = sampleSheet.debtToAssets
+    assert(ratio.isDefined)
+    // 106654000000 / 364980000000 ~ 0.2922
+    assert(Math.abs(ratio.get - 0.2922) < 0.001)
+  }
+
+  test("bookValuePerShare should calculate correctly") {
+    val bvps = sampleSheet.bookValuePerShare
+    assert(bvps.isDefined)
+    // 56950000000 / 15550000000 ~ 3.66
+    assert(Math.abs(bvps.get - 3.66) < 0.01)
+  }
+
+  test("tangibleBookValuePerShare should calculate correctly") {
+    val tbvps = sampleSheet.tangibleBookValuePerShare
+    assert(tbvps.isDefined)
+    // 56950000000 / 15550000000 ~ 3.66
+    assert(Math.abs(tbvps.get - 3.66) < 0.01)
+  }
+
+  test("currentRatio should return None when currentLiabilities is zero") {
+    val sheet = sampleSheet.copy(currentLiabilities = Some(0.0))
+    assertEquals(sheet.currentRatio, None)
+  }
+
+  test("currentRatio should return None when currentLiabilities is missing") {
+    val sheet = sampleSheet.copy(currentLiabilities = None)
+    assertEquals(sheet.currentRatio, None)
+  }
+
+  test("debtToEquity should return None when stockholdersEquity is zero") {
+    val sheet = sampleSheet.copy(stockholdersEquity = Some(0.0))
+    assertEquals(sheet.debtToEquity, None)
+  }
+
+  test("bookValuePerShare should return None when shares is zero") {
+    val sheet = sampleSheet.copy(ordinarySharesNumber = Some(0.0))
+    assertEquals(sheet.bookValuePerShare, None)
+  }
+
+  test("balance sheets should sort by date descending") {
+    val older = sampleSheet.copy(reportDate = LocalDate.of(2023, 9, 28))
+    val newer = sampleSheet.copy(reportDate = LocalDate.of(2024, 9, 28))
+    val sorted = List(older, newer).sorted
+    assertEquals(sorted.head.reportDate, LocalDate.of(2024, 9, 28))
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CashFlowStatementSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CashFlowStatementSpec.scala
@@ -1,0 +1,137 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.CashFlowStatement
+
+import java.time.LocalDate
+
+class CashFlowStatementSpec extends FunSuite {
+
+  private val sampleStatement = CashFlowStatement(
+    reportDate = LocalDate.of(2024, 9, 28),
+    periodType = "12M",
+    currencyCode = "USD",
+    operatingCashFlow = Some(118254000000.0),
+    netIncomeFromContinuingOperations = Some(94663000000.0),
+    depreciationAmortizationDepletion = Some(11445000000.0),
+    stockBasedCompensation = Some(11658000000.0),
+    deferredIncomeTax = Some(-5050000000.0),
+    changeInWorkingCapital = Some(6066000000.0),
+    changeInReceivables = Some(-11412000000.0),
+    changeInInventory = Some(1037000000.0),
+    changeInPayables = Some(15552000000.0),
+    investingCashFlow = Some(-2935000000.0),
+    capitalExpenditure = Some(-9447000000.0),
+    purchaseOfInvestment = Some(-48656000000.0),
+    saleOfInvestment = Some(62346000000.0),
+    purchaseOfBusiness = Some(-1789000000.0),
+    saleOfBusiness = None,
+    netPpePurchaseAndSale = Some(-4611000000.0),
+    financingCashFlow = Some(-121549000000.0),
+    issuanceOfDebt = Some(5000000000.0),
+    repaymentOfDebt = Some(-12941000000.0),
+    issuanceOfCapitalStock = None,
+    repurchaseOfCapitalStock = Some(-94949000000.0),
+    cashDividendsPaid = Some(-15234000000.0),
+    beginningCashPosition = Some(30737000000.0),
+    endCashPosition = Some(29943000000.0),
+    changesInCash = Some(-6230000000.0),
+    effectOfExchangeRateChanges = Some(436000000.0),
+    freeCashFlow = Some(108807000000.0)
+  )
+
+  test("calculatedFreeCashFlow should calculate correctly") {
+    val fcf = sampleStatement.calculatedFreeCashFlow
+    assert(fcf.isDefined)
+    // 118254000000 - abs(-9447000000) = 108807000000
+    assertEquals(fcf.get, 108807000000.0)
+  }
+
+  test("calculatedFreeCashFlow should handle positive capex value") {
+    // Some APIs report capex as positive
+    val stmt = sampleStatement.copy(capitalExpenditure = Some(9447000000.0))
+    val fcf = stmt.calculatedFreeCashFlow
+    assert(fcf.isDefined)
+    assertEquals(fcf.get, 108807000000.0)
+  }
+
+  test("freeCashFlowYield should calculate correctly") {
+    val marketCap = 3000000000000.0 // $3 trillion
+    val fcfYield = sampleStatement.freeCashFlowYield(marketCap)
+    assert(fcfYield.isDefined)
+    // 108807000000 / 3000000000000 ~ 0.0363
+    assert(Math.abs(fcfYield.get - 0.0363) < 0.001)
+  }
+
+  test("freeCashFlowYield should use API freeCashFlow when available") {
+    val stmt = sampleStatement.copy(freeCashFlow = Some(100000000000.0))
+    val marketCap = 3000000000000.0
+    val fcfYield = stmt.freeCashFlowYield(marketCap)
+    assert(fcfYield.isDefined)
+    // 100000000000 / 3000000000000 ~ 0.0333
+    assert(Math.abs(fcfYield.get - 0.0333) < 0.001)
+  }
+
+  test("freeCashFlowYield should fall back to calculated when API value missing") {
+    val stmt = sampleStatement.copy(freeCashFlow = None)
+    val marketCap = 3000000000000.0
+    val fcfYield = stmt.freeCashFlowYield(marketCap)
+    assert(fcfYield.isDefined)
+    // Uses calculatedFreeCashFlow: 108807000000
+    assert(Math.abs(fcfYield.get - 0.0363) < 0.001)
+  }
+
+  test("cashFlowToNetIncomeRatio should calculate correctly") {
+    val ratio = sampleStatement.cashFlowToNetIncomeRatio
+    assert(ratio.isDefined)
+    // 118254000000 / 94663000000 ~ 1.249
+    assert(Math.abs(ratio.get - 1.249) < 0.001)
+  }
+
+  test("capexToOperatingCashFlow should calculate correctly") {
+    val ratio = sampleStatement.capexToOperatingCashFlow
+    assert(ratio.isDefined)
+    // abs(-9447000000) / 118254000000 ~ 0.0799
+    assert(Math.abs(ratio.get - 0.0799) < 0.001)
+  }
+
+  test("netDebtChange should calculate correctly") {
+    val change = sampleStatement.netDebtChange
+    assert(change.isDefined)
+    // abs(-12941000000) - abs(5000000000) = 7941000000
+    assertEquals(change.get, 7941000000.0)
+  }
+
+  test("netDebtChange should handle missing repayment") {
+    val stmt = sampleStatement.copy(repaymentOfDebt = None)
+    val change = stmt.netDebtChange
+    assert(change.isDefined)
+    // 0 - 5000000000 = -5000000000
+    assertEquals(change.get, -5000000000.0)
+  }
+
+  test("netDebtChange should handle missing issuance") {
+    val stmt = sampleStatement.copy(issuanceOfDebt = None)
+    val change = stmt.netDebtChange
+    assert(change.isDefined)
+    // 12941000000 - 0 = 12941000000
+    assertEquals(change.get, 12941000000.0)
+  }
+
+  test("cashFlowToNetIncomeRatio should return None when netIncome is zero") {
+    val stmt = sampleStatement.copy(netIncomeFromContinuingOperations = Some(0.0))
+    assertEquals(stmt.cashFlowToNetIncomeRatio, None)
+  }
+
+  test("capexToOperatingCashFlow should return None when operating cash flow is zero") {
+    val stmt = sampleStatement.copy(operatingCashFlow = Some(0.0))
+    assertEquals(stmt.capexToOperatingCashFlow, None)
+  }
+
+  test("cash flow statements should sort by date descending") {
+    val older = sampleStatement.copy(reportDate = LocalDate.of(2023, 9, 28))
+    val newer = sampleStatement.copy(reportDate = LocalDate.of(2024, 9, 28))
+    val sorted = List(older, newer).sorted
+    assertEquals(sorted.head.reportDate, LocalDate.of(2024, 9, 28))
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/FinancialStatementsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/FinancialStatementsSpec.scala
@@ -1,0 +1,217 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+import java.time.LocalDate
+
+class FinancialStatementsSpec extends FunSuite {
+
+  private val sampleIncomeStatement = IncomeStatement(
+    reportDate = LocalDate.of(2024, 9, 28),
+    periodType = "12M",
+    currencyCode = "USD",
+    totalRevenue = Some(383285000000.0),
+    operatingRevenue = None,
+    costOfRevenue = None,
+    grossProfit = None,
+    operatingExpense = None,
+    sellingGeneralAndAdministration = None,
+    researchAndDevelopment = None,
+    depreciationAndAmortization = None,
+    operatingIncome = None,
+    interestIncome = None,
+    interestExpense = Some(3000000000.0),
+    netInterestIncome = None,
+    otherIncomeExpense = None,
+    pretaxIncome = None,
+    taxProvision = None,
+    netIncome = Some(94663000000.0),
+    netIncomeContinuousOperations = None,
+    netIncomeCommonStockholders = None,
+    basicEps = None,
+    dilutedEps = None,
+    basicAverageShares = None,
+    dilutedAverageShares = None,
+    ebit = Some(113033000000.0),
+    ebitda = None
+  )
+
+  private val sampleBalanceSheet = BalanceSheet(
+    reportDate = LocalDate.of(2024, 9, 28),
+    periodType = "12M",
+    currencyCode = "USD",
+    totalAssets = Some(364980000000.0),
+    currentAssets = None,
+    cashAndCashEquivalents = None,
+    shortTermInvestments = None,
+    accountsReceivable = None,
+    inventory = None,
+    otherCurrentAssets = None,
+    totalNonCurrentAssets = None,
+    netPpe = None,
+    grossPpe = None,
+    accumulatedDepreciation = None,
+    goodwill = None,
+    otherIntangibleAssets = None,
+    longTermInvestments = None,
+    otherNonCurrentAssets = None,
+    currentLiabilities = None,
+    accountsPayable = None,
+    currentDebt = None,
+    otherCurrentLiabilities = None,
+    totalNonCurrentLiabilities = None,
+    longTermDebt = None,
+    otherNonCurrentLiabilities = None,
+    totalLiabilities = None,
+    totalDebt = None,
+    netDebt = None,
+    stockholdersEquity = Some(56950000000.0),
+    commonStock = None,
+    additionalPaidInCapital = None,
+    retainedEarnings = None,
+    treasuryStock = None,
+    sharesIssued = None,
+    ordinarySharesNumber = None,
+    workingCapital = None,
+    tangibleBookValue = None,
+    investedCapital = None
+  )
+
+  private val sampleCashFlowStatement = CashFlowStatement(
+    reportDate = LocalDate.of(2024, 9, 28),
+    periodType = "12M",
+    currencyCode = "USD",
+    operatingCashFlow = Some(118254000000.0),
+    netIncomeFromContinuingOperations = None,
+    depreciationAmortizationDepletion = None,
+    stockBasedCompensation = None,
+    deferredIncomeTax = None,
+    changeInWorkingCapital = None,
+    changeInReceivables = None,
+    changeInInventory = None,
+    changeInPayables = None,
+    investingCashFlow = None,
+    capitalExpenditure = None,
+    purchaseOfInvestment = None,
+    saleOfInvestment = None,
+    purchaseOfBusiness = None,
+    saleOfBusiness = None,
+    netPpePurchaseAndSale = None,
+    financingCashFlow = None,
+    issuanceOfDebt = None,
+    repaymentOfDebt = None,
+    issuanceOfCapitalStock = None,
+    repurchaseOfCapitalStock = None,
+    cashDividendsPaid = None,
+    beginningCashPosition = None,
+    endCashPosition = None,
+    changesInCash = None,
+    effectOfExchangeRateChanges = None,
+    freeCashFlow = None
+  )
+
+  private val sampleFinancials = FinancialStatements(
+    ticker = Ticker("AAPL"),
+    currency = "USD",
+    incomeStatements = List(sampleIncomeStatement),
+    balanceSheets = List(sampleBalanceSheet),
+    cashFlowStatements = List(sampleCashFlowStatement)
+  )
+
+  test("returnOnAssets should calculate correctly") {
+    val roa = sampleFinancials.returnOnAssets
+    assert(roa.isDefined)
+    // 94663000000 / 364980000000 ~ 0.2594
+    assert(Math.abs(roa.get - 0.2594) < 0.001)
+  }
+
+  test("returnOnEquity should calculate correctly") {
+    val roe = sampleFinancials.returnOnEquity
+    assert(roe.isDefined)
+    // 94663000000 / 56950000000 ~ 1.662
+    assert(Math.abs(roe.get - 1.662) < 0.001)
+  }
+
+  test("assetTurnover should calculate correctly") {
+    val turnover = sampleFinancials.assetTurnover
+    assert(turnover.isDefined)
+    // 383285000000 / 364980000000 ~ 1.050
+    assert(Math.abs(turnover.get - 1.050) < 0.001)
+  }
+
+  test("interestCoverage should calculate correctly") {
+    val coverage = sampleFinancials.interestCoverage
+    assert(coverage.isDefined)
+    // 113033000000 / abs(3000000000) ~ 37.68
+    assert(Math.abs(coverage.get - 37.68) < 0.01)
+  }
+
+  test("returnOnAssets should return None when totalAssets is zero") {
+    val modified = sampleFinancials.copy(
+      balanceSheets = List(sampleBalanceSheet.copy(totalAssets = Some(0.0)))
+    )
+    assertEquals(modified.returnOnAssets, None)
+  }
+
+  test("returnOnAssets should return None when totalAssets is missing") {
+    val modified = sampleFinancials.copy(
+      balanceSheets = List(sampleBalanceSheet.copy(totalAssets = None))
+    )
+    assertEquals(modified.returnOnAssets, None)
+  }
+
+  test("returnOnEquity should return None when stockholdersEquity is zero") {
+    val modified = sampleFinancials.copy(
+      balanceSheets = List(sampleBalanceSheet.copy(stockholdersEquity = Some(0.0)))
+    )
+    assertEquals(modified.returnOnEquity, None)
+  }
+
+  test("interestCoverage should return None when interestExpense is zero") {
+    val modified = sampleFinancials.copy(
+      incomeStatements = List(sampleIncomeStatement.copy(interestExpense = Some(0.0)))
+    )
+    assertEquals(modified.interestCoverage, None)
+  }
+
+  test("interestCoverage should return None when interestExpense is missing") {
+    val modified = sampleFinancials.copy(
+      incomeStatements = List(sampleIncomeStatement.copy(interestExpense = None))
+    )
+    assertEquals(modified.interestCoverage, None)
+  }
+
+  test("nonEmpty should return true when any statements exist") {
+    assert(sampleFinancials.nonEmpty)
+  }
+
+  test("nonEmpty should return false when all statements are empty") {
+    val empty = FinancialStatements.empty(Ticker("TEST"))
+    assert(!empty.nonEmpty)
+  }
+
+  test("isEmpty should return true when no statements exist") {
+    val empty = FinancialStatements.empty(Ticker("TEST"))
+    assert(empty.isEmpty)
+  }
+
+  test("latestIncomeStatement should return the first statement") {
+    assertEquals(sampleFinancials.latestIncomeStatement, Some(sampleIncomeStatement))
+  }
+
+  test("latestIncomeStatement should return None when no statements exist") {
+    val empty = sampleFinancials.copy(incomeStatements = List.empty)
+    assertEquals(empty.latestIncomeStatement, None)
+  }
+
+  test("periodCount should return the maximum of all statement counts") {
+    val multi = sampleFinancials.copy(
+      incomeStatements =
+        List(sampleIncomeStatement, sampleIncomeStatement.copy(reportDate = LocalDate.of(2023, 9, 28))),
+      balanceSheets = List(sampleBalanceSheet),
+      cashFlowStatements = List(sampleCashFlowStatement, sampleCashFlowStatement, sampleCashFlowStatement)
+    )
+    assertEquals(multi.periodCount, 3)
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IncomeStatementSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IncomeStatementSpec.scala
@@ -1,0 +1,101 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.IncomeStatement
+
+import java.time.LocalDate
+
+class IncomeStatementSpec extends FunSuite {
+
+  private val sampleStatement = IncomeStatement(
+    reportDate = LocalDate.of(2024, 9, 28),
+    periodType = "12M",
+    currencyCode = "USD",
+    totalRevenue = Some(383285000000.0),
+    operatingRevenue = Some(383285000000.0),
+    costOfRevenue = Some(214137000000.0),
+    grossProfit = Some(169148000000.0),
+    operatingExpense = Some(58712000000.0),
+    sellingGeneralAndAdministration = Some(24873000000.0),
+    researchAndDevelopment = Some(33839000000.0),
+    depreciationAndAmortization = Some(11445000000.0),
+    operatingIncome = Some(110436000000.0),
+    interestIncome = Some(3999000000.0),
+    interestExpense = Some(3000000000.0),
+    netInterestIncome = Some(999000000.0),
+    otherIncomeExpense = Some(-422000000.0),
+    pretaxIncome = Some(113033000000.0),
+    taxProvision = Some(18370000000.0),
+    netIncome = Some(94663000000.0),
+    netIncomeContinuousOperations = Some(94663000000.0),
+    netIncomeCommonStockholders = Some(94663000000.0),
+    basicEps = Some(6.11),
+    dilutedEps = Some(6.08),
+    basicAverageShares = Some(15494000000.0),
+    dilutedAverageShares = Some(15558000000.0),
+    ebit = Some(113033000000.0),
+    ebitda = Some(124478000000.0)
+  )
+
+  test("grossMargin should calculate correctly") {
+    val margin = sampleStatement.grossMargin
+    assert(margin.isDefined)
+    // 169148000000 / 383285000000 ~ 0.4413
+    assert(Math.abs(margin.get - 0.4413) < 0.001)
+  }
+
+  test("operatingMargin should calculate correctly") {
+    val margin = sampleStatement.operatingMargin
+    assert(margin.isDefined)
+    // 110436000000 / 383285000000 ~ 0.2881
+    assert(Math.abs(margin.get - 0.2881) < 0.001)
+  }
+
+  test("netMargin should calculate correctly") {
+    val margin = sampleStatement.netMargin
+    assert(margin.isDefined)
+    // 94663000000 / 383285000000 ~ 0.2470
+    assert(Math.abs(margin.get - 0.2470) < 0.001)
+  }
+
+  test("ebitdaMargin should calculate correctly") {
+    val margin = sampleStatement.ebitdaMargin
+    assert(margin.isDefined)
+    // 124478000000 / 383285000000 ~ 0.3248
+    assert(Math.abs(margin.get - 0.3248) < 0.001)
+  }
+
+  test("effectiveTaxRate should calculate correctly") {
+    val rate = sampleStatement.effectiveTaxRate
+    assert(rate.isDefined)
+    // 18370000000 / 113033000000 ~ 0.1625
+    assert(Math.abs(rate.get - 0.1625) < 0.001)
+  }
+
+  test("grossMargin should return None when revenue is zero") {
+    val stmt = sampleStatement.copy(totalRevenue = Some(0.0))
+    assertEquals(stmt.grossMargin, None)
+  }
+
+  test("grossMargin should return None when grossProfit is missing") {
+    val stmt = sampleStatement.copy(grossProfit = None)
+    assertEquals(stmt.grossMargin, None)
+  }
+
+  test("grossMargin should return None when totalRevenue is missing") {
+    val stmt = sampleStatement.copy(totalRevenue = None)
+    assertEquals(stmt.grossMargin, None)
+  }
+
+  test("effectiveTaxRate should return None when pretaxIncome is zero") {
+    val stmt = sampleStatement.copy(pretaxIncome = Some(0.0))
+    assertEquals(stmt.effectiveTaxRate, None)
+  }
+
+  test("income statements should sort by date descending") {
+    val older = sampleStatement.copy(reportDate = LocalDate.of(2023, 9, 28))
+    val newer = sampleStatement.copy(reportDate = LocalDate.of(2024, 9, 28))
+    val sorted = List(older, newer).sorted
+    assertEquals(sorted.head.reportDate, LocalDate.of(2024, 9, 28))
+  }
+}


### PR DESCRIPTION
Implementing financial statements:

- Adding Frequency enum (Yearly, Quarterly, Trailing)
- Adding IncomeStatement model with derived metrics (margins, tax rate)
- Adding BalanceSheet model with derived metrics (ratios, per-share values)
- Adding CashFlowStatement model with derived metrics (FCF, cash flow ratios)
- Adding FinancialStatements container with cross-statement metrics (ROA, ROE)
- Extending YFinanceGateway with getFinancials using fundamentals-timeseries API
- Extending YFinanceClient with financial statement retrieval methods
- Adding Chimney library for type-safe case class transformations
- Adding unit tests for all financial statement models
- Adding integration tests for financial statements API