### PR TITLE
Adding analyst data API for prices, recommendations and earnings

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -310,6 +310,45 @@ final class YFinanceClient[F[_]: Monad] private (
   ): F[List[CashFlowStatement]] =
     gateway.getFinancials(ticker, frequency, "cash-flow").map(extractCashFlowStatements)
 
+  // --- Analyst Data ---
+
+  private def fetchAnalystData[A](ticker: Ticker)(extract: YFinanceAnalystResult => A): F[A] =
+    auth.getCredentials.flatMap { credentials =>
+      gateway.getAnalystData(ticker, credentials).map(extract)
+    }
+
+  /** Retrieves analyst consensus price targets for a ticker. */
+  def getAnalystPriceTargets(ticker: Ticker): F[Option[AnalystPriceTargets]] =
+    fetchAnalystData(ticker)(extractPriceTargets)
+
+  /** Retrieves analyst recommendation trends for a ticker. */
+  def getRecommendations(ticker: Ticker): F[List[RecommendationTrend]] =
+    fetchAnalystData(ticker)(extractRecommendations)
+
+  /** Retrieves analyst upgrade/downgrade history for a ticker. */
+  def getUpgradeDowngradeHistory(ticker: Ticker): F[List[UpgradeDowngrade]] =
+    fetchAnalystData(ticker)(extractUpgradeDowngrades)
+
+  /** Retrieves analyst earnings (EPS) estimates for a ticker. */
+  def getEarningsEstimates(ticker: Ticker): F[List[EarningsEstimate]] =
+    fetchAnalystData(ticker)(extractEarningsEstimates)
+
+  /** Retrieves analyst revenue estimates for a ticker. */
+  def getRevenueEstimates(ticker: Ticker): F[List[RevenueEstimate]] =
+    fetchAnalystData(ticker)(extractRevenueEstimates)
+
+  /** Retrieves historical earnings (actual vs. estimate) for a ticker. */
+  def getEarningsHistory(ticker: Ticker): F[List[EarningsHistory]] =
+    fetchAnalystData(ticker)(extractEarningsHistoryEntries)
+
+  /** Retrieves growth estimates with index comparison for a ticker. */
+  def getGrowthEstimates(ticker: Ticker): F[List[GrowthEstimates]] =
+    fetchAnalystData(ticker)(extractGrowthEstimates)
+
+  /** Retrieves comprehensive analyst data for a ticker. */
+  def getAnalystData(ticker: Ticker): F[Option[AnalystData]] =
+    fetchAnalystData(ticker)(mapToAnalystData)
+
   private def mapQueryResult(result: YFinanceQueryResult): Option[ChartResult] = {
     result.chart.result.headOption.map { data =>
       val quotes = data.timestamp.indices.map { i =>
@@ -684,6 +723,201 @@ final class YFinanceClient[F[_]: Monad] private (
         .withFieldRenamed(_.netPPEPurchaseAndSale, _.netPpePurchaseAndSale)
         .transform
     }.sorted
+
+  // --- Analyst Data Mapping ---
+
+  private def analystQuoteData(result: YFinanceAnalystResult): Option[AnalystQuoteData] =
+    result.quoteSummary.result.headOption
+
+  private def earningsTrendEntries(result: YFinanceAnalystResult): List[EarningsTrendEntryRaw] =
+    analystQuoteData(result).flatMap(_.earningsTrend).flatMap(_.trend).getOrElse(List.empty)
+
+  private def extractPriceTargets(result: YFinanceAnalystResult): Option[AnalystPriceTargets] =
+    analystQuoteData(result).flatMap(_.financialData).flatMap(mapPriceTargets)
+
+  private def extractRecommendations(result: YFinanceAnalystResult): List[RecommendationTrend] =
+    analystQuoteData(result)
+      .flatMap(_.recommendationTrend)
+      .flatMap(_.trend)
+      .getOrElse(List.empty)
+      .flatMap(mapRecommendationTrend)
+      .sorted
+
+  private def extractUpgradeDowngrades(result: YFinanceAnalystResult): List[UpgradeDowngrade] =
+    analystQuoteData(result)
+      .flatMap(_.upgradeDowngradeHistory)
+      .flatMap(_.history)
+      .getOrElse(List.empty)
+      .flatMap(mapUpgradeDowngrade)
+      .sorted
+
+  private def extractEarningsEstimates(result: YFinanceAnalystResult): List[EarningsEstimate] =
+    earningsTrendEntries(result).flatMap(mapEarningsEstimate).sorted
+
+  private def extractRevenueEstimates(result: YFinanceAnalystResult): List[RevenueEstimate] =
+    earningsTrendEntries(result).flatMap(mapRevenueEstimate).sorted
+
+  private def extractEpsTrends(result: YFinanceAnalystResult): List[EpsTrend] =
+    earningsTrendEntries(result).flatMap(mapEpsTrend).sorted
+
+  private def extractEpsRevisionsList(result: YFinanceAnalystResult): List[EpsRevisions] =
+    earningsTrendEntries(result).flatMap(mapEpsRevisions).sorted
+
+  private def extractEarningsHistoryEntries(result: YFinanceAnalystResult): List[EarningsHistory] =
+    analystQuoteData(result)
+      .flatMap(_.earningsHistory)
+      .flatMap(_.history)
+      .getOrElse(List.empty)
+      .flatMap(mapEarningsHistoryEntry)
+      .sorted
+
+  private def extractGrowthEstimates(result: YFinanceAnalystResult): List[GrowthEstimates] = {
+    val data = analystQuoteData(result)
+    val indexTrend = data.flatMap(_.indexTrend)
+    val indexSymbol = indexTrend.flatMap(_.symbol)
+    val indexGrowthByPeriod: Map[String, Double] = indexTrend
+      .flatMap(_.estimates)
+      .getOrElse(List.empty)
+      .flatMap(e => for { p <- e.period; g <- e.growth.map(_.raw) } yield p -> g)
+      .toMap
+
+    earningsTrendEntries(result).flatMap { entry =>
+      entry.period.map { period =>
+        GrowthEstimates(
+          period = period,
+          stockGrowth = entry.growth.map(_.raw),
+          indexGrowth = indexGrowthByPeriod.get(period),
+          indexSymbol = indexSymbol
+        )
+      }
+    }.sorted
+  }
+
+  private def mapToAnalystData(result: YFinanceAnalystResult): Option[AnalystData] =
+    analystQuoteData(result).map { _ =>
+      AnalystData(
+        priceTargets = extractPriceTargets(result),
+        recommendations = extractRecommendations(result),
+        upgradeDowngradeHistory = extractUpgradeDowngrades(result),
+        earningsEstimates = extractEarningsEstimates(result),
+        revenueEstimates = extractRevenueEstimates(result),
+        epsTrends = extractEpsTrends(result),
+        epsRevisions = extractEpsRevisionsList(result),
+        earningsHistory = extractEarningsHistoryEntries(result),
+        growthEstimates = extractGrowthEstimates(result)
+      )
+    }
+
+  private def mapPriceTargets(raw: AnalystFinancialDataRaw): Option[AnalystPriceTargets] =
+    for {
+      currentPrice <- raw.currentPrice.map(_.raw)
+      targetHigh <- raw.targetHighPrice.map(_.raw)
+      targetLow <- raw.targetLowPrice.map(_.raw)
+      targetMean <- raw.targetMeanPrice.map(_.raw)
+      targetMedian <- raw.targetMedianPrice.map(_.raw)
+      numAnalysts <- raw.numberOfAnalystOpinions.map(_.raw)
+      recKey <- raw.recommendationKey
+      recMean <- raw.recommendationMean.map(_.raw)
+    } yield AnalystPriceTargets(
+      currentPrice = currentPrice,
+      targetHigh = targetHigh,
+      targetLow = targetLow,
+      targetMean = targetMean,
+      targetMedian = targetMedian,
+      numberOfAnalysts = numAnalysts,
+      recommendationKey = recKey,
+      recommendationMean = recMean
+    )
+
+  private def mapRecommendationTrend(raw: RecommendationTrendEntryRaw): Option[RecommendationTrend] =
+    raw.period.map { period =>
+      RecommendationTrend(
+        period = period,
+        strongBuy = raw.strongBuy.getOrElse(0),
+        buy = raw.buy.getOrElse(0),
+        hold = raw.hold.getOrElse(0),
+        sell = raw.sell.getOrElse(0),
+        strongSell = raw.strongSell.getOrElse(0)
+      )
+    }
+
+  private def mapUpgradeDowngrade(raw: UpgradeDowngradeEntryRaw): Option[UpgradeDowngrade] =
+    for {
+      epochDate <- raw.epochGradeDate
+      firm <- raw.firm
+      toGrade <- raw.toGrade
+      action <- raw.action
+    } yield UpgradeDowngrade(
+      date = epochToLocalDate(epochDate),
+      firm = firm,
+      toGrade = toGrade,
+      fromGrade = raw.fromGrade.filter(_.nonEmpty),
+      action = UpgradeDowngradeAction.fromString(action)
+    )
+
+  private def mapEarningsEstimate(raw: EarningsTrendEntryRaw): Option[EarningsEstimate] =
+    raw.period.map { period =>
+      EarningsEstimate(
+        period = period,
+        endDate = raw.endDate,
+        avg = raw.earningsEstimate.flatMap(_.avg).map(_.raw),
+        low = raw.earningsEstimate.flatMap(_.low).map(_.raw),
+        high = raw.earningsEstimate.flatMap(_.high).map(_.raw),
+        yearAgoEps = raw.earningsEstimate.flatMap(_.yearAgoEps).map(_.raw),
+        numberOfAnalysts = raw.earningsEstimate.flatMap(_.numberOfAnalysts).map(_.raw),
+        growth = raw.earningsEstimate.flatMap(_.growth).map(_.raw)
+      )
+    }
+
+  private def mapRevenueEstimate(raw: EarningsTrendEntryRaw): Option[RevenueEstimate] =
+    raw.period.map { period =>
+      RevenueEstimate(
+        period = period,
+        endDate = raw.endDate,
+        avg = raw.revenueEstimate.flatMap(_.avg).map(_.raw),
+        low = raw.revenueEstimate.flatMap(_.low).map(_.raw),
+        high = raw.revenueEstimate.flatMap(_.high).map(_.raw),
+        numberOfAnalysts = raw.revenueEstimate.flatMap(_.numberOfAnalysts).map(_.raw),
+        yearAgoRevenue = raw.revenueEstimate.flatMap(_.yearAgoRevenue).map(_.raw),
+        growth = raw.revenueEstimate.flatMap(_.growth).map(_.raw)
+      )
+    }
+
+  private def mapEpsTrend(raw: EarningsTrendEntryRaw): Option[EpsTrend] =
+    raw.period.map { period =>
+      EpsTrend(
+        period = period,
+        current = raw.epsTrend.flatMap(_.current).map(_.raw),
+        sevenDaysAgo = raw.epsTrend.flatMap(_.sevenDaysAgo).map(_.raw),
+        thirtyDaysAgo = raw.epsTrend.flatMap(_.thirtyDaysAgo).map(_.raw),
+        sixtyDaysAgo = raw.epsTrend.flatMap(_.sixtyDaysAgo).map(_.raw),
+        ninetyDaysAgo = raw.epsTrend.flatMap(_.ninetyDaysAgo).map(_.raw)
+      )
+    }
+
+  private def mapEpsRevisions(raw: EarningsTrendEntryRaw): Option[EpsRevisions] =
+    raw.period.map { period =>
+      EpsRevisions(
+        period = period,
+        upLast7Days = raw.epsRevisions.flatMap(_.upLast7days).map(_.raw),
+        upLast30Days = raw.epsRevisions.flatMap(_.upLast30days).map(_.raw),
+        downLast30Days = raw.epsRevisions.flatMap(_.downLast30days).map(_.raw),
+        downLast90Days = raw.epsRevisions.flatMap(_.downLast90days).map(_.raw)
+      )
+    }
+
+  private def mapEarningsHistoryEntry(raw: EarningsHistoryEntryRaw): Option[EarningsHistory] =
+    for {
+      quarter <- raw.quarter.map(v => epochToLocalDate(v.raw))
+      period <- raw.period
+    } yield EarningsHistory(
+      quarter = quarter,
+      period = period,
+      epsActual = raw.epsActual.map(_.raw),
+      epsEstimate = raw.epsEstimate.map(_.raw),
+      epsDifference = raw.epsDifference.map(_.raw),
+      surprisePercent = raw.surprisePercent.map(_.raw)
+    )
 
 }
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/AnalystData.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/AnalystData.scala
@@ -1,0 +1,100 @@
+package org.coinductive.yfinance4s.models
+
+/** Comprehensive analyst data for a security.
+  *
+  * @param priceTargets
+  *   Analyst consensus price targets and recommendation
+  * @param recommendations
+  *   Recommendation trends by period (buy/hold/sell counts)
+  * @param upgradeDowngradeHistory
+  *   Historical analyst upgrades, downgrades, and initiations
+  * @param earningsEstimates
+  *   Analyst earnings (EPS) estimates by period
+  * @param revenueEstimates
+  *   Analyst revenue estimates by period
+  * @param epsTrends
+  *   EPS consensus trend over time by period
+  * @param epsRevisions
+  *   EPS revision counts by period
+  * @param earningsHistory
+  *   Historical EPS actual vs. estimate
+  * @param growthEstimates
+  *   Growth estimates with index comparison
+  */
+final case class AnalystData(
+    priceTargets: Option[AnalystPriceTargets],
+    recommendations: List[RecommendationTrend],
+    upgradeDowngradeHistory: List[UpgradeDowngrade],
+    earningsEstimates: List[EarningsEstimate],
+    revenueEstimates: List[RevenueEstimate],
+    epsTrends: List[EpsTrend],
+    epsRevisions: List[EpsRevisions],
+    earningsHistory: List[EarningsHistory],
+    growthEstimates: List[GrowthEstimates]
+) {
+
+  /** True if any analyst data is available. */
+  def nonEmpty: Boolean =
+    priceTargets.isDefined ||
+      recommendations.nonEmpty ||
+      upgradeDowngradeHistory.nonEmpty ||
+      earningsEstimates.nonEmpty ||
+      revenueEstimates.nonEmpty ||
+      earningsHistory.nonEmpty ||
+      growthEstimates.nonEmpty
+
+  /** True if no analyst data is available. */
+  def isEmpty: Boolean = !nonEmpty
+
+  /** The current month's recommendation trend (period "0m"), if available. */
+  def currentRecommendation: Option[RecommendationTrend] =
+    recommendations.find(_.period == "0m")
+
+  /** The current quarter's earnings estimate (period "0q"), if available. */
+  def currentQuarterEarningsEstimate: Option[EarningsEstimate] =
+    earningsEstimates.find(_.period == "0q")
+
+  /** The current quarter's revenue estimate (period "0q"), if available. */
+  def currentQuarterRevenueEstimate: Option[RevenueEstimate] =
+    revenueEstimates.find(_.period == "0q")
+
+  /** The current year's earnings estimate (period "0y"), if available. */
+  def currentYearEarningsEstimate: Option[EarningsEstimate] =
+    earningsEstimates.find(_.period == "0y")
+
+  /** The number of consecutive quarters where earnings beat estimates. */
+  def consecutiveBeats: Int =
+    earningsHistory.sorted.takeWhile(_.isBeat.getOrElse(false)).size
+
+  /** Recent upgrades (last N entries that are upgrades). */
+  def recentUpgrades(limit: Int = 5): List[UpgradeDowngrade] =
+    upgradeDowngradeHistory.sorted.filter(_.isUpgrade).take(limit)
+
+  /** Recent downgrades (last N entries that are downgrades). */
+  def recentDowngrades(limit: Int = 5): List[UpgradeDowngrade] =
+    upgradeDowngradeHistory.sorted.filter(_.isDowngrade).take(limit)
+
+  /** Earnings beat rate over available history (percentage of quarters that beat). */
+  def earningsBeatRate: Option[Double] = {
+    val beats = earningsHistory.flatMap(_.isBeat)
+    if (beats.nonEmpty)
+      Some(beats.count(identity).toDouble / beats.size * 100.0)
+    else None
+  }
+}
+
+object AnalystData {
+
+  /** Empty analyst data. */
+  val empty: AnalystData = AnalystData(
+    priceTargets = None,
+    recommendations = List.empty,
+    upgradeDowngradeHistory = List.empty,
+    earningsEstimates = List.empty,
+    revenueEstimates = List.empty,
+    epsTrends = List.empty,
+    epsRevisions = List.empty,
+    earningsHistory = List.empty,
+    growthEstimates = List.empty
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/AnalystPriceTargets.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/AnalystPriceTargets.scala
@@ -1,0 +1,59 @@
+package org.coinductive.yfinance4s.models
+
+/** Analyst consensus price targets for a security.
+  *
+  * @param currentPrice
+  *   The current market price of the security
+  * @param targetHigh
+  *   The highest analyst price target
+  * @param targetLow
+  *   The lowest analyst price target
+  * @param targetMean
+  *   The mean (average) analyst price target
+  * @param targetMedian
+  *   The median analyst price target
+  * @param numberOfAnalysts
+  *   The number of analysts providing price targets
+  * @param recommendationKey
+  *   Consensus recommendation as a string (e.g., "buy", "hold", "sell", "strong_buy", "underperform")
+  * @param recommendationMean
+  *   Consensus recommendation on a 1-5 scale (1 = Strong Buy, 5 = Strong Sell)
+  */
+final case class AnalystPriceTargets(
+    currentPrice: Double,
+    targetHigh: Double,
+    targetLow: Double,
+    targetMean: Double,
+    targetMedian: Double,
+    numberOfAnalysts: Int,
+    recommendationKey: String,
+    recommendationMean: Double
+) {
+
+  /** The potential upside from the mean target, as a percentage. Positive values indicate upside, negative values
+    * indicate downside.
+    */
+  def meanUpsidePercent: Double =
+    if (currentPrice > 0) ((targetMean - currentPrice) / currentPrice) * 100.0
+    else 0.0
+
+  /** The potential upside from the median target, as a percentage. */
+  def medianUpsidePercent: Double =
+    if (currentPrice > 0) ((targetMedian - currentPrice) / currentPrice) * 100.0
+    else 0.0
+
+  /** The range of analyst targets (high - low). */
+  def targetRange: Double = targetHigh - targetLow
+
+  /** The spread of analyst targets as a percentage of the mean target. Lower values indicate higher analyst consensus.
+    */
+  def targetSpreadPercent: Double =
+    if (targetMean > 0) (targetRange / targetMean) * 100.0
+    else 0.0
+
+  /** Whether the current price is below all analyst targets. */
+  def isBelowAllTargets: Boolean = currentPrice < targetLow
+
+  /** Whether the current price is above all analyst targets. */
+  def isAboveAllTargets: Boolean = currentPrice > targetHigh
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsEstimate.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsEstimate.scala
@@ -1,0 +1,59 @@
+package org.coinductive.yfinance4s.models
+
+/** Analyst earnings (EPS) estimates for a specific period.
+  *
+  * @param period
+  *   The estimate period (e.g., "0q" = current quarter, "+1q" = next quarter, "0y" = current year, "+1y" = next year)
+  * @param endDate
+  *   The end date of the period (e.g., "2024-06-30"), if available
+  * @param avg
+  *   Average analyst EPS estimate
+  * @param low
+  *   Lowest analyst EPS estimate
+  * @param high
+  *   Highest analyst EPS estimate
+  * @param yearAgoEps
+  *   EPS from the same period one year ago
+  * @param numberOfAnalysts
+  *   Number of analysts providing estimates
+  * @param growth
+  *   Expected EPS growth rate vs. year-ago period
+  */
+final case class EarningsEstimate(
+    period: String,
+    endDate: Option[String],
+    avg: Option[Double],
+    low: Option[Double],
+    high: Option[Double],
+    yearAgoEps: Option[Double],
+    numberOfAnalysts: Option[Int],
+    growth: Option[Double]
+) {
+
+  /** The range of analyst EPS estimates (high - low). */
+  def estimateRange: Option[Double] =
+    for {
+      h <- high
+      l <- low
+    } yield h - l
+
+  /** The spread of estimates as a percentage of the average. Lower values indicate higher analyst consensus. */
+  def estimateSpreadPercent: Option[Double] =
+    for {
+      range <- estimateRange
+      a <- avg
+      if a != 0
+    } yield (range / Math.abs(a)) * 100.0
+
+  /** Whether this is a quarterly estimate period ("0q", "+1q", etc.) */
+  def isQuarterly: Boolean = period.endsWith("q")
+
+  /** Whether this is a yearly estimate period ("0y", "+1y", etc.) */
+  def isYearly: Boolean = period.endsWith("y")
+}
+
+object EarningsEstimate {
+
+  /** Ordering by period: current periods first. */
+  implicit val ordering: Ordering[EarningsEstimate] = Ordering.by(_.period)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsHistory.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsHistory.scala
@@ -1,0 +1,49 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+/** Historical earnings result for a single quarter.
+  *
+  * Compares actual reported EPS against analyst estimates for a past quarter.
+  *
+  * @param quarter
+  *   The fiscal quarter end date
+  * @param period
+  *   The period identifier (e.g., "-4q", "-3q", "-2q", "-1q")
+  * @param epsActual
+  *   The actual reported EPS
+  * @param epsEstimate
+  *   The consensus analyst EPS estimate before the earnings report
+  * @param epsDifference
+  *   The difference between actual and estimate (actual - estimate)
+  * @param surprisePercent
+  *   The earnings surprise as a percentage of the estimate
+  */
+final case class EarningsHistory(
+    quarter: LocalDate,
+    period: String,
+    epsActual: Option[Double],
+    epsEstimate: Option[Double],
+    epsDifference: Option[Double],
+    surprisePercent: Option[Double]
+) {
+
+  /** Whether earnings beat the analyst estimate. */
+  def isBeat: Option[Boolean] =
+    epsDifference.map(_ > 0)
+
+  /** Whether earnings missed the analyst estimate. */
+  def isMiss: Option[Boolean] =
+    epsDifference.map(_ < 0)
+
+  /** Whether earnings exactly met the analyst estimate. */
+  def isMet: Option[Boolean] =
+    epsDifference.map(_ == 0)
+}
+
+object EarningsHistory {
+
+  /** Ordering by quarter date, most recent first. */
+  implicit val ordering: Ordering[EarningsHistory] =
+    Ordering.by[EarningsHistory, LocalDate](_.quarter).reverse
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EpsRevisions.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EpsRevisions.scala
@@ -1,0 +1,42 @@
+package org.coinductive.yfinance4s.models
+
+/** EPS estimate revision counts for a specific period.
+  *
+  * Tracks how many analysts have revised their estimates up or down.
+  *
+  * @param period
+  *   The estimate period (e.g., "0q", "+1q", "0y", "+1y")
+  * @param upLast7Days
+  *   Number of upward revisions in the last 7 days
+  * @param upLast30Days
+  *   Number of upward revisions in the last 30 days
+  * @param downLast30Days
+  *   Number of downward revisions in the last 30 days
+  * @param downLast90Days
+  *   Number of downward revisions in the last 90 days
+  */
+final case class EpsRevisions(
+    period: String,
+    upLast7Days: Option[Int],
+    upLast30Days: Option[Int],
+    downLast30Days: Option[Int],
+    downLast90Days: Option[Int]
+) {
+
+  /** Net revisions in the last 30 days (positive = more ups than downs). */
+  def netRevisions30Days: Option[Int] =
+    for {
+      up <- upLast30Days
+      down <- downLast30Days
+    } yield up - down
+
+  /** Whether the revision trend is positive (more ups than downs in last 30 days). */
+  def isPositiveTrend: Option[Boolean] =
+    netRevisions30Days.map(_ > 0)
+}
+
+object EpsRevisions {
+
+  /** Ordering by period: current periods first. */
+  implicit val ordering: Ordering[EpsRevisions] = Ordering.by(_.period)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EpsTrend.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EpsTrend.scala
@@ -1,0 +1,59 @@
+package org.coinductive.yfinance4s.models
+
+/** EPS consensus estimate trend over recent time windows.
+  *
+  * Shows how the consensus EPS estimate has changed over the past 90 days.
+  *
+  * @param period
+  *   The estimate period (e.g., "0q", "+1q", "0y", "+1y")
+  * @param current
+  *   Current consensus EPS estimate
+  * @param sevenDaysAgo
+  *   Consensus EPS estimate 7 days ago
+  * @param thirtyDaysAgo
+  *   Consensus EPS estimate 30 days ago
+  * @param sixtyDaysAgo
+  *   Consensus EPS estimate 60 days ago
+  * @param ninetyDaysAgo
+  *   Consensus EPS estimate 90 days ago
+  */
+final case class EpsTrend(
+    period: String,
+    current: Option[Double],
+    sevenDaysAgo: Option[Double],
+    thirtyDaysAgo: Option[Double],
+    sixtyDaysAgo: Option[Double],
+    ninetyDaysAgo: Option[Double]
+) {
+
+  /** The change in consensus EPS over the last 7 days. */
+  def changeSevenDays: Option[Double] =
+    for {
+      c <- current
+      s <- sevenDaysAgo
+    } yield c - s
+
+  /** The change in consensus EPS over the last 30 days. */
+  def changeThirtyDays: Option[Double] =
+    for {
+      c <- current
+      t <- thirtyDaysAgo
+    } yield c - t
+
+  /** The change in consensus EPS over the last 90 days. */
+  def changeNinetyDays: Option[Double] =
+    for {
+      c <- current
+      n <- ninetyDaysAgo
+    } yield c - n
+
+  /** Whether the consensus EPS has been trending upward over 30 days. */
+  def isTrendingUp: Option[Boolean] =
+    changeThirtyDays.map(_ > 0)
+}
+
+object EpsTrend {
+
+  /** Ordering by period: current periods first. */
+  implicit val ordering: Ordering[EpsTrend] = Ordering.by(_.period)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/GrowthEstimates.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/GrowthEstimates.scala
@@ -1,0 +1,40 @@
+package org.coinductive.yfinance4s.models
+
+/** Growth estimates for the stock compared against the index benchmark.
+  *
+  * @param period
+  *   The estimate period (e.g., "0q", "+1q", "0y", "+1y")
+  * @param stockGrowth
+  *   The estimated earnings growth for the stock
+  * @param indexGrowth
+  *   The estimated earnings growth for the benchmark index (e.g., S&P 500)
+  * @param indexSymbol
+  *   The benchmark index symbol (e.g., "SP5" for S&P 500)
+  */
+final case class GrowthEstimates(
+    period: String,
+    stockGrowth: Option[Double],
+    indexGrowth: Option[Double],
+    indexSymbol: Option[String]
+) {
+
+  /** Whether the stock is expected to outgrow the index. */
+  def isOutperforming: Option[Boolean] =
+    for {
+      sg <- stockGrowth
+      ig <- indexGrowth
+    } yield sg > ig
+
+  /** The growth differential (stock growth - index growth). */
+  def growthDifferential: Option[Double] =
+    for {
+      sg <- stockGrowth
+      ig <- indexGrowth
+    } yield sg - ig
+}
+
+object GrowthEstimates {
+
+  /** Ordering by period: current periods first. */
+  implicit val ordering: Ordering[GrowthEstimates] = Ordering.by(_.period)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/RecommendationTrend.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/RecommendationTrend.scala
@@ -1,0 +1,61 @@
+package org.coinductive.yfinance4s.models
+
+/** Analyst recommendation summary for a given period.
+  *
+  * @param period
+  *   The time period (e.g., "0m" for current month, "-1m" for last month)
+  * @param strongBuy
+  *   Number of analysts with a "Strong Buy" recommendation
+  * @param buy
+  *   Number of analysts with a "Buy" recommendation
+  * @param hold
+  *   Number of analysts with a "Hold" recommendation
+  * @param sell
+  *   Number of analysts with a "Sell" recommendation
+  * @param strongSell
+  *   Number of analysts with a "Strong Sell" recommendation
+  */
+final case class RecommendationTrend(
+    period: String,
+    strongBuy: Int,
+    buy: Int,
+    hold: Int,
+    sell: Int,
+    strongSell: Int
+) {
+
+  /** Total number of analyst recommendations in this period. */
+  def totalAnalysts: Int = strongBuy + buy + hold + sell + strongSell
+
+  /** Total bullish recommendations (strong buy + buy). */
+  def totalBullish: Int = strongBuy + buy
+
+  /** Total bearish recommendations (sell + strong sell). */
+  def totalBearish: Int = sell + strongSell
+
+  /** Bullish percentage of total recommendations. Returns 0 if no analysts. */
+  def bullishPercent: Double =
+    if (totalAnalysts > 0) totalBullish.toDouble / totalAnalysts * 100.0
+    else 0.0
+
+  /** Bearish percentage of total recommendations. Returns 0 if no analysts. */
+  def bearishPercent: Double =
+    if (totalAnalysts > 0) totalBearish.toDouble / totalAnalysts * 100.0
+    else 0.0
+
+  /** Net sentiment: positive means more bulls, negative means more bears. */
+  def netSentiment: Int = totalBullish - totalBearish
+
+  /** Whether the consensus is predominantly bullish (>50% buy/strong buy). */
+  def isBullish: Boolean = bullishPercent > 50.0
+}
+
+object RecommendationTrend {
+
+  /** Ordering by period: current month first ("0m" < "-1m" < "-2m" < "-3m"). */
+  implicit val ordering: Ordering[RecommendationTrend] =
+    Ordering.by[RecommendationTrend, Int](parsePeriodMonths).reverse
+
+  private def parsePeriodMonths(r: RecommendationTrend): Int =
+    r.period.stripSuffix("m").toIntOption.getOrElse(Int.MinValue)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/RevenueEstimate.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/RevenueEstimate.scala
@@ -1,0 +1,51 @@
+package org.coinductive.yfinance4s.models
+
+/** Analyst revenue estimates for a specific period.
+  *
+  * @param period
+  *   The estimate period (e.g., "0q", "+1q", "0y", "+1y")
+  * @param endDate
+  *   The end date of the period, if available
+  * @param avg
+  *   Average analyst revenue estimate (in currency units)
+  * @param low
+  *   Lowest analyst revenue estimate
+  * @param high
+  *   Highest analyst revenue estimate
+  * @param numberOfAnalysts
+  *   Number of analysts providing estimates
+  * @param yearAgoRevenue
+  *   Revenue from the same period one year ago
+  * @param growth
+  *   Expected revenue growth rate vs. year-ago period
+  */
+final case class RevenueEstimate(
+    period: String,
+    endDate: Option[String],
+    avg: Option[Long],
+    low: Option[Long],
+    high: Option[Long],
+    numberOfAnalysts: Option[Int],
+    yearAgoRevenue: Option[Long],
+    growth: Option[Double]
+) {
+
+  /** The range of analyst revenue estimates (high - low). */
+  def estimateRange: Option[Long] =
+    for {
+      h <- high
+      l <- low
+    } yield h - l
+
+  /** Whether this is a quarterly estimate period. */
+  def isQuarterly: Boolean = period.endsWith("q")
+
+  /** Whether this is a yearly estimate period. */
+  def isYearly: Boolean = period.endsWith("y")
+}
+
+object RevenueEstimate {
+
+  /** Ordering by period: current periods first. */
+  implicit val ordering: Ordering[RevenueEstimate] = Ordering.by(_.period)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/UpgradeDowngrade.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/UpgradeDowngrade.scala
@@ -1,0 +1,68 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.LocalDate
+
+/** Represents an analyst upgrade, downgrade, or initiation event.
+  *
+  * @param date
+  *   The date of the grade change
+  * @param firm
+  *   The name of the analyst firm (e.g., "Morgan Stanley", "Goldman Sachs")
+  * @param toGrade
+  *   The new grade assigned (e.g., "Overweight", "Buy", "Neutral")
+  * @param fromGrade
+  *   The previous grade, if applicable (None for initiations)
+  * @param action
+  *   The type of action taken
+  */
+final case class UpgradeDowngrade(
+    date: LocalDate,
+    firm: String,
+    toGrade: String,
+    fromGrade: Option[String],
+    action: UpgradeDowngradeAction
+) {
+
+  /** Whether this is a positive action (upgrade). */
+  def isUpgrade: Boolean = action == UpgradeDowngradeAction.Upgrade
+
+  /** Whether this is a negative action (downgrade). */
+  def isDowngrade: Boolean = action == UpgradeDowngradeAction.Downgrade
+
+  /** Whether this is a new coverage initiation. */
+  def isInitiation: Boolean = action == UpgradeDowngradeAction.Initiation
+
+  /** Whether this is a maintained/reiterated rating. */
+  def isMaintained: Boolean =
+    action == UpgradeDowngradeAction.Maintained || action == UpgradeDowngradeAction.Reiterated
+}
+
+object UpgradeDowngrade {
+
+  /** Ordering by date, most recent first. */
+  implicit val ordering: Ordering[UpgradeDowngrade] =
+    Ordering.by[UpgradeDowngrade, LocalDate](_.date).reverse
+}
+
+/** The type of analyst action. */
+sealed trait UpgradeDowngradeAction {
+  def value: String
+}
+
+object UpgradeDowngradeAction {
+  case object Upgrade extends UpgradeDowngradeAction { val value = "up" }
+  case object Downgrade extends UpgradeDowngradeAction { val value = "down" }
+  case object Maintained extends UpgradeDowngradeAction { val value = "main" }
+  case object Reiterated extends UpgradeDowngradeAction { val value = "reit" }
+  case object Initiation extends UpgradeDowngradeAction { val value = "init" }
+  final case class Other(value: String) extends UpgradeDowngradeAction
+
+  def fromString(s: String): UpgradeDowngradeAction = s.toLowerCase match {
+    case "up"   => Upgrade
+    case "down" => Downgrade
+    case "main" => Maintained
+    case "reit" => Reiterated
+    case "init" => Initiation
+    case other  => Other(other)
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceAnalystResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceAnalystResult.scala
@@ -1,0 +1,229 @@
+package org.coinductive.yfinance4s.models
+
+import io.circe.{Decoder, HCursor}
+import io.circe.generic.semiauto.deriveDecoder
+import org.coinductive.yfinance4s.models.YFinanceQuoteResult.Value
+
+// --- Top-level result wrapper ---
+
+private[yfinance4s] final case class YFinanceAnalystResult(
+    quoteSummary: AnalystQuoteSummary
+)
+
+private[yfinance4s] object YFinanceAnalystResult {
+  implicit val decoder: Decoder[YFinanceAnalystResult] = deriveDecoder
+}
+
+private[yfinance4s] final case class AnalystQuoteSummary(
+    result: List[AnalystQuoteData],
+    error: Option[String]
+)
+
+private[yfinance4s] object AnalystQuoteSummary {
+  implicit val decoder: Decoder[AnalystQuoteSummary] = deriveDecoder
+}
+
+private[yfinance4s] final case class AnalystQuoteData(
+    financialData: Option[AnalystFinancialDataRaw],
+    recommendationTrend: Option[RecommendationTrendRaw],
+    upgradeDowngradeHistory: Option[UpgradeDowngradeHistoryRaw],
+    earningsTrend: Option[EarningsTrendRaw],
+    earningsHistory: Option[EarningsHistoryContainerRaw],
+    indexTrend: Option[IndexTrendRaw]
+)
+
+private[yfinance4s] object AnalystQuoteData {
+  implicit val decoder: Decoder[AnalystQuoteData] = deriveDecoder
+}
+
+// --- financialData (price targets subset) ---
+
+private[yfinance4s] final case class AnalystFinancialDataRaw(
+    targetHighPrice: Option[Value[Double]],
+    targetLowPrice: Option[Value[Double]],
+    targetMeanPrice: Option[Value[Double]],
+    targetMedianPrice: Option[Value[Double]],
+    currentPrice: Option[Value[Double]],
+    numberOfAnalystOpinions: Option[Value[Int]],
+    recommendationKey: Option[String],
+    recommendationMean: Option[Value[Double]]
+)
+
+private[yfinance4s] object AnalystFinancialDataRaw {
+  implicit val decoder: Decoder[AnalystFinancialDataRaw] = deriveDecoder
+}
+
+// --- recommendationTrend ---
+
+private[yfinance4s] final case class RecommendationTrendRaw(
+    trend: Option[List[RecommendationTrendEntryRaw]]
+)
+
+private[yfinance4s] object RecommendationTrendRaw {
+  implicit val decoder: Decoder[RecommendationTrendRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class RecommendationTrendEntryRaw(
+    period: Option[String],
+    strongBuy: Option[Int],
+    buy: Option[Int],
+    hold: Option[Int],
+    sell: Option[Int],
+    strongSell: Option[Int]
+)
+
+private[yfinance4s] object RecommendationTrendEntryRaw {
+  implicit val decoder: Decoder[RecommendationTrendEntryRaw] = deriveDecoder
+}
+
+// --- upgradeDowngradeHistory ---
+
+private[yfinance4s] final case class UpgradeDowngradeHistoryRaw(
+    history: Option[List[UpgradeDowngradeEntryRaw]]
+)
+
+private[yfinance4s] object UpgradeDowngradeHistoryRaw {
+  implicit val decoder: Decoder[UpgradeDowngradeHistoryRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class UpgradeDowngradeEntryRaw(
+    epochGradeDate: Option[Long],
+    firm: Option[String],
+    toGrade: Option[String],
+    fromGrade: Option[String],
+    action: Option[String]
+)
+
+private[yfinance4s] object UpgradeDowngradeEntryRaw {
+  implicit val decoder: Decoder[UpgradeDowngradeEntryRaw] = deriveDecoder
+}
+
+// --- earningsTrend ---
+
+private[yfinance4s] final case class EarningsTrendRaw(
+    trend: Option[List[EarningsTrendEntryRaw]]
+)
+
+private[yfinance4s] object EarningsTrendRaw {
+  implicit val decoder: Decoder[EarningsTrendRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class EarningsTrendEntryRaw(
+    period: Option[String],
+    endDate: Option[String],
+    growth: Option[Value[Double]],
+    earningsEstimate: Option[EarningsEstimateRaw],
+    revenueEstimate: Option[RevenueEstimateRaw],
+    epsTrend: Option[EpsTrendRaw],
+    epsRevisions: Option[EpsRevisionsRaw]
+)
+
+private[yfinance4s] object EarningsTrendEntryRaw {
+  implicit val decoder: Decoder[EarningsTrendEntryRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class EarningsEstimateRaw(
+    avg: Option[Value[Double]],
+    low: Option[Value[Double]],
+    high: Option[Value[Double]],
+    yearAgoEps: Option[Value[Double]],
+    numberOfAnalysts: Option[Value[Int]],
+    growth: Option[Value[Double]]
+)
+
+private[yfinance4s] object EarningsEstimateRaw {
+  implicit val decoder: Decoder[EarningsEstimateRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class RevenueEstimateRaw(
+    avg: Option[Value[Long]],
+    low: Option[Value[Long]],
+    high: Option[Value[Long]],
+    numberOfAnalysts: Option[Value[Int]],
+    yearAgoRevenue: Option[Value[Long]],
+    growth: Option[Value[Double]]
+)
+
+private[yfinance4s] object RevenueEstimateRaw {
+  implicit val decoder: Decoder[RevenueEstimateRaw] = deriveDecoder
+}
+
+// Custom decoder needed: "7daysAgo" etc. are not valid Scala identifiers
+private[yfinance4s] final case class EpsTrendRaw(
+    current: Option[Value[Double]],
+    sevenDaysAgo: Option[Value[Double]],
+    thirtyDaysAgo: Option[Value[Double]],
+    sixtyDaysAgo: Option[Value[Double]],
+    ninetyDaysAgo: Option[Value[Double]]
+)
+
+private[yfinance4s] object EpsTrendRaw {
+  implicit val decoder: Decoder[EpsTrendRaw] = (c: HCursor) =>
+    for {
+      current <- c.downField("current").as[Option[Value[Double]]]
+      sevenDaysAgo <- c.downField("7daysAgo").as[Option[Value[Double]]]
+      thirtyDaysAgo <- c.downField("30daysAgo").as[Option[Value[Double]]]
+      sixtyDaysAgo <- c.downField("60daysAgo").as[Option[Value[Double]]]
+      ninetyDaysAgo <- c.downField("90daysAgo").as[Option[Value[Double]]]
+    } yield EpsTrendRaw(current, sevenDaysAgo, thirtyDaysAgo, sixtyDaysAgo, ninetyDaysAgo)
+}
+
+private[yfinance4s] final case class EpsRevisionsRaw(
+    upLast7days: Option[Value[Int]],
+    upLast30days: Option[Value[Int]],
+    downLast30days: Option[Value[Int]],
+    downLast90days: Option[Value[Int]]
+)
+
+private[yfinance4s] object EpsRevisionsRaw {
+  implicit val decoder: Decoder[EpsRevisionsRaw] = (c: HCursor) =>
+    for {
+      up7 <- c.downField("upLast7days").as[Option[Value[Int]]].orElse(Right(None))
+      up30 <- c.downField("upLast30days").as[Option[Value[Int]]].orElse(Right(None))
+      down30 <- c.downField("downLast30days").as[Option[Value[Int]]].orElse(Right(None))
+      down90 <- c.downField("downLast90days").as[Option[Value[Int]]].orElse(Right(None))
+    } yield EpsRevisionsRaw(up7, up30, down30, down90)
+}
+
+// --- earningsHistory ---
+
+private[yfinance4s] final case class EarningsHistoryContainerRaw(
+    history: Option[List[EarningsHistoryEntryRaw]]
+)
+
+private[yfinance4s] object EarningsHistoryContainerRaw {
+  implicit val decoder: Decoder[EarningsHistoryContainerRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class EarningsHistoryEntryRaw(
+    epsActual: Option[Value[Double]],
+    epsEstimate: Option[Value[Double]],
+    epsDifference: Option[Value[Double]],
+    surprisePercent: Option[Value[Double]],
+    quarter: Option[Value[Long]],
+    period: Option[String]
+)
+
+private[yfinance4s] object EarningsHistoryEntryRaw {
+  implicit val decoder: Decoder[EarningsHistoryEntryRaw] = deriveDecoder
+}
+
+// --- indexTrend ---
+
+private[yfinance4s] final case class IndexTrendRaw(
+    symbol: Option[String],
+    estimates: Option[List[IndexTrendEstimateRaw]]
+)
+
+private[yfinance4s] object IndexTrendRaw {
+  implicit val decoder: Decoder[IndexTrendRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class IndexTrendEstimateRaw(
+    period: Option[String],
+    growth: Option[Value[Double]]
+)
+
+private[yfinance4s] object IndexTrendEstimateRaw {
+  implicit val decoder: Decoder[IndexTrendEstimateRaw] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/AnalystDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/AnalystDataSpec.scala
@@ -1,0 +1,154 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.Ticker
+
+import scala.concurrent.duration.*
+
+class AnalystDataSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  test("getAnalystPriceTargets should return targets for AAPL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getAnalystPriceTargets(Ticker("AAPL")).map { result =>
+        assert(result.isDefined, "Result should be defined for AAPL")
+        val targets = result.get
+
+        assert(targets.currentPrice > 0, s"Current price should be positive: ${targets.currentPrice}")
+        assert(targets.targetHigh > targets.targetLow, "Target high should exceed target low")
+        assert(
+          targets.targetMean >= targets.targetLow && targets.targetMean <= targets.targetHigh,
+          s"Target mean ${targets.targetMean} should be between low ${targets.targetLow} and high ${targets.targetHigh}"
+        )
+        assert(targets.numberOfAnalysts > 0, s"Should have analyst coverage: ${targets.numberOfAnalysts}")
+        assert(targets.recommendationKey.nonEmpty, "Recommendation key should not be empty")
+      }
+    }
+  }
+
+  test("getRecommendations should return trends for MSFT") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getRecommendations(Ticker("MSFT")).map { recommendations =>
+        assert(recommendations.nonEmpty, "MSFT should have recommendation trends")
+
+        // Should have a current month entry
+        val current = recommendations.find(_.period == "0m")
+        assert(current.isDefined, "Should have a current month (0m) entry")
+        assert(current.get.totalAnalysts > 0, s"Current month should have analysts: ${current.get.totalAnalysts}")
+
+        // Should be sorted with current month first
+        assertEquals(recommendations.head.period, "0m")
+      }
+    }
+  }
+
+  test("getUpgradeDowngradeHistory should return history for GOOGL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getUpgradeDowngradeHistory(Ticker("GOOGL")).map { history =>
+        assert(history.nonEmpty, "GOOGL should have upgrade/downgrade history")
+
+        // Validate structure
+        history.foreach { entry =>
+          assert(entry.firm.nonEmpty, "Firm name should not be empty")
+          assert(entry.toGrade.nonEmpty, "To grade should not be empty")
+        }
+
+        // Results should be sorted by date descending
+        val dates = history.map(_.date)
+        assert(dates == dates.sorted.reverse, "History should be sorted by date descending")
+      }
+    }
+  }
+
+  test("getEarningsEstimates should return estimates for NVDA") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getEarningsEstimates(Ticker("NVDA")).map { estimates =>
+        assert(estimates.nonEmpty, "NVDA should have earnings estimates")
+
+        // Should have both quarterly and yearly estimates
+        assert(estimates.exists(_.isQuarterly), "Should have quarterly estimates")
+        assert(estimates.exists(_.isYearly), "Should have yearly estimates")
+
+        // Well-covered stock should have analyst count
+        estimates.foreach { est =>
+          est.numberOfAnalysts.foreach { n =>
+            assert(n > 0, s"Number of analysts should be positive: $n")
+          }
+        }
+      }
+    }
+  }
+
+  test("getRevenueEstimates should return estimates for AMZN") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getRevenueEstimates(Ticker("AMZN")).map { estimates =>
+        assert(estimates.nonEmpty, "AMZN should have revenue estimates")
+
+        // Large company should have positive revenue estimates
+        estimates.foreach { est =>
+          est.avg.foreach { avg =>
+            assert(avg > 0, s"Average revenue should be positive: $avg")
+          }
+        }
+      }
+    }
+  }
+
+  test("getEarningsHistory should return historical results for AAPL") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getEarningsHistory(Ticker("AAPL")).map { history =>
+        assert(history.nonEmpty, "AAPL should have earnings history")
+
+        // Validate structure
+        history.foreach { entry =>
+          assert(entry.epsActual.isDefined, "EPS actual should be defined for AAPL")
+        }
+
+        // Should be sorted by quarter descending
+        val quarters = history.map(_.quarter)
+        assert(quarters == quarters.sorted.reverse, "History should be sorted by quarter descending")
+      }
+    }
+  }
+
+  test("getGrowthEstimates should return growth data for MSFT") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getGrowthEstimates(Ticker("MSFT")).map { estimates =>
+        assert(estimates.nonEmpty, "MSFT should have growth estimates")
+
+        // Should have stock growth for at least one period
+        assert(estimates.exists(_.stockGrowth.isDefined), "Should have stock growth data")
+      }
+    }
+  }
+
+  test("getAnalystData should return comprehensive data for NVDA") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getAnalystData(Ticker("NVDA")).map { dataOpt =>
+        assert(dataOpt.isDefined, "Result should be defined for NVDA")
+        val data = dataOpt.get
+
+        assert(data.nonEmpty, "NVDA should have analyst data")
+        assert(data.priceTargets.isDefined, "NVDA should have price targets")
+        assert(data.recommendations.nonEmpty, "NVDA should have recommendations")
+        assert(data.earningsEstimates.nonEmpty, "NVDA should have earnings estimates")
+      }
+    }
+  }
+
+  test("getAnalystData should work for stocks with limited analyst data") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.getAnalystData(Ticker("IBM")).map { dataOpt =>
+        assert(dataOpt.isDefined, "Result should be defined for IBM")
+        assert(dataOpt.get.nonEmpty, "IBM should have analyst data")
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/AnalystDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/AnalystDataSpec.scala
@@ -1,0 +1,629 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+import java.time.LocalDate
+
+class AnalystDataSpec extends FunSuite {
+
+  // --- AnalystPriceTargets tests ---
+
+  private val priceTargets = AnalystPriceTargets(
+    currentPrice = 200.0,
+    targetHigh = 250.0,
+    targetLow = 180.0,
+    targetMean = 215.0,
+    targetMedian = 220.0,
+    numberOfAnalysts = 40,
+    recommendationKey = "buy",
+    recommendationMean = 1.8
+  )
+
+  test("meanUpsidePercent should calculate positive upside correctly") {
+    // (215 - 200) / 200 * 100 = 7.5%
+    assert(Math.abs(priceTargets.meanUpsidePercent - 7.5) < 0.001)
+  }
+
+  test("meanUpsidePercent should calculate negative downside correctly") {
+    val overpriced = priceTargets.copy(currentPrice = 230.0)
+    // (215 - 230) / 230 * 100 = -6.521...
+    assert(overpriced.meanUpsidePercent < 0)
+  }
+
+  test("meanUpsidePercent should return 0 when current price is 0") {
+    val zeroPrice = priceTargets.copy(currentPrice = 0.0)
+    assertEquals(zeroPrice.meanUpsidePercent, 0.0)
+  }
+
+  test("medianUpsidePercent should calculate correctly") {
+    // (220 - 200) / 200 * 100 = 10.0%
+    assert(Math.abs(priceTargets.medianUpsidePercent - 10.0) < 0.001)
+  }
+
+  test("targetRange should calculate high minus low") {
+    // 250 - 180 = 70
+    assert(Math.abs(priceTargets.targetRange - 70.0) < 0.001)
+  }
+
+  test("targetSpreadPercent should calculate spread relative to mean") {
+    // 70 / 215 * 100 = 32.558...
+    assert(priceTargets.targetSpreadPercent > 32.0 && priceTargets.targetSpreadPercent < 33.0)
+  }
+
+  test("targetSpreadPercent should return 0 when mean is 0") {
+    val zeroMean = priceTargets.copy(targetMean = 0.0)
+    assertEquals(zeroMean.targetSpreadPercent, 0.0)
+  }
+
+  test("isBelowAllTargets should return true when price below lowest target") {
+    val cheapStock = priceTargets.copy(currentPrice = 170.0)
+    assert(cheapStock.isBelowAllTargets)
+    assert(!priceTargets.isBelowAllTargets)
+  }
+
+  test("isAboveAllTargets should return true when price above highest target") {
+    val expensiveStock = priceTargets.copy(currentPrice = 260.0)
+    assert(expensiveStock.isAboveAllTargets)
+    assert(!priceTargets.isAboveAllTargets)
+  }
+
+  // --- RecommendationTrend tests ---
+
+  private val recTrend = RecommendationTrend(
+    period = "0m",
+    strongBuy = 15,
+    buy = 25,
+    hold = 8,
+    sell = 1,
+    strongSell = 0
+  )
+
+  test("totalAnalysts should sum all categories") {
+    assertEquals(recTrend.totalAnalysts, 49)
+  }
+
+  test("totalBullish should sum strongBuy and buy") {
+    assertEquals(recTrend.totalBullish, 40)
+  }
+
+  test("totalBearish should sum sell and strongSell") {
+    assertEquals(recTrend.totalBearish, 1)
+  }
+
+  test("bullishPercent should calculate correctly") {
+    // 40 / 49 * 100 = 81.63...
+    assert(recTrend.bullishPercent > 81.0 && recTrend.bullishPercent < 82.0)
+  }
+
+  test("bearishPercent should return 0 when no analysts") {
+    val empty = recTrend.copy(strongBuy = 0, buy = 0, hold = 0, sell = 0, strongSell = 0)
+    assertEquals(empty.bearishPercent, 0.0)
+  }
+
+  test("netSentiment should be positive when more bulls") {
+    assert(recTrend.netSentiment > 0)
+    assertEquals(recTrend.netSentiment, 39) // 40 - 1
+  }
+
+  test("netSentiment should be negative when more bears") {
+    val bearish = recTrend.copy(strongBuy = 0, buy = 1, sell = 10, strongSell = 5)
+    assert(bearish.netSentiment < 0)
+  }
+
+  test("isBullish should return true when bullish > 50%") {
+    assert(recTrend.isBullish)
+  }
+
+  test("isBullish should return false when bullish <= 50%") {
+    val neutral = recTrend.copy(strongBuy = 1, buy = 1, hold = 10, sell = 1, strongSell = 1)
+    assert(!neutral.isBullish)
+  }
+
+  test("RecommendationTrend ordering should sort current month first") {
+    val trends = List(
+      recTrend.copy(period = "-2m"),
+      recTrend.copy(period = "0m"),
+      recTrend.copy(period = "-1m"),
+      recTrend.copy(period = "-3m")
+    )
+    val sorted = trends.sorted
+    assertEquals(sorted.map(_.period), List("0m", "-1m", "-2m", "-3m"))
+  }
+
+  // --- UpgradeDowngrade tests ---
+
+  private val upgrade = UpgradeDowngrade(
+    date = LocalDate.of(2024, 1, 15),
+    firm = "Morgan Stanley",
+    toGrade = "Overweight",
+    fromGrade = Some("Equal-Weight"),
+    action = UpgradeDowngradeAction.Upgrade
+  )
+
+  test("isUpgrade should return true for upgrade actions") {
+    assert(upgrade.isUpgrade)
+    assert(!upgrade.isDowngrade)
+    assert(!upgrade.isInitiation)
+    assert(!upgrade.isMaintained)
+  }
+
+  test("isDowngrade should return true for downgrade actions") {
+    val downgrade = upgrade.copy(action = UpgradeDowngradeAction.Downgrade)
+    assert(downgrade.isDowngrade)
+    assert(!downgrade.isUpgrade)
+  }
+
+  test("isInitiation should return true for init actions") {
+    val initiation = upgrade.copy(action = UpgradeDowngradeAction.Initiation, fromGrade = None)
+    assert(initiation.isInitiation)
+  }
+
+  test("isMaintained should return true for main and reit actions") {
+    val maintained = upgrade.copy(action = UpgradeDowngradeAction.Maintained)
+    val reiterated = upgrade.copy(action = UpgradeDowngradeAction.Reiterated)
+    assert(maintained.isMaintained)
+    assert(reiterated.isMaintained)
+  }
+
+  test("UpgradeDowngradeAction.fromString should handle known actions") {
+    assertEquals(UpgradeDowngradeAction.fromString("up"), UpgradeDowngradeAction.Upgrade)
+    assertEquals(UpgradeDowngradeAction.fromString("down"), UpgradeDowngradeAction.Downgrade)
+    assertEquals(UpgradeDowngradeAction.fromString("main"), UpgradeDowngradeAction.Maintained)
+    assertEquals(UpgradeDowngradeAction.fromString("reit"), UpgradeDowngradeAction.Reiterated)
+    assertEquals(UpgradeDowngradeAction.fromString("init"), UpgradeDowngradeAction.Initiation)
+  }
+
+  test("UpgradeDowngradeAction.fromString should handle unknown actions with Other") {
+    val other = UpgradeDowngradeAction.fromString("suspend")
+    assertEquals(other, UpgradeDowngradeAction.Other("suspend"))
+    assertEquals(other.value, "suspend")
+  }
+
+  test("UpgradeDowngrade ordering should sort most recent first") {
+    val events = List(
+      upgrade.copy(date = LocalDate.of(2023, 6, 1)),
+      upgrade.copy(date = LocalDate.of(2024, 3, 15)),
+      upgrade.copy(date = LocalDate.of(2024, 1, 10))
+    )
+    val sorted = events.sorted
+    assertEquals(
+      sorted.map(_.date),
+      List(
+        LocalDate.of(2024, 3, 15),
+        LocalDate.of(2024, 1, 10),
+        LocalDate.of(2023, 6, 1)
+      )
+    )
+  }
+
+  // --- EarningsEstimate tests ---
+
+  private val earningsEst = EarningsEstimate(
+    period = "0q",
+    endDate = Some("2024-06-30"),
+    avg = Some(2.04),
+    low = Some(1.67),
+    high = Some(2.47),
+    yearAgoEps = Some(1.82),
+    numberOfAnalysts = Some(31),
+    growth = Some(0.12)
+  )
+
+  test("EarningsEstimate estimateRange should calculate high minus low") {
+    val range = earningsEst.estimateRange
+    assert(range.isDefined)
+    assert(Math.abs(range.get - 0.80) < 0.001)
+  }
+
+  test("EarningsEstimate estimateSpreadPercent should calculate spread relative to average") {
+    val spread = earningsEst.estimateSpreadPercent
+    assert(spread.isDefined)
+    // 0.80 / 2.04 * 100 = 39.21...
+    assert(spread.get > 39.0 && spread.get < 40.0)
+  }
+
+  test("EarningsEstimate estimateSpreadPercent should handle zero average") {
+    val zeroAvg = earningsEst.copy(avg = Some(0.0))
+    assertEquals(zeroAvg.estimateSpreadPercent, None)
+  }
+
+  test("EarningsEstimate isQuarterly should identify quarterly periods") {
+    assert(earningsEst.isQuarterly)
+    assert(!earningsEst.isYearly)
+  }
+
+  test("EarningsEstimate isYearly should identify yearly periods") {
+    val yearly = earningsEst.copy(period = "0y")
+    assert(yearly.isYearly)
+    assert(!yearly.isQuarterly)
+  }
+
+  test("EarningsEstimate estimateRange should return None when data is missing") {
+    val noHigh = earningsEst.copy(high = None)
+    assertEquals(noHigh.estimateRange, None)
+  }
+
+  // --- RevenueEstimate tests ---
+
+  private val revenueEst = RevenueEstimate(
+    period = "0q",
+    endDate = Some("2024-06-30"),
+    avg = Some(52247700000L),
+    low = Some(48955000000L),
+    high = Some(55838000000L),
+    numberOfAnalysts = Some(27),
+    yearAgoRevenue = Some(53809000000L),
+    growth = Some(-0.029)
+  )
+
+  test("RevenueEstimate estimateRange should calculate high minus low") {
+    val range = revenueEst.estimateRange
+    assert(range.isDefined)
+    assertEquals(range.get, 55838000000L - 48955000000L)
+  }
+
+  test("RevenueEstimate isQuarterly should identify quarterly periods") {
+    assert(revenueEst.isQuarterly)
+    assert(!revenueEst.isYearly)
+  }
+
+  test("RevenueEstimate isYearly should identify yearly periods") {
+    val yearly = revenueEst.copy(period = "+1y")
+    assert(yearly.isYearly)
+    assert(!yearly.isQuarterly)
+  }
+
+  test("RevenueEstimate estimateRange should return None when data is missing") {
+    val noData = revenueEst.copy(high = None, low = None)
+    assertEquals(noData.estimateRange, None)
+  }
+
+  // --- EpsTrend tests ---
+
+  private val epsTrend = EpsTrend(
+    period = "0q",
+    current = Some(2.04),
+    sevenDaysAgo = Some(2.02),
+    thirtyDaysAgo = Some(2.00),
+    sixtyDaysAgo = Some(2.00),
+    ninetyDaysAgo = Some(2.07)
+  )
+
+  test("changeSevenDays should calculate difference") {
+    val change = epsTrend.changeSevenDays
+    assert(change.isDefined)
+    assert(Math.abs(change.get - 0.02) < 0.001)
+  }
+
+  test("changeThirtyDays should calculate difference") {
+    val change = epsTrend.changeThirtyDays
+    assert(change.isDefined)
+    assert(Math.abs(change.get - 0.04) < 0.001)
+  }
+
+  test("changeNinetyDays should calculate difference") {
+    val change = epsTrend.changeNinetyDays
+    assert(change.isDefined)
+    assert(Math.abs(change.get - (-0.03)) < 0.001)
+  }
+
+  test("isTrendingUp should return true for positive 30-day change") {
+    assertEquals(epsTrend.isTrendingUp, Some(true))
+  }
+
+  test("isTrendingUp should return false for negative 30-day change") {
+    val declining = epsTrend.copy(current = Some(1.95))
+    assertEquals(declining.isTrendingUp, Some(false))
+  }
+
+  test("EpsTrend change methods should return None when data is missing") {
+    val noData = epsTrend.copy(current = None)
+    assertEquals(noData.changeSevenDays, None)
+    assertEquals(noData.changeThirtyDays, None)
+    assertEquals(noData.changeNinetyDays, None)
+    assertEquals(noData.isTrendingUp, None)
+  }
+
+  // --- EpsRevisions tests ---
+
+  private val epsRevisions = EpsRevisions(
+    period = "0q",
+    upLast7Days = Some(4),
+    upLast30Days = Some(10),
+    downLast30Days = Some(2),
+    downLast90Days = Some(3)
+  )
+
+  test("netRevisions30Days should calculate up minus down") {
+    assertEquals(epsRevisions.netRevisions30Days, Some(8))
+  }
+
+  test("isPositiveTrend should return true when more ups") {
+    assertEquals(epsRevisions.isPositiveTrend, Some(true))
+  }
+
+  test("isPositiveTrend should return false when more downs") {
+    val negative = epsRevisions.copy(upLast30Days = Some(1), downLast30Days = Some(5))
+    assertEquals(negative.isPositiveTrend, Some(false))
+  }
+
+  test("netRevisions30Days should return None when data is missing") {
+    val noData = epsRevisions.copy(upLast30Days = None)
+    assertEquals(noData.netRevisions30Days, None)
+    assertEquals(noData.isPositiveTrend, None)
+  }
+
+  // --- EarningsHistory tests ---
+
+  private val earningsHistoryEntry = EarningsHistory(
+    quarter = LocalDate.of(2024, 3, 31),
+    period = "-1q",
+    epsActual = Some(1.52),
+    epsEstimate = Some(1.43),
+    epsDifference = Some(0.09),
+    surprisePercent = Some(6.3)
+  )
+
+  test("isBeat should return true when positive difference") {
+    assertEquals(earningsHistoryEntry.isBeat, Some(true))
+    assertEquals(earningsHistoryEntry.isMiss, Some(false))
+  }
+
+  test("isMiss should return true when negative difference") {
+    val miss = earningsHistoryEntry.copy(epsDifference = Some(-0.05))
+    assertEquals(miss.isMiss, Some(true))
+    assertEquals(miss.isBeat, Some(false))
+  }
+
+  test("isMet should return true when zero difference") {
+    val met = earningsHistoryEntry.copy(epsDifference = Some(0.0))
+    assertEquals(met.isMet, Some(true))
+    assertEquals(met.isBeat, Some(false))
+    assertEquals(met.isMiss, Some(false))
+  }
+
+  test("EarningsHistory isBeat should return None when data is missing") {
+    val noData = earningsHistoryEntry.copy(epsDifference = None)
+    assertEquals(noData.isBeat, None)
+    assertEquals(noData.isMiss, None)
+    assertEquals(noData.isMet, None)
+  }
+
+  test("EarningsHistory ordering should sort most recent quarter first") {
+    val entries = List(
+      earningsHistoryEntry.copy(quarter = LocalDate.of(2023, 6, 30)),
+      earningsHistoryEntry.copy(quarter = LocalDate.of(2024, 3, 31)),
+      earningsHistoryEntry.copy(quarter = LocalDate.of(2023, 12, 31))
+    )
+    val sorted = entries.sorted
+    assertEquals(
+      sorted.map(_.quarter),
+      List(
+        LocalDate.of(2024, 3, 31),
+        LocalDate.of(2023, 12, 31),
+        LocalDate.of(2023, 6, 30)
+      )
+    )
+  }
+
+  // --- GrowthEstimates tests ---
+
+  private val growthEst = GrowthEstimates(
+    period = "0q",
+    stockGrowth = Some(0.12),
+    indexGrowth = Some(0.08),
+    indexSymbol = Some("SP5")
+  )
+
+  test("isOutperforming should return true when stock growth exceeds index") {
+    assertEquals(growthEst.isOutperforming, Some(true))
+  }
+
+  test("isOutperforming should return false when stock underperforms") {
+    val underperforming = growthEst.copy(stockGrowth = Some(0.05))
+    assertEquals(underperforming.isOutperforming, Some(false))
+  }
+
+  test("growthDifferential should calculate difference") {
+    val diff = growthEst.growthDifferential
+    assert(diff.isDefined)
+    assert(Math.abs(diff.get - 0.04) < 0.001)
+  }
+
+  test("isOutperforming should return None when data is missing") {
+    val noStock = growthEst.copy(stockGrowth = None)
+    assertEquals(noStock.isOutperforming, None)
+    assertEquals(noStock.growthDifferential, None)
+
+    val noIndex = growthEst.copy(indexGrowth = None)
+    assertEquals(noIndex.isOutperforming, None)
+    assertEquals(noIndex.growthDifferential, None)
+  }
+
+  // --- AnalystData tests ---
+
+  test("isEmpty should return true for empty AnalystData") {
+    assert(AnalystData.empty.isEmpty)
+  }
+
+  test("nonEmpty should return true when priceTargets is present") {
+    val withTargets = AnalystData.empty.copy(priceTargets = Some(priceTargets))
+    assert(withTargets.nonEmpty)
+  }
+
+  test("nonEmpty should return true when recommendations is present") {
+    val withRecs = AnalystData.empty.copy(recommendations = List(recTrend))
+    assert(withRecs.nonEmpty)
+  }
+
+  test("nonEmpty should return true when earningsEstimates is present") {
+    val withEstimates = AnalystData.empty.copy(earningsEstimates = List(earningsEst))
+    assert(withEstimates.nonEmpty)
+  }
+
+  test("nonEmpty should return true when upgradeDowngradeHistory is present") {
+    val withHistory = AnalystData.empty.copy(upgradeDowngradeHistory = List(upgrade))
+    assert(withHistory.nonEmpty)
+  }
+
+  test("nonEmpty should return true when earningsHistory is present") {
+    val withEarnings = AnalystData.empty.copy(earningsHistory = List(earningsHistoryEntry))
+    assert(withEarnings.nonEmpty)
+  }
+
+  test("nonEmpty should return true when growthEstimates is present") {
+    val withGrowth = AnalystData.empty.copy(growthEstimates = List(growthEst))
+    assert(withGrowth.nonEmpty)
+  }
+
+  test("currentRecommendation should find period 0m") {
+    val data = AnalystData.empty.copy(recommendations =
+      List(
+        recTrend.copy(period = "-1m"),
+        recTrend.copy(period = "0m"),
+        recTrend.copy(period = "-2m")
+      )
+    )
+    val current = data.currentRecommendation
+    assert(current.isDefined)
+    assertEquals(current.get.period, "0m")
+  }
+
+  test("currentRecommendation should return None when no 0m period") {
+    val data = AnalystData.empty.copy(recommendations =
+      List(
+        recTrend.copy(period = "-1m"),
+        recTrend.copy(period = "-2m")
+      )
+    )
+    assertEquals(data.currentRecommendation, None)
+  }
+
+  test("currentQuarterEarningsEstimate should find period 0q") {
+    val data = AnalystData.empty.copy(earningsEstimates =
+      List(
+        earningsEst.copy(period = "+1q"),
+        earningsEst.copy(period = "0q"),
+        earningsEst.copy(period = "0y")
+      )
+    )
+    val current = data.currentQuarterEarningsEstimate
+    assert(current.isDefined)
+    assertEquals(current.get.period, "0q")
+  }
+
+  test("currentQuarterRevenueEstimate should find period 0q") {
+    val data = AnalystData.empty.copy(revenueEstimates =
+      List(
+        revenueEst.copy(period = "+1q"),
+        revenueEst.copy(period = "0q")
+      )
+    )
+    val current = data.currentQuarterRevenueEstimate
+    assert(current.isDefined)
+    assertEquals(current.get.period, "0q")
+  }
+
+  test("currentYearEarningsEstimate should find period 0y") {
+    val data = AnalystData.empty.copy(earningsEstimates =
+      List(
+        earningsEst.copy(period = "0q"),
+        earningsEst.copy(period = "0y"),
+        earningsEst.copy(period = "+1y")
+      )
+    )
+    val current = data.currentYearEarningsEstimate
+    assert(current.isDefined)
+    assertEquals(current.get.period, "0y")
+  }
+
+  test("consecutiveBeats should count consecutive beats from most recent") {
+    val history = List(
+      EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", Some(1.5), Some(1.4), Some(0.1), Some(7.0)),
+      EarningsHistory(LocalDate.of(2023, 12, 31), "-2q", Some(1.3), Some(1.2), Some(0.1), Some(8.0)),
+      EarningsHistory(LocalDate.of(2023, 9, 30), "-3q", Some(1.1), Some(1.15), Some(-0.05), Some(-4.3)),
+      EarningsHistory(LocalDate.of(2023, 6, 30), "-4q", Some(1.0), Some(0.9), Some(0.1), Some(11.0))
+    )
+    val data = AnalystData.empty.copy(earningsHistory = history)
+    // Sorted by most recent first: Q1-2024 (beat), Q4-2023 (beat), Q3-2023 (miss), Q2-2023 (beat)
+    // Consecutive beats from front = 2
+    assertEquals(data.consecutiveBeats, 2)
+  }
+
+  test("consecutiveBeats should return 0 when most recent is a miss") {
+    val history = List(
+      EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", Some(1.3), Some(1.4), Some(-0.1), Some(-7.0)),
+      EarningsHistory(LocalDate.of(2023, 12, 31), "-2q", Some(1.3), Some(1.2), Some(0.1), Some(8.0))
+    )
+    val data = AnalystData.empty.copy(earningsHistory = history)
+    assertEquals(data.consecutiveBeats, 0)
+  }
+
+  test("recentUpgrades should filter and limit upgrades") {
+    val events = List(
+      UpgradeDowngrade(LocalDate.of(2024, 3, 1), "A", "Buy", Some("Hold"), UpgradeDowngradeAction.Upgrade),
+      UpgradeDowngrade(LocalDate.of(2024, 2, 1), "B", "Hold", Some("Buy"), UpgradeDowngradeAction.Downgrade),
+      UpgradeDowngrade(LocalDate.of(2024, 1, 1), "C", "Overweight", Some("Neutral"), UpgradeDowngradeAction.Upgrade),
+      UpgradeDowngrade(LocalDate.of(2023, 12, 1), "D", "Buy", None, UpgradeDowngradeAction.Initiation)
+    )
+    val data = AnalystData.empty.copy(upgradeDowngradeHistory = events)
+    val upgrades = data.recentUpgrades(2)
+    assertEquals(upgrades.size, 2)
+    assert(upgrades.forall(_.isUpgrade))
+    // Should be sorted most recent first
+    assertEquals(upgrades.head.firm, "A")
+    assertEquals(upgrades(1).firm, "C")
+  }
+
+  test("recentDowngrades should filter and limit downgrades") {
+    val events = List(
+      UpgradeDowngrade(LocalDate.of(2024, 3, 1), "A", "Buy", Some("Hold"), UpgradeDowngradeAction.Upgrade),
+      UpgradeDowngrade(LocalDate.of(2024, 2, 1), "B", "Hold", Some("Buy"), UpgradeDowngradeAction.Downgrade),
+      UpgradeDowngrade(LocalDate.of(2024, 1, 1), "C", "Sell", Some("Hold"), UpgradeDowngradeAction.Downgrade)
+    )
+    val data = AnalystData.empty.copy(upgradeDowngradeHistory = events)
+    val downgrades = data.recentDowngrades()
+    assertEquals(downgrades.size, 2)
+    assert(downgrades.forall(_.isDowngrade))
+    assertEquals(downgrades.head.firm, "B")
+  }
+
+  test("earningsBeatRate should calculate percentage of beats") {
+    val history = List(
+      EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", Some(1.5), Some(1.4), Some(0.1), Some(7.0)),
+      EarningsHistory(LocalDate.of(2023, 12, 31), "-2q", Some(1.3), Some(1.2), Some(0.1), Some(8.0)),
+      EarningsHistory(LocalDate.of(2023, 9, 30), "-3q", Some(1.1), Some(1.15), Some(-0.05), Some(-4.3)),
+      EarningsHistory(LocalDate.of(2023, 6, 30), "-4q", Some(1.0), Some(0.9), Some(0.1), Some(11.0))
+    )
+    val data = AnalystData.empty.copy(earningsHistory = history)
+    val rate = data.earningsBeatRate
+    assert(rate.isDefined)
+    // 3 beats out of 4 = 75%
+    assert(Math.abs(rate.get - 75.0) < 0.001)
+  }
+
+  test("earningsBeatRate should return None for empty history") {
+    assertEquals(AnalystData.empty.earningsBeatRate, None)
+  }
+
+  test("earningsBeatRate should return None when all epsDifference is None") {
+    val history = List(
+      EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", None, None, None, None)
+    )
+    val data = AnalystData.empty.copy(earningsHistory = history)
+    assertEquals(data.earningsBeatRate, None)
+  }
+
+  test("empty AnalystData should return None for all accessors") {
+    val data = AnalystData.empty
+    assertEquals(data.currentRecommendation, None)
+    assertEquals(data.currentQuarterEarningsEstimate, None)
+    assertEquals(data.currentQuarterRevenueEstimate, None)
+    assertEquals(data.currentYearEarningsEstimate, None)
+    assertEquals(data.consecutiveBeats, 0)
+    assertEquals(data.recentUpgrades().size, 0)
+    assertEquals(data.recentDowngrades().size, 0)
+    assertEquals(data.earningsBeatRate, None)
+  }
+}


### PR DESCRIPTION
- Adding YFinanceAnalystResult raw Circe model for QuoteSummary API modules (financialData, recommendationTrend, upgradeDowngradeHistory, earningsTrend, earningsHistory, indexTrend)
- Adding 10 public domain models: AnalystPriceTargets, RecommendationTrend, UpgradeDowngrade, EarningsEstimate, RevenueEstimate, EpsTrend, EpsRevisions, EarningsHistory, GrowthEstimates, AnalystData
- Extending YFinanceGateway with getAnalystData using authenticated QuoteSummary endpoint with crumb + cookies
- Adding 8 public client methods: getAnalystPriceTargets, getRecommendations, getUpgradeDowngradeHistory, getEarningsEstimates, getRevenueEstimates, getEarningsHistory, getGrowthEstimates, and combined getAnalystData