### PR TITLE
Feat: adding search functionality for ticker and news lookup

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Analysts.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Analysts.scala
@@ -1,0 +1,268 @@
+package org.coinductive.yfinance4s
+
+import cats.Monad
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import org.coinductive.yfinance4s.Mapping.*
+import org.coinductive.yfinance4s.models.*
+
+/** Algebra for analyst data (price targets, recommendations, estimates, etc.). */
+trait Analysts[F[_]] {
+
+  /** Retrieves analyst consensus price targets for a ticker. */
+  def getAnalystPriceTargets(ticker: Ticker): F[Option[AnalystPriceTargets]]
+
+  /** Retrieves analyst recommendation trends for a ticker. */
+  def getRecommendations(ticker: Ticker): F[List[RecommendationTrend]]
+
+  /** Retrieves analyst upgrade/downgrade history for a ticker. */
+  def getUpgradeDowngradeHistory(ticker: Ticker): F[List[UpgradeDowngrade]]
+
+  /** Retrieves analyst earnings (EPS) estimates for a ticker. */
+  def getEarningsEstimates(ticker: Ticker): F[List[EarningsEstimate]]
+
+  /** Retrieves analyst revenue estimates for a ticker. */
+  def getRevenueEstimates(ticker: Ticker): F[List[RevenueEstimate]]
+
+  /** Retrieves historical earnings (actual vs. estimate) for a ticker. */
+  def getEarningsHistory(ticker: Ticker): F[List[EarningsHistory]]
+
+  /** Retrieves growth estimates with index comparison for a ticker. */
+  def getGrowthEstimates(ticker: Ticker): F[List[GrowthEstimates]]
+
+  /** Retrieves comprehensive analyst data for a ticker. */
+  def getAnalystData(ticker: Ticker): F[Option[AnalystData]]
+}
+
+private[yfinance4s] object Analysts {
+
+  final class Impl[F[_]: Monad](
+      gateway: YFinanceGateway[F],
+      auth: YFinanceAuth[F]
+  ) extends Analysts[F] {
+
+    def getAnalystPriceTargets(ticker: Ticker): F[Option[AnalystPriceTargets]] =
+      fetchAnalystData(ticker)(extractPriceTargets)
+
+    def getRecommendations(ticker: Ticker): F[List[RecommendationTrend]] =
+      fetchAnalystData(ticker)(extractRecommendations)
+
+    def getUpgradeDowngradeHistory(ticker: Ticker): F[List[UpgradeDowngrade]] =
+      fetchAnalystData(ticker)(extractUpgradeDowngrades)
+
+    def getEarningsEstimates(ticker: Ticker): F[List[EarningsEstimate]] =
+      fetchAnalystData(ticker)(extractEarningsEstimates)
+
+    def getRevenueEstimates(ticker: Ticker): F[List[RevenueEstimate]] =
+      fetchAnalystData(ticker)(extractRevenueEstimates)
+
+    def getEarningsHistory(ticker: Ticker): F[List[EarningsHistory]] =
+      fetchAnalystData(ticker)(extractEarningsHistoryEntries)
+
+    def getGrowthEstimates(ticker: Ticker): F[List[GrowthEstimates]] =
+      fetchAnalystData(ticker)(extractGrowthEstimates)
+
+    def getAnalystData(ticker: Ticker): F[Option[AnalystData]] =
+      fetchAnalystData(ticker)(mapToAnalystData)
+
+    // --- Private Helpers ---
+
+    private def fetchAnalystData[A](ticker: Ticker)(extract: YFinanceAnalystResult => A): F[A] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getAnalystData(ticker, credentials).map(extract)
+      }
+
+    private def analystQuoteData(result: YFinanceAnalystResult): Option[AnalystQuoteData] =
+      result.quoteSummary.result.headOption
+
+    private def earningsTrendEntries(result: YFinanceAnalystResult): List[EarningsTrendEntryRaw] =
+      analystQuoteData(result).flatMap(_.earningsTrend).flatMap(_.trend).getOrElse(List.empty)
+
+    private def extractPriceTargets(result: YFinanceAnalystResult): Option[AnalystPriceTargets] =
+      analystQuoteData(result).flatMap(_.financialData).flatMap(mapPriceTargets)
+
+    private def extractRecommendations(result: YFinanceAnalystResult): List[RecommendationTrend] =
+      analystQuoteData(result)
+        .flatMap(_.recommendationTrend)
+        .flatMap(_.trend)
+        .getOrElse(List.empty)
+        .flatMap(mapRecommendationTrend)
+        .sorted
+
+    private def extractUpgradeDowngrades(result: YFinanceAnalystResult): List[UpgradeDowngrade] =
+      analystQuoteData(result)
+        .flatMap(_.upgradeDowngradeHistory)
+        .flatMap(_.history)
+        .getOrElse(List.empty)
+        .flatMap(mapUpgradeDowngrade)
+        .sorted
+
+    private def extractEarningsEstimates(result: YFinanceAnalystResult): List[EarningsEstimate] =
+      earningsTrendEntries(result).flatMap(mapEarningsEstimate).sorted
+
+    private def extractRevenueEstimates(result: YFinanceAnalystResult): List[RevenueEstimate] =
+      earningsTrendEntries(result).flatMap(mapRevenueEstimate).sorted
+
+    private def extractEpsTrends(result: YFinanceAnalystResult): List[EpsTrend] =
+      earningsTrendEntries(result).flatMap(mapEpsTrend).sorted
+
+    private def extractEpsRevisionsList(result: YFinanceAnalystResult): List[EpsRevisions] =
+      earningsTrendEntries(result).flatMap(mapEpsRevisions).sorted
+
+    private def extractEarningsHistoryEntries(result: YFinanceAnalystResult): List[EarningsHistory] =
+      analystQuoteData(result)
+        .flatMap(_.earningsHistory)
+        .flatMap(_.history)
+        .getOrElse(List.empty)
+        .flatMap(mapEarningsHistoryEntry)
+        .sorted
+
+    private def extractGrowthEstimates(result: YFinanceAnalystResult): List[GrowthEstimates] = {
+      val data = analystQuoteData(result)
+      val indexTrend = data.flatMap(_.indexTrend)
+      val indexSymbol = indexTrend.flatMap(_.symbol)
+      val indexGrowthByPeriod: Map[String, Double] = indexTrend
+        .flatMap(_.estimates)
+        .getOrElse(List.empty)
+        .flatMap(e => for { p <- e.period; g <- e.growth.map(_.raw) } yield p -> g)
+        .toMap
+
+      earningsTrendEntries(result).flatMap { entry =>
+        entry.period.map { period =>
+          GrowthEstimates(
+            period = period,
+            stockGrowth = entry.growth.map(_.raw),
+            indexGrowth = indexGrowthByPeriod.get(period),
+            indexSymbol = indexSymbol
+          )
+        }
+      }.sorted
+    }
+
+    private def mapToAnalystData(result: YFinanceAnalystResult): Option[AnalystData] =
+      analystQuoteData(result).map { _ =>
+        AnalystData(
+          priceTargets = extractPriceTargets(result),
+          recommendations = extractRecommendations(result),
+          upgradeDowngradeHistory = extractUpgradeDowngrades(result),
+          earningsEstimates = extractEarningsEstimates(result),
+          revenueEstimates = extractRevenueEstimates(result),
+          epsTrends = extractEpsTrends(result),
+          epsRevisions = extractEpsRevisionsList(result),
+          earningsHistory = extractEarningsHistoryEntries(result),
+          growthEstimates = extractGrowthEstimates(result)
+        )
+      }
+
+    private def mapPriceTargets(raw: AnalystFinancialDataRaw): Option[AnalystPriceTargets] =
+      for {
+        currentPrice <- raw.currentPrice.map(_.raw)
+        targetHigh <- raw.targetHighPrice.map(_.raw)
+        targetLow <- raw.targetLowPrice.map(_.raw)
+        targetMean <- raw.targetMeanPrice.map(_.raw)
+        targetMedian <- raw.targetMedianPrice.map(_.raw)
+        numAnalysts <- raw.numberOfAnalystOpinions.map(_.raw)
+        recKey <- raw.recommendationKey
+        recMean <- raw.recommendationMean.map(_.raw)
+      } yield AnalystPriceTargets(
+        currentPrice = currentPrice,
+        targetHigh = targetHigh,
+        targetLow = targetLow,
+        targetMean = targetMean,
+        targetMedian = targetMedian,
+        numberOfAnalysts = numAnalysts,
+        recommendationKey = recKey,
+        recommendationMean = recMean
+      )
+
+    private def mapRecommendationTrend(raw: RecommendationTrendEntryRaw): Option[RecommendationTrend] =
+      raw.period.map { period =>
+        RecommendationTrend(
+          period = period,
+          strongBuy = raw.strongBuy.getOrElse(0),
+          buy = raw.buy.getOrElse(0),
+          hold = raw.hold.getOrElse(0),
+          sell = raw.sell.getOrElse(0),
+          strongSell = raw.strongSell.getOrElse(0)
+        )
+      }
+
+    private def mapUpgradeDowngrade(raw: UpgradeDowngradeEntryRaw): Option[UpgradeDowngrade] =
+      for {
+        epochDate <- raw.epochGradeDate
+        firm <- raw.firm
+        toGrade <- raw.toGrade
+        action <- raw.action
+      } yield UpgradeDowngrade(
+        date = epochToLocalDate(epochDate),
+        firm = firm,
+        toGrade = toGrade,
+        fromGrade = raw.fromGrade.filter(_.nonEmpty),
+        action = UpgradeDowngradeAction.fromString(action)
+      )
+
+    private def mapEarningsEstimate(raw: EarningsTrendEntryRaw): Option[EarningsEstimate] =
+      raw.period.map { period =>
+        EarningsEstimate(
+          period = period,
+          endDate = raw.endDate,
+          avg = raw.earningsEstimate.flatMap(_.avg).map(_.raw),
+          low = raw.earningsEstimate.flatMap(_.low).map(_.raw),
+          high = raw.earningsEstimate.flatMap(_.high).map(_.raw),
+          yearAgoEps = raw.earningsEstimate.flatMap(_.yearAgoEps).map(_.raw),
+          numberOfAnalysts = raw.earningsEstimate.flatMap(_.numberOfAnalysts).map(_.raw),
+          growth = raw.earningsEstimate.flatMap(_.growth).map(_.raw)
+        )
+      }
+
+    private def mapRevenueEstimate(raw: EarningsTrendEntryRaw): Option[RevenueEstimate] =
+      raw.period.map { period =>
+        RevenueEstimate(
+          period = period,
+          endDate = raw.endDate,
+          avg = raw.revenueEstimate.flatMap(_.avg).map(_.raw),
+          low = raw.revenueEstimate.flatMap(_.low).map(_.raw),
+          high = raw.revenueEstimate.flatMap(_.high).map(_.raw),
+          numberOfAnalysts = raw.revenueEstimate.flatMap(_.numberOfAnalysts).map(_.raw),
+          yearAgoRevenue = raw.revenueEstimate.flatMap(_.yearAgoRevenue).map(_.raw),
+          growth = raw.revenueEstimate.flatMap(_.growth).map(_.raw)
+        )
+      }
+
+    private def mapEpsTrend(raw: EarningsTrendEntryRaw): Option[EpsTrend] =
+      raw.period.map { period =>
+        EpsTrend(
+          period = period,
+          current = raw.epsTrend.flatMap(_.current).map(_.raw),
+          sevenDaysAgo = raw.epsTrend.flatMap(_.sevenDaysAgo).map(_.raw),
+          thirtyDaysAgo = raw.epsTrend.flatMap(_.thirtyDaysAgo).map(_.raw),
+          sixtyDaysAgo = raw.epsTrend.flatMap(_.sixtyDaysAgo).map(_.raw),
+          ninetyDaysAgo = raw.epsTrend.flatMap(_.ninetyDaysAgo).map(_.raw)
+        )
+      }
+
+    private def mapEpsRevisions(raw: EarningsTrendEntryRaw): Option[EpsRevisions] =
+      raw.period.map { period =>
+        EpsRevisions(
+          period = period,
+          upLast7Days = raw.epsRevisions.flatMap(_.upLast7days).map(_.raw),
+          upLast30Days = raw.epsRevisions.flatMap(_.upLast30days).map(_.raw),
+          downLast30Days = raw.epsRevisions.flatMap(_.downLast30days).map(_.raw),
+          downLast90Days = raw.epsRevisions.flatMap(_.downLast90days).map(_.raw)
+        )
+      }
+
+    private def mapEarningsHistoryEntry(raw: EarningsHistoryEntryRaw): Option[EarningsHistory] =
+      for {
+        quarter <- raw.quarter.map(v => epochToLocalDate(v.raw))
+        period <- raw.period
+      } yield EarningsHistory(
+        quarter = quarter,
+        period = period,
+        epsActual = raw.epsActual.map(_.raw),
+        epsEstimate = raw.epsEstimate.map(_.raw),
+        epsDifference = raw.epsDifference.map(_.raw),
+        surprisePercent = raw.surprisePercent.map(_.raw)
+      )
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Charts.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Charts.scala
@@ -1,0 +1,225 @@
+package org.coinductive.yfinance4s
+
+import cats.Functor
+import cats.syntax.functor.*
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.YFinanceQueryResult.InstrumentData
+
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
+
+/** Algebra for historical chart data, stock quotes, and corporate actions. */
+trait Charts[F[_]] {
+
+  /** Retrieves historical chart data (OHLCV) for a ticker by range. */
+  def getChart(ticker: Ticker, interval: Interval, range: Range): F[Option[ChartResult]]
+
+  /** Retrieves historical chart data (OHLCV) for a ticker by date range. */
+  def getChart(
+      ticker: Ticker,
+      interval: Interval,
+      since: ZonedDateTime,
+      until: ZonedDateTime
+  ): F[Option[ChartResult]]
+
+  /** Retrieves current quote with fundamentals for a ticker. */
+  def getStock(ticker: Ticker): F[Option[StockResult]]
+
+  /** Retrieves dividend history for a ticker. */
+  def getDividends(ticker: Ticker, interval: Interval, range: Range): F[Option[List[DividendEvent]]]
+
+  /** Retrieves dividend history for a ticker within a custom date range. */
+  def getDividends(
+      ticker: Ticker,
+      interval: Interval,
+      since: ZonedDateTime,
+      until: ZonedDateTime
+  ): F[Option[List[DividendEvent]]]
+
+  /** Retrieves stock split history for a ticker. */
+  def getSplits(ticker: Ticker, interval: Interval, range: Range): F[Option[List[SplitEvent]]]
+
+  /** Retrieves stock split history for a ticker within a custom date range. */
+  def getSplits(
+      ticker: Ticker,
+      interval: Interval,
+      since: ZonedDateTime,
+      until: ZonedDateTime
+  ): F[Option[List[SplitEvent]]]
+
+  /** Retrieves all corporate actions (dividends and splits) for a ticker. */
+  def getCorporateActions(ticker: Ticker, interval: Interval, range: Range): F[Option[CorporateActions]]
+
+  /** Retrieves all corporate actions for a ticker within a custom date range. */
+  def getCorporateActions(
+      ticker: Ticker,
+      interval: Interval,
+      since: ZonedDateTime,
+      until: ZonedDateTime
+  ): F[Option[CorporateActions]]
+}
+
+private[yfinance4s] object Charts {
+
+  final class Impl[F[_]: Functor](
+      gateway: YFinanceGateway[F],
+      scrapper: YFinanceScrapper[F]
+  ) extends Charts[F] {
+
+    def getChart(ticker: Ticker, interval: Interval, range: Range): F[Option[ChartResult]] =
+      gateway.getChart(ticker, interval, range).map(mapQueryResult)
+
+    def getChart(
+        ticker: Ticker,
+        interval: Interval,
+        since: ZonedDateTime,
+        until: ZonedDateTime
+    ): F[Option[ChartResult]] = gateway.getChart(ticker, interval, since, until).map(mapQueryResult)
+
+    def getStock(ticker: Ticker): F[Option[StockResult]] =
+      scrapper.getQuote(ticker).map(_.flatMap(mapQuoteResult))
+
+    def getDividends(ticker: Ticker, interval: Interval, range: Range): F[Option[List[DividendEvent]]] =
+      gateway.getChart(ticker, interval, range).map(extractDividends)
+
+    def getDividends(
+        ticker: Ticker,
+        interval: Interval,
+        since: ZonedDateTime,
+        until: ZonedDateTime
+    ): F[Option[List[DividendEvent]]] =
+      gateway.getChart(ticker, interval, since, until).map(extractDividends)
+
+    def getSplits(ticker: Ticker, interval: Interval, range: Range): F[Option[List[SplitEvent]]] =
+      gateway.getChart(ticker, interval, range).map(extractSplits)
+
+    def getSplits(
+        ticker: Ticker,
+        interval: Interval,
+        since: ZonedDateTime,
+        until: ZonedDateTime
+    ): F[Option[List[SplitEvent]]] =
+      gateway.getChart(ticker, interval, since, until).map(extractSplits)
+
+    def getCorporateActions(ticker: Ticker, interval: Interval, range: Range): F[Option[CorporateActions]] =
+      gateway.getChart(ticker, interval, range).map(extractCorporateActions)
+
+    def getCorporateActions(
+        ticker: Ticker,
+        interval: Interval,
+        since: ZonedDateTime,
+        until: ZonedDateTime
+    ): F[Option[CorporateActions]] =
+      gateway.getChart(ticker, interval, since, until).map(extractCorporateActions)
+
+    // --- Private Mapping Helpers ---
+
+    private def mapQueryResult(result: YFinanceQueryResult): Option[ChartResult] =
+      result.chart.result.headOption.map { data =>
+        val quotes = data.timestamp.indices.map { i =>
+          val quote = data.indicators.quote.head
+          val adjclose = data.indicators.adjclose.head
+          ChartResult.Quote(
+            ZonedDateTime.ofInstant(Instant.ofEpochSecond(data.timestamp(i)), ZoneOffset.UTC),
+            quote.close(i),
+            quote.open(i),
+            quote.volume(i),
+            quote.high(i),
+            quote.low(i),
+            adjclose.adjclose(i)
+          )
+        }.toList
+
+        val dividends = extractDividendsFromData(data)
+        val splits = extractSplitsFromData(data)
+
+        ChartResult(quotes, dividends, splits)
+      }
+
+    private def extractDividends(result: YFinanceQueryResult): Option[List[DividendEvent]] =
+      result.chart.result.headOption.map(extractDividendsFromData)
+
+    private def extractSplits(result: YFinanceQueryResult): Option[List[SplitEvent]] =
+      result.chart.result.headOption.map(extractSplitsFromData)
+
+    private def extractCorporateActions(result: YFinanceQueryResult): Option[CorporateActions] =
+      result.chart.result.headOption.map { data =>
+        CorporateActions(
+          dividends = extractDividendsFromData(data),
+          splits = extractSplitsFromData(data)
+        )
+      }
+
+    private def extractDividendsFromData(data: InstrumentData): List[DividendEvent] =
+      data.events
+        .flatMap(_.dividends)
+        .getOrElse(Map.empty)
+        .map { case (timestamp, raw) => DividendEvent.fromRaw(timestamp, raw) }
+        .toList
+        .sorted
+
+    private def extractSplitsFromData(data: InstrumentData): List[SplitEvent] =
+      data.events
+        .flatMap(_.splits)
+        .getOrElse(Map.empty)
+        .map { case (timestamp, raw) => SplitEvent.fromRaw(timestamp, raw) }
+        .toList
+        .sorted
+
+    private def mapQuoteResult(result: YFinanceQuoteResult): Option[StockResult] =
+      result.summary.body.quoteSummary.result.headOption.map { quoteData =>
+        val price = quoteData.price
+        val profile = quoteData.summaryProfile
+        val details = quoteData.summaryDetail
+        val financials = quoteData.financialData
+        val stats = quoteData.defaultKeyStatistics
+        StockResult(
+          price.symbol,
+          price.longName,
+          price.quoteType,
+          price.currency,
+          price.regularMarketPrice.raw,
+          price.regularMarketChangePercent.raw,
+          price.marketCap.raw,
+          price.exchangeName,
+          profile.sector,
+          profile.industry,
+          profile.longBusinessSummary,
+          details.trailingPE.map(_.raw),
+          details.forwardPE.map(_.raw),
+          details.dividendYield.map(_.raw),
+          financials.totalCash.raw,
+          financials.totalDebt.raw,
+          financials.totalRevenue.raw,
+          financials.ebitda.raw,
+          financials.debtToEquity.raw,
+          financials.revenuePerShare.raw,
+          financials.returnOnAssets.raw,
+          financials.returnOnEquity.raw,
+          financials.freeCashflow.raw,
+          financials.operatingCashflow.raw,
+          financials.earningsGrowth.raw,
+          financials.revenueGrowth.raw,
+          financials.grossMargins.raw,
+          financials.ebitdaMargins.raw,
+          financials.operatingMargins.raw,
+          financials.profitMargins.raw,
+          stats.enterpriseValue.raw,
+          stats.floatShares.raw,
+          stats.sharesOutstanding.raw,
+          stats.sharesShort.raw,
+          stats.shortRatio.raw,
+          stats.shortPercentOfFloat.raw,
+          stats.impliedSharesOutstanding.raw,
+          stats.netIncomeToCommon.raw,
+          result.fundamentals.body.timeseries.result
+            .flatMap(_.trailingPegRatio.headOption.map(_.reportedValue.raw)),
+          stats.enterpriseToRevenue.raw,
+          stats.enterpriseToEbitda.raw,
+          stats.bookValue.map(_.raw),
+          stats.priceToBook.map(_.raw),
+          stats.trailingEps.map(_.raw),
+          stats.forwardEps.map(_.raw)
+        )
+      }
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Financials.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Financials.scala
@@ -1,0 +1,132 @@
+package org.coinductive.yfinance4s
+
+import cats.Functor
+import cats.syntax.functor.*
+import io.scalaland.chimney.dsl.*
+import org.coinductive.yfinance4s.models.*
+
+/** Algebra for financial statements data. */
+trait Financials[F[_]] {
+
+  /** Retrieves comprehensive financial statements for a ticker. */
+  def getFinancialStatements(
+      ticker: Ticker,
+      frequency: Frequency = Frequency.Yearly
+  ): F[Option[FinancialStatements]]
+
+  /** Retrieves income statements for a ticker. */
+  def getIncomeStatements(
+      ticker: Ticker,
+      frequency: Frequency = Frequency.Yearly
+  ): F[List[IncomeStatement]]
+
+  /** Retrieves balance sheets for a ticker. */
+  def getBalanceSheets(
+      ticker: Ticker,
+      frequency: Frequency = Frequency.Yearly
+  ): F[List[BalanceSheet]]
+
+  /** Retrieves cash flow statements for a ticker. */
+  def getCashFlowStatements(
+      ticker: Ticker,
+      frequency: Frequency = Frequency.Yearly
+  ): F[List[CashFlowStatement]]
+}
+
+private[yfinance4s] object Financials {
+
+  private val DefaultCurrency = "USD"
+
+  final class Impl[F[_]: Functor](gateway: YFinanceGateway[F]) extends Financials[F] {
+
+    def getFinancialStatements(
+        ticker: Ticker,
+        frequency: Frequency
+    ): F[Option[FinancialStatements]] =
+      gateway.getFinancials(ticker, frequency).map(mapFinancialStatements(ticker, _))
+
+    def getIncomeStatements(
+        ticker: Ticker,
+        frequency: Frequency
+    ): F[List[IncomeStatement]] =
+      gateway.getFinancials(ticker, frequency, "income").map(extractIncomeStatements)
+
+    def getBalanceSheets(
+        ticker: Ticker,
+        frequency: Frequency
+    ): F[List[BalanceSheet]] =
+      gateway.getFinancials(ticker, frequency, "balance-sheet").map(extractBalanceSheets)
+
+    def getCashFlowStatements(
+        ticker: Ticker,
+        frequency: Frequency
+    ): F[List[CashFlowStatement]] =
+      gateway.getFinancials(ticker, frequency, "cash-flow").map(extractCashFlowStatements)
+
+    // --- Private Mapping Helpers ---
+
+    private def mapFinancialStatements(
+        ticker: Ticker,
+        result: YFinanceFinancialsResult
+    ): Option[FinancialStatements] = {
+      val byDate = result.byDate
+      if (byDate.isEmpty) return None
+
+      val currency = byDate.values.headOption.map(_.currencyCode).getOrElse(DefaultCurrency)
+
+      Some(
+        FinancialStatements(
+          ticker = ticker,
+          currency = currency,
+          incomeStatements = extractIncomeStatements(result),
+          balanceSheets = extractBalanceSheets(result),
+          cashFlowStatements = extractCashFlowStatements(result)
+        )
+      )
+    }
+
+    private def extractIncomeStatements(result: YFinanceFinancialsResult): List[IncomeStatement] =
+      result.byDate.toList.map { case (date, raw) =>
+        raw.income
+          .into[IncomeStatement]
+          .withFieldConst(_.reportDate, date)
+          .withFieldConst(_.periodType, raw.periodType)
+          .withFieldConst(_.currencyCode, raw.currencyCode)
+          .withFieldRenamed(_.depreciationAndAmortizationInIncomeStatement, _.depreciationAndAmortization)
+          .withFieldRenamed(_.basicEPS, _.basicEps)
+          .withFieldRenamed(_.dilutedEPS, _.dilutedEps)
+          .withFieldRenamed(_.eBIT, _.ebit)
+          .withFieldRenamed(_.eBITDA, _.ebitda)
+          .transform
+      }.sorted
+
+    private def extractBalanceSheets(result: YFinanceFinancialsResult): List[BalanceSheet] =
+      result.byDate.toList.map { case (date, raw) =>
+        raw.balance
+          .into[BalanceSheet]
+          .withFieldConst(_.reportDate, date)
+          .withFieldConst(_.periodType, raw.periodType)
+          .withFieldConst(_.currencyCode, raw.currencyCode)
+          .withFieldRenamed(_.otherShortTermInvestments, _.shortTermInvestments)
+          .withFieldRenamed(_.netPPE, _.netPpe)
+          .withFieldRenamed(_.grossPPE, _.grossPpe)
+          .withFieldRenamed(_.longTermEquityInvestment, _.longTermInvestments)
+          .withFieldRenamed(_.totalNonCurrentLiabilitiesNetMinorityInterest, _.totalNonCurrentLiabilities)
+          .withFieldRenamed(_.totalLiabilitiesNetMinorityInterest, _.totalLiabilities)
+          .withFieldRenamed(_.shareIssued, _.sharesIssued)
+          .transform
+      }.sorted
+
+    private def extractCashFlowStatements(result: YFinanceFinancialsResult): List[CashFlowStatement] =
+      result.byDate.toList.map { case (date, raw) =>
+        raw.cashFlow
+          .into[CashFlowStatement]
+          .withFieldConst(_.reportDate, date)
+          .withFieldConst(_.periodType, raw.periodType)
+          .withFieldConst(_.currencyCode, raw.currencyCode)
+          .withFieldRenamed(_.changeInPayable, _.changeInPayables)
+          .withFieldRenamed(_.netPPEPurchaseAndSale, _.netPpePurchaseAndSale)
+          .transform
+      }.sorted
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Holders.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Holders.scala
@@ -1,0 +1,193 @@
+package org.coinductive.yfinance4s
+
+import cats.Monad
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import org.coinductive.yfinance4s.Mapping.*
+import org.coinductive.yfinance4s.models.*
+
+/** Algebra for holders and insider data. */
+trait Holders[F[_]] {
+
+  /** Retrieves major holders breakdown for a ticker. */
+  def getMajorHolders(ticker: Ticker): F[Option[MajorHolders]]
+
+  /** Retrieves top institutional holders for a ticker. */
+  def getInstitutionalHolders(ticker: Ticker): F[List[InstitutionalHolder]]
+
+  /** Retrieves top mutual fund holders for a ticker. */
+  def getMutualFundHolders(ticker: Ticker): F[List[MutualFundHolder]]
+
+  /** Retrieves recent insider transactions for a ticker. */
+  def getInsiderTransactions(ticker: Ticker): F[List[InsiderTransaction]]
+
+  /** Retrieves insider roster (current positions) for a ticker. */
+  def getInsiderRoster(ticker: Ticker): F[List[InsiderRosterEntry]]
+
+  /** Retrieves comprehensive holders data for a ticker. */
+  def getHoldersData(ticker: Ticker): F[Option[HoldersData]]
+}
+
+private[yfinance4s] object Holders {
+
+  final class Impl[F[_]: Monad](
+      gateway: YFinanceGateway[F],
+      auth: YFinanceAuth[F]
+  ) extends Holders[F] {
+
+    def getMajorHolders(ticker: Ticker): F[Option[MajorHolders]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getHolders(ticker, credentials).map(extractMajorHolders)
+      }
+
+    def getInstitutionalHolders(ticker: Ticker): F[List[InstitutionalHolder]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getHolders(ticker, credentials).map(extractInstitutionalHolders)
+      }
+
+    def getMutualFundHolders(ticker: Ticker): F[List[MutualFundHolder]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getHolders(ticker, credentials).map(extractMutualFundHolders)
+      }
+
+    def getInsiderTransactions(ticker: Ticker): F[List[InsiderTransaction]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getHolders(ticker, credentials).map(extractInsiderTransactions)
+      }
+
+    def getInsiderRoster(ticker: Ticker): F[List[InsiderRosterEntry]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getHolders(ticker, credentials).map(extractInsiderRoster)
+      }
+
+    def getHoldersData(ticker: Ticker): F[Option[HoldersData]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getHolders(ticker, credentials).map(mapToHoldersData)
+      }
+
+    // --- Private Mapping Helpers ---
+
+    private def extractMajorHolders(result: YFinanceHoldersResult): Option[MajorHolders] =
+      result.quoteSummary.result.headOption.flatMap { data =>
+        data.majorHoldersBreakdown.flatMap(mapMajorHolders)
+      }
+
+    private def extractInstitutionalHolders(result: YFinanceHoldersResult): List[InstitutionalHolder] =
+      result.quoteSummary.result.headOption
+        .flatMap(_.institutionOwnership)
+        .flatMap(_.ownershipList)
+        .getOrElse(List.empty)
+        .flatMap(mapInstitutionalHolder)
+        .sorted
+
+    private def extractMutualFundHolders(result: YFinanceHoldersResult): List[MutualFundHolder] =
+      result.quoteSummary.result.headOption
+        .flatMap(_.fundOwnership)
+        .flatMap(_.ownershipList)
+        .getOrElse(List.empty)
+        .flatMap(mapMutualFundHolder)
+        .sorted
+
+    private def extractInsiderTransactions(result: YFinanceHoldersResult): List[InsiderTransaction] =
+      result.quoteSummary.result.headOption
+        .flatMap(_.insiderTransactions)
+        .flatMap(_.transactions)
+        .getOrElse(List.empty)
+        .flatMap(mapInsiderTransaction)
+        .sorted
+
+    private def extractInsiderRoster(result: YFinanceHoldersResult): List[InsiderRosterEntry] =
+      result.quoteSummary.result.headOption
+        .flatMap(_.insiderHolders)
+        .flatMap(_.holders)
+        .getOrElse(List.empty)
+        .flatMap(mapInsiderRosterEntry)
+        .sorted
+
+    private def mapToHoldersData(result: YFinanceHoldersResult): Option[HoldersData] =
+      result.quoteSummary.result.headOption.map { data =>
+        HoldersData(
+          majorHolders = data.majorHoldersBreakdown.flatMap(mapMajorHolders),
+          institutionalHolders = data.institutionOwnership
+            .flatMap(_.ownershipList)
+            .getOrElse(List.empty)
+            .flatMap(mapInstitutionalHolder)
+            .sorted,
+          mutualFundHolders = data.fundOwnership
+            .flatMap(_.ownershipList)
+            .getOrElse(List.empty)
+            .flatMap(mapMutualFundHolder)
+            .sorted,
+          insiderTransactions = data.insiderTransactions
+            .flatMap(_.transactions)
+            .getOrElse(List.empty)
+            .flatMap(mapInsiderTransaction)
+            .sorted,
+          insiderRoster = data.insiderHolders
+            .flatMap(_.holders)
+            .getOrElse(List.empty)
+            .flatMap(mapInsiderRosterEntry)
+            .sorted
+        )
+      }
+
+    private def mapMajorHolders(raw: MajorHoldersBreakdownRaw): Option[MajorHolders] =
+      for {
+        insiders <- raw.insidersPercentHeld.map(_.raw)
+        institutions <- raw.institutionsPercentHeld.map(_.raw)
+        institutionsFloat <- raw.institutionsFloatPercentHeld.map(_.raw)
+        institutionsCount <- raw.institutionsCount.map(_.raw)
+      } yield MajorHolders(insiders, institutions, institutionsFloat, institutionsCount)
+
+    private def mapInstitutionalHolder(raw: OwnershipEntryRaw): Option[InstitutionalHolder] =
+      for {
+        org <- raw.organization
+        reportDate <- raw.reportDate.map(v => epochToLocalDate(v.raw))
+        pctHeld <- raw.pctHeld.map(_.raw)
+        position <- raw.position.map(_.raw)
+        value <- raw.value.map(_.raw)
+      } yield InstitutionalHolder(org, reportDate, pctHeld, position, value)
+
+    private def mapMutualFundHolder(raw: OwnershipEntryRaw): Option[MutualFundHolder] =
+      for {
+        org <- raw.organization
+        reportDate <- raw.reportDate.map(v => epochToLocalDate(v.raw))
+        pctHeld <- raw.pctHeld.map(_.raw)
+        position <- raw.position.map(_.raw)
+        value <- raw.value.map(_.raw)
+      } yield MutualFundHolder(org, reportDate, pctHeld, position, value)
+
+    private def mapInsiderTransaction(raw: InsiderTransactionRaw): Option[InsiderTransaction] =
+      for {
+        filerName <- raw.filerName
+        filerRelation <- raw.filerRelation
+        transactionDate <- raw.startDate.map(v => epochToLocalDate(v.raw))
+        shares <- raw.shares.map(_.raw)
+      } yield InsiderTransaction(
+        filerName = filerName,
+        filerRelation = filerRelation,
+        transactionDate = transactionDate,
+        shares = shares,
+        value = raw.value.map(_.raw),
+        transactionText = raw.transactionText.getOrElse(""),
+        ownershipType = raw.ownership.map(OwnershipType.fromString).getOrElse(OwnershipType.Direct),
+        filerUrl = raw.filerUrl.filter(_.nonEmpty)
+      )
+
+    private def mapInsiderRosterEntry(raw: InsiderHolderRaw): Option[InsiderRosterEntry] =
+      for {
+        name <- raw.name
+        relation <- raw.relation
+      } yield InsiderRosterEntry(
+        name = name,
+        relation = relation,
+        latestTransactionDate = raw.latestTransDate.map(v => epochToLocalDate(v.raw)),
+        latestTransactionType = raw.transactionDescription,
+        positionDirect = raw.positionDirect.map(_.raw),
+        positionDirectDate = raw.positionDirectDate.map(v => epochToLocalDate(v.raw)),
+        positionIndirect = raw.positionIndirect.map(_.raw),
+        positionIndirectDate = raw.positionIndirectDate.map(v => epochToLocalDate(v.raw)),
+        url = raw.url.filter(_.nonEmpty)
+      )
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Mapping.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Mapping.scala
@@ -1,0 +1,12 @@
+package org.coinductive.yfinance4s
+
+import java.time.{Instant, LocalDate, ZoneOffset, ZonedDateTime}
+
+private[yfinance4s] object Mapping {
+
+  def epochToLocalDate(epochSeconds: Long): LocalDate =
+    Instant.ofEpochSecond(epochSeconds).atZone(ZoneOffset.UTC).toLocalDate
+
+  def epochToZonedDateTime(epochSeconds: Long): ZonedDateTime =
+    ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Options.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Options.scala
@@ -1,0 +1,119 @@
+package org.coinductive.yfinance4s
+
+import cats.Monad
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import org.coinductive.yfinance4s.Mapping.*
+import org.coinductive.yfinance4s.models.*
+
+import java.time.{LocalDate, ZoneOffset}
+
+/** Algebra for options chain data. */
+trait Options[F[_]] {
+
+  /** Retrieves all available option expiration dates for a ticker. */
+  def getOptionExpirations(ticker: Ticker): F[Option[List[LocalDate]]]
+
+  /** Retrieves the option chain for a specific expiration date. */
+  def getOptionChain(ticker: Ticker, expirationDate: LocalDate): F[Option[OptionChain]]
+
+  /** Retrieves the nearest expiration's option chain along with all available expirations. */
+  def getFullOptionChain(ticker: Ticker): F[Option[FullOptionChain]]
+}
+
+private[yfinance4s] object Options {
+
+  final class Impl[F[_]: Monad](
+      gateway: YFinanceGateway[F],
+      auth: YFinanceAuth[F]
+  ) extends Options[F] {
+
+    def getOptionExpirations(ticker: Ticker): F[Option[List[LocalDate]]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getOptions(ticker, credentials).map(extractExpirations)
+      }
+
+    def getOptionChain(ticker: Ticker, expirationDate: LocalDate): F[Option[OptionChain]] = {
+      val epochSeconds = expirationDate.atStartOfDay(ZoneOffset.UTC).toEpochSecond
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getOptions(ticker, epochSeconds, credentials).map(extractOptionChain(_, expirationDate))
+      }
+    }
+
+    def getFullOptionChain(ticker: Ticker): F[Option[FullOptionChain]] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getOptions(ticker, credentials).map(mapToFullOptionChain)
+      }
+
+    // --- Private Mapping Helpers ---
+
+    private def extractExpirations(result: YFinanceOptionsResult): Option[List[LocalDate]] =
+      result.optionChain.result.headOption.map { data =>
+        data.expirationDates.map(epochToLocalDate).sorted
+      }
+
+    private def extractOptionChain(result: YFinanceOptionsResult, requestedDate: LocalDate): Option[OptionChain] =
+      result.optionChain.result.headOption.flatMap { data =>
+        data.options
+          .find(container => epochToLocalDate(container.expirationDate) == requestedDate)
+          .map(container => buildOptionChain(container, data.strikes))
+      }
+
+    private def mapToFullOptionChain(result: YFinanceOptionsResult): Option[FullOptionChain] =
+      result.optionChain.result.headOption.map { data =>
+        val expirations = data.expirationDates.map(epochToLocalDate).sorted
+        val underlyingPrice = data.quote.flatMap(_.regularMarketPrice)
+
+        val chains = data.options.map { container =>
+          val date = epochToLocalDate(container.expirationDate)
+          date -> buildOptionChain(container, data.strikes)
+        }.toMap
+
+        FullOptionChain(
+          underlyingSymbol = data.underlyingSymbol,
+          underlyingPrice = underlyingPrice,
+          expirationDates = expirations,
+          chains = chains
+        )
+      }
+
+    private def buildOptionChain(container: OptionsContainerRaw, allStrikes: List[Double]): OptionChain = {
+      val expirationDate = epochToLocalDate(container.expirationDate)
+      val calls = container.calls.map(rawToContract(_, OptionType.Call, expirationDate)).sorted
+      val puts = container.puts.map(rawToContract(_, OptionType.Put, expirationDate)).sorted
+      val activeStrikes = (calls.map(_.strike) ++ puts.map(_.strike)).distinct.sorted
+
+      OptionChain(
+        expirationDate = expirationDate,
+        calls = calls,
+        puts = puts,
+        strikes = activeStrikes,
+        hasMiniOptions = container.hasMiniOptions
+      )
+    }
+
+    private def rawToContract(
+        raw: OptionContractRaw,
+        optionType: OptionType,
+        expiration: LocalDate
+    ): OptionContract =
+      OptionContract(
+        contractSymbol = raw.contractSymbol,
+        optionType = optionType,
+        strike = raw.strike,
+        expiration = expiration,
+        currency = raw.currency,
+        lastPrice = raw.lastPrice,
+        change = raw.change,
+        percentChange = raw.percentChange,
+        bid = raw.bid,
+        ask = raw.ask,
+        volume = raw.volume,
+        openInterest = raw.openInterest,
+        impliedVolatility = raw.impliedVolatility.map(_ * 100.0),
+        inTheMoney = raw.inTheMoney,
+        lastTradeDate = raw.lastTradeDate.map(epochToZonedDateTime),
+        contractSize = raw.contractSize.map(ContractSize.fromString).getOrElse(ContractSize.Regular)
+      )
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Tickers.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Tickers.scala
@@ -75,49 +75,49 @@ final class Tickers[F[_]] private (
 
   /** Fetches historical chart data for all tickers by range. */
   def history(interval: Interval, range: Range)(implicit C: Concurrent[F]): F[Map[Ticker, ChartResult]] =
-    fetchAll(_.getChart(_, interval, range), "chart data")
+    fetchAll(_.charts.getChart(_, interval, range), "chart data")
 
   /** Fetches historical chart data for all tickers by date range. */
   def history(interval: Interval, since: ZonedDateTime, until: ZonedDateTime)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, ChartResult]] =
-    fetchAll(_.getChart(_, interval, since, until), "chart data")
+    fetchAll(_.charts.getChart(_, interval, since, until), "chart data")
 
   /** Fetches current stock quotes for all tickers. */
   def info(implicit C: Concurrent[F]): F[Map[Ticker, StockResult]] =
-    fetchAll(_.getStock(_), "stock data")
+    fetchAll(_.charts.getStock(_), "stock data")
 
   /** Fetches financial statements for all tickers. */
   def financials(frequency: Frequency = Frequency.Yearly)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, FinancialStatements]] =
-    fetchAll(_.getFinancialStatements(_, frequency), "financial data")
+    fetchAll(_.financials.getFinancialStatements(_, frequency), "financial data")
 
   /** Fetches dividend history for all tickers. */
   def dividends(interval: Interval, range: Range)(implicit C: Concurrent[F]): F[Map[Ticker, List[DividendEvent]]] =
-    fetchAll(_.getDividends(_, interval, range), "dividend data")
+    fetchAll(_.charts.getDividends(_, interval, range), "dividend data")
 
   /** Fetches stock split history for all tickers. */
   def splits(interval: Interval, range: Range)(implicit C: Concurrent[F]): F[Map[Ticker, List[SplitEvent]]] =
-    fetchAll(_.getSplits(_, interval, range), "split data")
+    fetchAll(_.charts.getSplits(_, interval, range), "split data")
 
   /** Fetches combined corporate actions for all tickers. */
   def corporateActions(interval: Interval, range: Range)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, CorporateActions]] =
-    fetchAll(_.getCorporateActions(_, interval, range), "corporate actions")
+    fetchAll(_.charts.getCorporateActions(_, interval, range), "corporate actions")
 
   /** Fetches holders information for all tickers. */
   def holdersData(implicit C: Concurrent[F]): F[Map[Ticker, HoldersData]] =
-    fetchAll(_.getHoldersData(_), "holders data")
+    fetchAll(_.holders.getHoldersData(_), "holders data")
 
   /** Fetches analyst data for all tickers. */
   def analystData(implicit C: Concurrent[F]): F[Map[Ticker, AnalystData]] =
-    fetchAll(_.getAnalystData(_), "analyst data")
+    fetchAll(_.analysts.getAnalystData(_), "analyst data")
 
   /** Fetches option expiration dates for all tickers. */
   def optionExpirations(implicit C: Concurrent[F]): F[Map[Ticker, List[LocalDate]]] =
-    fetchAll(_.getOptionExpirations(_), "option expirations")
+    fetchAll(_.options.getOptionExpirations(_), "option expirations")
 
   // --- Error-Tolerant Data Methods ---
 
@@ -125,53 +125,53 @@ final class Tickers[F[_]] private (
   def attemptHistory(interval: Interval, range: Range)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, Either[Throwable, ChartResult]]] =
-    fetchAllAttempt(_.getChart(_, interval, range), "chart data")
+    fetchAllAttempt(_.charts.getChart(_, interval, range), "chart data")
 
   /** Fetches historical chart data by date range, collecting errors per ticker. */
   def attemptHistory(interval: Interval, since: ZonedDateTime, until: ZonedDateTime)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, Either[Throwable, ChartResult]]] =
-    fetchAllAttempt(_.getChart(_, interval, since, until), "chart data")
+    fetchAllAttempt(_.charts.getChart(_, interval, since, until), "chart data")
 
   /** Fetches current stock quotes, collecting errors per ticker. */
   def attemptInfo(implicit C: Concurrent[F]): F[Map[Ticker, Either[Throwable, StockResult]]] =
-    fetchAllAttempt(_.getStock(_), "stock data")
+    fetchAllAttempt(_.charts.getStock(_), "stock data")
 
   /** Fetches financial statements, collecting errors per ticker. */
   def attemptFinancials(frequency: Frequency = Frequency.Yearly)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, Either[Throwable, FinancialStatements]]] =
-    fetchAllAttempt(_.getFinancialStatements(_, frequency), "financial data")
+    fetchAllAttempt(_.financials.getFinancialStatements(_, frequency), "financial data")
 
   /** Fetches dividend history, collecting errors per ticker. */
   def attemptDividends(interval: Interval, range: Range)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, Either[Throwable, List[DividendEvent]]]] =
-    fetchAllAttempt(_.getDividends(_, interval, range), "dividend data")
+    fetchAllAttempt(_.charts.getDividends(_, interval, range), "dividend data")
 
   /** Fetches stock split history, collecting errors per ticker. */
   def attemptSplits(interval: Interval, range: Range)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, Either[Throwable, List[SplitEvent]]]] =
-    fetchAllAttempt(_.getSplits(_, interval, range), "split data")
+    fetchAllAttempt(_.charts.getSplits(_, interval, range), "split data")
 
   /** Fetches corporate actions, collecting errors per ticker. */
   def attemptCorporateActions(interval: Interval, range: Range)(implicit
       C: Concurrent[F]
   ): F[Map[Ticker, Either[Throwable, CorporateActions]]] =
-    fetchAllAttempt(_.getCorporateActions(_, interval, range), "corporate actions")
+    fetchAllAttempt(_.charts.getCorporateActions(_, interval, range), "corporate actions")
 
   /** Fetches holders information, collecting errors per ticker. */
   def attemptHoldersData(implicit C: Concurrent[F]): F[Map[Ticker, Either[Throwable, HoldersData]]] =
-    fetchAllAttempt(_.getHoldersData(_), "holders data")
+    fetchAllAttempt(_.holders.getHoldersData(_), "holders data")
 
   /** Fetches analyst data, collecting errors per ticker. */
   def attemptAnalystData(implicit C: Concurrent[F]): F[Map[Ticker, Either[Throwable, AnalystData]]] =
-    fetchAllAttempt(_.getAnalystData(_), "analyst data")
+    fetchAllAttempt(_.analysts.getAnalystData(_), "analyst data")
 
   /** Fetches option expiration dates, collecting errors per ticker. */
   def attemptOptionExpirations(implicit C: Concurrent[F]): F[Map[Ticker, Either[Throwable, List[LocalDate]]]] =
-    fetchAllAttempt(_.getOptionExpirations(_), "option expirations")
+    fetchAllAttempt(_.options.getOptionExpirations(_), "option expirations")
 
   // --- Internal Helpers ---
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -6,164 +6,55 @@ import cats.effect.{Async, Concurrent, Resource}
 import cats.effect.syntax.concurrent.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
-import io.scalaland.chimney.dsl.*
+import org.coinductive.yfinance4s.Mapping.*
 import org.coinductive.yfinance4s.models.*
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.InstrumentData
 
-import java.time.{Instant, LocalDate, ZoneOffset, ZonedDateTime}
+import java.time.ZonedDateTime
 
 /** Effectful Yahoo Finance client for fetching financial data.
   *
-  * Provides methods for retrieving historical price data, current quotes, corporate actions, options chains, holders
-  * information, financial statements, and analyst data. All operations are wrapped in an effect type `F[_]`.
+  * Provides domain-specific modules for retrieving historical price data, current quotes, corporate actions, options
+  * chains, holders information, financial statements, and analyst data. All operations are wrapped in an effect type
+  * `F[_]`.
   *
   * Obtain an instance via [[YFinanceClient.resource]].
   */
 trait YFinanceClient[F[_]] {
 
-  // --- Chart / Historical Data ---
+  /** Historical chart data, stock quotes, and corporate actions. */
+  def charts: Charts[F]
 
-  /** Retrieves historical chart data (OHLCV) for a ticker by range. */
-  def getChart(ticker: Ticker, interval: Interval, range: Range): F[Option[ChartResult]]
+  /** Options chain data. */
+  def options: Options[F]
 
-  /** Retrieves historical chart data (OHLCV) for a ticker by date range. */
-  def getChart(
-      ticker: Ticker,
-      interval: Interval,
-      since: ZonedDateTime,
-      until: ZonedDateTime
-  ): F[Option[ChartResult]]
+  /** Holders and insider data. */
+  def holders: Holders[F]
 
-  /** Retrieves current quote with fundamentals for a ticker. */
-  def getStock(ticker: Ticker): F[Option[StockResult]]
+  /** Financial statements data. */
+  def financials: Financials[F]
 
-  // --- Corporate Actions ---
+  /** Analyst data (price targets, recommendations, estimates, etc.). */
+  def analysts: Analysts[F]
 
-  /** Retrieves dividend history for a ticker.
+  /** Searches Yahoo Finance for tickers, companies, and news.
     *
-    * @param ticker
-    *   The stock ticker symbol (e.g., Ticker("AAPL"))
-    * @param interval
-    *   The data interval (typically Interval.`1Day` for dividends)
-    * @param range
-    *   The time range to query (e.g., Range.`1Year`, Range.Max)
+    * @param query
+    *   The search query (ticker symbol or company name)
+    * @param maxResults
+    *   Maximum number of quote results (default 8)
+    * @param newsCount
+    *   Number of news articles to include (default 8)
+    * @param enableFuzzyQuery
+    *   Enable fuzzy matching for typo tolerance (default false)
     * @return
-    *   An optional list of dividend events, sorted chronologically
+    *   Search results containing matched quotes, news, and lists
     */
-  def getDividends(ticker: Ticker, interval: Interval, range: Range): F[Option[List[DividendEvent]]]
-
-  /** Retrieves dividend history for a ticker within a custom date range. */
-  def getDividends(
-      ticker: Ticker,
-      interval: Interval,
-      since: ZonedDateTime,
-      until: ZonedDateTime
-  ): F[Option[List[DividendEvent]]]
-
-  /** Retrieves stock split history for a ticker. */
-  def getSplits(ticker: Ticker, interval: Interval, range: Range): F[Option[List[SplitEvent]]]
-
-  /** Retrieves stock split history for a ticker within a custom date range. */
-  def getSplits(
-      ticker: Ticker,
-      interval: Interval,
-      since: ZonedDateTime,
-      until: ZonedDateTime
-  ): F[Option[List[SplitEvent]]]
-
-  /** Retrieves all corporate actions (dividends and splits) for a ticker. */
-  def getCorporateActions(ticker: Ticker, interval: Interval, range: Range): F[Option[CorporateActions]]
-
-  /** Retrieves all corporate actions for a ticker within a custom date range. */
-  def getCorporateActions(
-      ticker: Ticker,
-      interval: Interval,
-      since: ZonedDateTime,
-      until: ZonedDateTime
-  ): F[Option[CorporateActions]]
-
-  // --- Options ---
-
-  /** Retrieves all available option expiration dates for a ticker. */
-  def getOptionExpirations(ticker: Ticker): F[Option[List[LocalDate]]]
-
-  /** Retrieves the option chain for a specific expiration date. */
-  def getOptionChain(ticker: Ticker, expirationDate: LocalDate): F[Option[OptionChain]]
-
-  /** Retrieves the nearest expiration's option chain along with all available expirations. */
-  def getFullOptionChain(ticker: Ticker): F[Option[FullOptionChain]]
-
-  // --- Holders ---
-
-  /** Retrieves major holders breakdown for a ticker. */
-  def getMajorHolders(ticker: Ticker): F[Option[MajorHolders]]
-
-  /** Retrieves top institutional holders for a ticker. */
-  def getInstitutionalHolders(ticker: Ticker): F[List[InstitutionalHolder]]
-
-  /** Retrieves top mutual fund holders for a ticker. */
-  def getMutualFundHolders(ticker: Ticker): F[List[MutualFundHolder]]
-
-  /** Retrieves recent insider transactions for a ticker. */
-  def getInsiderTransactions(ticker: Ticker): F[List[InsiderTransaction]]
-
-  /** Retrieves insider roster (current positions) for a ticker. */
-  def getInsiderRoster(ticker: Ticker): F[List[InsiderRosterEntry]]
-
-  /** Retrieves comprehensive holders data for a ticker. */
-  def getHoldersData(ticker: Ticker): F[Option[HoldersData]]
-
-  // --- Financial Statements ---
-
-  /** Retrieves comprehensive financial statements for a ticker. */
-  def getFinancialStatements(
-      ticker: Ticker,
-      frequency: Frequency = Frequency.Yearly
-  ): F[Option[FinancialStatements]]
-
-  /** Retrieves income statements for a ticker. */
-  def getIncomeStatements(
-      ticker: Ticker,
-      frequency: Frequency = Frequency.Yearly
-  ): F[List[IncomeStatement]]
-
-  /** Retrieves balance sheets for a ticker. */
-  def getBalanceSheets(
-      ticker: Ticker,
-      frequency: Frequency = Frequency.Yearly
-  ): F[List[BalanceSheet]]
-
-  /** Retrieves cash flow statements for a ticker. */
-  def getCashFlowStatements(
-      ticker: Ticker,
-      frequency: Frequency = Frequency.Yearly
-  ): F[List[CashFlowStatement]]
-
-  // --- Analyst Data ---
-
-  /** Retrieves analyst consensus price targets for a ticker. */
-  def getAnalystPriceTargets(ticker: Ticker): F[Option[AnalystPriceTargets]]
-
-  /** Retrieves analyst recommendation trends for a ticker. */
-  def getRecommendations(ticker: Ticker): F[List[RecommendationTrend]]
-
-  /** Retrieves analyst upgrade/downgrade history for a ticker. */
-  def getUpgradeDowngradeHistory(ticker: Ticker): F[List[UpgradeDowngrade]]
-
-  /** Retrieves analyst earnings (EPS) estimates for a ticker. */
-  def getEarningsEstimates(ticker: Ticker): F[List[EarningsEstimate]]
-
-  /** Retrieves analyst revenue estimates for a ticker. */
-  def getRevenueEstimates(ticker: Ticker): F[List[RevenueEstimate]]
-
-  /** Retrieves historical earnings (actual vs. estimate) for a ticker. */
-  def getEarningsHistory(ticker: Ticker): F[List[EarningsHistory]]
-
-  /** Retrieves growth estimates with index comparison for a ticker. */
-  def getGrowthEstimates(ticker: Ticker): F[List[GrowthEstimates]]
-
-  /** Retrieves comprehensive analyst data for a ticker. */
-  def getAnalystData(ticker: Ticker): F[Option[AnalystData]]
+  def search(
+      query: String,
+      maxResults: Int = YFinanceClient.SearchDefaults.MaxResults,
+      newsCount: Int = YFinanceClient.SearchDefaults.NewsCount,
+      enableFuzzyQuery: Boolean = YFinanceClient.SearchDefaults.EnableFuzzyQuery
+  ): F[SearchResult]
 
   // --- Multi-Ticker Downloads (concrete with default implementations) ---
 
@@ -175,7 +66,7 @@ trait YFinanceClient[F[_]] {
       parallelism: Int = YFinanceClient.DefaultParallelism
   )(implicit C: Concurrent[F]): F[Map[Ticker, ChartResult]] =
     YFinanceClient.downloadMulti(tickers, parallelism) { ticker =>
-      getChart(ticker, interval, range).flatMap {
+      charts.getChart(ticker, interval, range).flatMap {
         case Some(result) => C.pure(result)
         case None         => C.raiseError[ChartResult](new NoSuchElementException(s"No chart data for ${ticker.value}"))
       }
@@ -190,7 +81,7 @@ trait YFinanceClient[F[_]] {
       parallelism: Int
   )(implicit C: Concurrent[F]): F[Map[Ticker, ChartResult]] =
     YFinanceClient.downloadMulti(tickers, parallelism) { ticker =>
-      getChart(ticker, interval, since, until).flatMap {
+      charts.getChart(ticker, interval, since, until).flatMap {
         case Some(result) => C.pure(result)
         case None         => C.raiseError[ChartResult](new NoSuchElementException(s"No chart data for ${ticker.value}"))
       }
@@ -202,7 +93,7 @@ trait YFinanceClient[F[_]] {
       parallelism: Int = YFinanceClient.DefaultParallelism
   )(implicit C: Concurrent[F]): F[Map[Ticker, StockResult]] =
     YFinanceClient.downloadMulti(tickers, parallelism) { ticker =>
-      getStock(ticker).flatMap {
+      charts.getStock(ticker).flatMap {
         case Some(result) => C.pure(result)
         case None         => C.raiseError[StockResult](new NoSuchElementException(s"No stock data for ${ticker.value}"))
       }
@@ -215,7 +106,7 @@ trait YFinanceClient[F[_]] {
       parallelism: Int = YFinanceClient.DefaultParallelism
   )(implicit C: Concurrent[F]): F[Map[Ticker, FinancialStatements]] =
     YFinanceClient.downloadMulti(tickers, parallelism) { ticker =>
-      getFinancialStatements(ticker, frequency).flatMap {
+      financials.getFinancialStatements(ticker, frequency).flatMap {
         case Some(result) => C.pure(result)
         case None =>
           C.raiseError[FinancialStatements](new NoSuchElementException(s"No financial data for ${ticker.value}"))
@@ -227,13 +118,18 @@ object YFinanceClient {
 
   private[yfinance4s] val DefaultParallelism = 4
 
-  def resource[F[_]: Async](config: YFinanceClientConfig): Resource[F, YFinanceClient[F]] = {
+  private[yfinance4s] object SearchDefaults {
+    val MaxResults = 8
+    val NewsCount = 8
+    val EnableFuzzyQuery = false
+  }
+
+  def resource[F[_]: Async](config: YFinanceClientConfig): Resource[F, YFinanceClient[F]] =
     for {
       gateway <- YFinanceGateway.resource[F](config.connectTimeout, config.readTimeout, config.retries)
       scrapper <- YFinanceScrapper.resource[F](config.connectTimeout, config.readTimeout, config.retries)
       auth <- YFinanceAuth.resource[F](config.connectTimeout, config.readTimeout, config.retries)
     } yield new Impl(gateway, scrapper, auth)
-  }
 
   private def downloadMulti[F[_], A](
       tickers: NonEmptyList[Ticker],
@@ -251,731 +147,71 @@ object YFinanceClient {
       auth: YFinanceAuth[F]
   ) extends YFinanceClient[F] {
 
-    def getChart(ticker: Ticker, interval: Interval, range: Range): F[Option[ChartResult]] =
-      gateway.getChart(ticker, interval, range).map(mapQueryResult)
+    val charts: Charts[F] = new Charts.Impl(gateway, scrapper)
+    val options: Options[F] = new Options.Impl(gateway, auth)
+    val holders: Holders[F] = new Holders.Impl(gateway, auth)
+    val financials: Financials[F] = new Financials.Impl(gateway)
+    val analysts: Analysts[F] = new Analysts.Impl(gateway, auth)
 
-    def getChart(
-        ticker: Ticker,
-        interval: Interval,
-        since: ZonedDateTime,
-        until: ZonedDateTime
-    ): F[Option[ChartResult]] = gateway.getChart(ticker, interval, since, until).map(mapQueryResult)
+    def search(
+        query: String,
+        maxResults: Int,
+        newsCount: Int,
+        enableFuzzyQuery: Boolean
+    ): F[SearchResult] =
+      gateway.search(query, maxResults, newsCount, enableFuzzyQuery).map(mapSearchResult)
 
-    def getStock(ticker: Ticker): F[Option[StockResult]] = {
-      scrapper.getQuote(ticker).map(_.flatMap(mapQuoteResult))
-    }
+    // --- Search Mapping Helpers ---
 
-    def getDividends(ticker: Ticker, interval: Interval, range: Range): F[Option[List[DividendEvent]]] =
-      gateway.getChart(ticker, interval, range).map(extractDividends)
+    private def mapSearchResult(result: YFinanceSearchResult): SearchResult =
+      SearchResult(
+        quotes = result.quotes.flatMap(mapSearchQuote),
+        news = result.news.map(mapSearchNews),
+        lists = result.lists.getOrElse(List.empty).flatMap(mapSearchList),
+        totalResults = result.count
+      )
 
-    def getDividends(
-        ticker: Ticker,
-        interval: Interval,
-        since: ZonedDateTime,
-        until: ZonedDateTime
-    ): F[Option[List[DividendEvent]]] =
-      gateway.getChart(ticker, interval, since, until).map(extractDividends)
-
-    def getSplits(ticker: Ticker, interval: Interval, range: Range): F[Option[List[SplitEvent]]] =
-      gateway.getChart(ticker, interval, range).map(extractSplits)
-
-    def getSplits(
-        ticker: Ticker,
-        interval: Interval,
-        since: ZonedDateTime,
-        until: ZonedDateTime
-    ): F[Option[List[SplitEvent]]] =
-      gateway.getChart(ticker, interval, since, until).map(extractSplits)
-
-    def getCorporateActions(ticker: Ticker, interval: Interval, range: Range): F[Option[CorporateActions]] =
-      gateway.getChart(ticker, interval, range).map(extractCorporateActions)
-
-    def getCorporateActions(
-        ticker: Ticker,
-        interval: Interval,
-        since: ZonedDateTime,
-        until: ZonedDateTime
-    ): F[Option[CorporateActions]] =
-      gateway.getChart(ticker, interval, since, until).map(extractCorporateActions)
-
-    def getOptionExpirations(ticker: Ticker): F[Option[List[LocalDate]]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getOptions(ticker, credentials).map(extractExpirations)
-      }
-
-    def getOptionChain(ticker: Ticker, expirationDate: LocalDate): F[Option[OptionChain]] = {
-      val epochSeconds = expirationDate.atStartOfDay(ZoneOffset.UTC).toEpochSecond
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getOptions(ticker, epochSeconds, credentials).map(extractOptionChain(_, expirationDate))
-      }
-    }
-
-    def getFullOptionChain(ticker: Ticker): F[Option[FullOptionChain]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getOptions(ticker, credentials).map(mapToFullOptionChain)
-      }
-
-    def getMajorHolders(ticker: Ticker): F[Option[MajorHolders]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getHolders(ticker, credentials).map(extractMajorHolders)
-      }
-
-    def getInstitutionalHolders(ticker: Ticker): F[List[InstitutionalHolder]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getHolders(ticker, credentials).map(extractInstitutionalHolders)
-      }
-
-    def getMutualFundHolders(ticker: Ticker): F[List[MutualFundHolder]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getHolders(ticker, credentials).map(extractMutualFundHolders)
-      }
-
-    def getInsiderTransactions(ticker: Ticker): F[List[InsiderTransaction]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getHolders(ticker, credentials).map(extractInsiderTransactions)
-      }
-
-    def getInsiderRoster(ticker: Ticker): F[List[InsiderRosterEntry]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getHolders(ticker, credentials).map(extractInsiderRoster)
-      }
-
-    def getHoldersData(ticker: Ticker): F[Option[HoldersData]] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getHolders(ticker, credentials).map(mapToHoldersData)
-      }
-
-    // --- Financial Statements ---
-
-    def getFinancialStatements(
-        ticker: Ticker,
-        frequency: Frequency
-    ): F[Option[FinancialStatements]] =
-      gateway.getFinancials(ticker, frequency).map(mapFinancialStatements(ticker, _))
-
-    def getIncomeStatements(
-        ticker: Ticker,
-        frequency: Frequency
-    ): F[List[IncomeStatement]] =
-      gateway.getFinancials(ticker, frequency, "income").map(extractIncomeStatements)
-
-    def getBalanceSheets(
-        ticker: Ticker,
-        frequency: Frequency
-    ): F[List[BalanceSheet]] =
-      gateway.getFinancials(ticker, frequency, "balance-sheet").map(extractBalanceSheets)
-
-    def getCashFlowStatements(
-        ticker: Ticker,
-        frequency: Frequency
-    ): F[List[CashFlowStatement]] =
-      gateway.getFinancials(ticker, frequency, "cash-flow").map(extractCashFlowStatements)
-
-    // --- Analyst Data ---
-
-    private def fetchAnalystData[A](ticker: Ticker)(extract: YFinanceAnalystResult => A): F[A] =
-      auth.getCredentials.flatMap { credentials =>
-        gateway.getAnalystData(ticker, credentials).map(extract)
-      }
-
-    def getAnalystPriceTargets(ticker: Ticker): F[Option[AnalystPriceTargets]] =
-      fetchAnalystData(ticker)(extractPriceTargets)
-
-    def getRecommendations(ticker: Ticker): F[List[RecommendationTrend]] =
-      fetchAnalystData(ticker)(extractRecommendations)
-
-    def getUpgradeDowngradeHistory(ticker: Ticker): F[List[UpgradeDowngrade]] =
-      fetchAnalystData(ticker)(extractUpgradeDowngrades)
-
-    def getEarningsEstimates(ticker: Ticker): F[List[EarningsEstimate]] =
-      fetchAnalystData(ticker)(extractEarningsEstimates)
-
-    def getRevenueEstimates(ticker: Ticker): F[List[RevenueEstimate]] =
-      fetchAnalystData(ticker)(extractRevenueEstimates)
-
-    def getEarningsHistory(ticker: Ticker): F[List[EarningsHistory]] =
-      fetchAnalystData(ticker)(extractEarningsHistoryEntries)
-
-    def getGrowthEstimates(ticker: Ticker): F[List[GrowthEstimates]] =
-      fetchAnalystData(ticker)(extractGrowthEstimates)
-
-    def getAnalystData(ticker: Ticker): F[Option[AnalystData]] =
-      fetchAnalystData(ticker)(mapToAnalystData)
-
-    // --- Private Mapping Helpers ---
-
-    private def mapQueryResult(result: YFinanceQueryResult): Option[ChartResult] = {
-      result.chart.result.headOption.map { data =>
-        val quotes = data.timestamp.indices.map { i =>
-          val quote = data.indicators.quote.head
-          val adjclose = data.indicators.adjclose.head
-          ChartResult.Quote(
-            ZonedDateTime.ofInstant(Instant.ofEpochSecond(data.timestamp(i)), ZoneOffset.UTC),
-            quote.close(i),
-            quote.open(i),
-            quote.volume(i),
-            quote.high(i),
-            quote.low(i),
-            adjclose.adjclose(i)
-          )
-        }.toList
-
-        val dividends = extractDividendsFromData(data)
-        val splits = extractSplitsFromData(data)
-
-        ChartResult(quotes, dividends, splits)
-      }
-    }
-
-    private def extractDividends(result: YFinanceQueryResult): Option[List[DividendEvent]] =
-      result.chart.result.headOption.map(extractDividendsFromData)
-
-    private def extractSplits(result: YFinanceQueryResult): Option[List[SplitEvent]] =
-      result.chart.result.headOption.map(extractSplitsFromData)
-
-    private def extractCorporateActions(result: YFinanceQueryResult): Option[CorporateActions] =
-      result.chart.result.headOption.map { data =>
-        CorporateActions(
-          dividends = extractDividendsFromData(data),
-          splits = extractSplitsFromData(data)
+    private def mapSearchQuote(raw: SearchQuoteRaw): Option[QuoteSearchResult] =
+      raw.symbol.map { sym =>
+        QuoteSearchResult(
+          symbol = sym,
+          shortName = raw.shortname,
+          longName = raw.longname,
+          quoteType = raw.quoteType,
+          exchange = raw.exchange,
+          exchangeDisplay = raw.exchDisp,
+          sector = raw.sectorDisp.orElse(raw.sector),
+          industry = raw.industryDisp.orElse(raw.industry),
+          score = raw.score
         )
       }
 
-    private def extractDividendsFromData(data: InstrumentData): List[DividendEvent] =
-      data.events
-        .flatMap(_.dividends)
-        .getOrElse(Map.empty)
-        .map { case (timestamp, raw) => DividendEvent.fromRaw(timestamp, raw) }
-        .toList
-        .sorted
+    private def mapSearchNews(raw: SearchNewsRaw): NewsItem = {
+      val thumbnailUrl = raw.thumbnail
+        .flatMap(_.resolutions.headOption)
+        .map(_.url)
 
-    private def extractSplitsFromData(data: InstrumentData): List[SplitEvent] =
-      data.events
-        .flatMap(_.splits)
-        .getOrElse(Map.empty)
-        .map { case (timestamp, raw) => SplitEvent.fromRaw(timestamp, raw) }
-        .toList
-        .sorted
-
-    private def mapQuoteResult(result: YFinanceQuoteResult) = {
-      result.summary.body.quoteSummary.result.headOption.map { quoteData =>
-        val price = quoteData.price
-        val profile = quoteData.summaryProfile
-        val details = quoteData.summaryDetail
-        val financials = quoteData.financialData
-        val stats = quoteData.defaultKeyStatistics
-        StockResult(
-          price.symbol,
-          price.longName,
-          price.quoteType,
-          price.currency,
-          price.regularMarketPrice.raw,
-          price.regularMarketChangePercent.raw,
-          price.marketCap.raw,
-          price.exchangeName,
-          profile.sector,
-          profile.industry,
-          profile.longBusinessSummary,
-          details.trailingPE.map(_.raw),
-          details.forwardPE.map(_.raw),
-          details.dividendYield.map(_.raw),
-          financials.totalCash.raw,
-          financials.totalDebt.raw,
-          financials.totalRevenue.raw,
-          financials.ebitda.raw,
-          financials.debtToEquity.raw,
-          financials.revenuePerShare.raw,
-          financials.returnOnAssets.raw,
-          financials.returnOnEquity.raw,
-          financials.freeCashflow.raw,
-          financials.operatingCashflow.raw,
-          financials.earningsGrowth.raw,
-          financials.revenueGrowth.raw,
-          financials.grossMargins.raw,
-          financials.ebitdaMargins.raw,
-          financials.operatingMargins.raw,
-          financials.profitMargins.raw,
-          stats.enterpriseValue.raw,
-          stats.floatShares.raw,
-          stats.sharesOutstanding.raw,
-          stats.sharesShort.raw,
-          stats.shortRatio.raw,
-          stats.shortPercentOfFloat.raw,
-          stats.impliedSharesOutstanding.raw,
-          stats.netIncomeToCommon.raw,
-          result.fundamentals.body.timeseries.result
-            .flatMap(_.trailingPegRatio.headOption.map(_.reportedValue.raw)),
-          stats.enterpriseToRevenue.raw,
-          stats.enterpriseToEbitda.raw,
-          stats.bookValue.map(_.raw),
-          stats.priceToBook.map(_.raw),
-          stats.trailingEps.map(_.raw),
-          stats.forwardEps.map(_.raw)
-        )
-      }
-    }
-
-    private def extractExpirations(result: YFinanceOptionsResult): Option[List[LocalDate]] =
-      result.optionChain.result.headOption.map { data =>
-        data.expirationDates.map(epochToLocalDate).sorted
-      }
-
-    private def extractOptionChain(result: YFinanceOptionsResult, requestedDate: LocalDate): Option[OptionChain] =
-      result.optionChain.result.headOption.flatMap { data =>
-        data.options
-          .find(container => epochToLocalDate(container.expirationDate) == requestedDate)
-          .map(container => buildOptionChain(container, data.strikes))
-      }
-
-    private def mapToFullOptionChain(result: YFinanceOptionsResult): Option[FullOptionChain] =
-      result.optionChain.result.headOption.map { data =>
-        val expirations = data.expirationDates.map(epochToLocalDate).sorted
-        val underlyingPrice = data.quote.flatMap(_.regularMarketPrice)
-
-        val chains = data.options.map { container =>
-          val date = epochToLocalDate(container.expirationDate)
-          date -> buildOptionChain(container, data.strikes)
-        }.toMap
-
-        FullOptionChain(
-          underlyingSymbol = data.underlyingSymbol,
-          underlyingPrice = underlyingPrice,
-          expirationDates = expirations,
-          chains = chains
-        )
-      }
-
-    private def buildOptionChain(container: OptionsContainerRaw, allStrikes: List[Double]): OptionChain = {
-      val expirationDate = epochToLocalDate(container.expirationDate)
-      val calls = container.calls.map(rawToContract(_, OptionType.Call, expirationDate)).sorted
-      val puts = container.puts.map(rawToContract(_, OptionType.Put, expirationDate)).sorted
-      val activeStrikes = (calls.map(_.strike) ++ puts.map(_.strike)).distinct.sorted
-
-      OptionChain(
-        expirationDate = expirationDate,
-        calls = calls,
-        puts = puts,
-        strikes = activeStrikes,
-        hasMiniOptions = container.hasMiniOptions
+      NewsItem(
+        uuid = raw.uuid,
+        title = raw.title,
+        publisher = raw.publisher,
+        link = raw.link,
+        publishTime = epochToZonedDateTime(raw.providerPublishTime),
+        articleType = raw.`type`,
+        thumbnailUrl = thumbnailUrl,
+        relatedTickers = raw.relatedTickers.getOrElse(List.empty)
       )
     }
 
-    private def rawToContract(
-        raw: OptionContractRaw,
-        optionType: OptionType,
-        expiration: LocalDate
-    ): OptionContract =
-      OptionContract(
-        contractSymbol = raw.contractSymbol,
-        optionType = optionType,
-        strike = raw.strike,
-        expiration = expiration,
-        currency = raw.currency,
-        lastPrice = raw.lastPrice,
-        change = raw.change,
-        percentChange = raw.percentChange,
-        bid = raw.bid,
-        ask = raw.ask,
-        volume = raw.volume,
-        openInterest = raw.openInterest,
-        impliedVolatility = raw.impliedVolatility.map(_ * 100.0),
-        inTheMoney = raw.inTheMoney,
-        lastTradeDate = raw.lastTradeDate.map(epochToZonedDateTime),
-        contractSize = raw.contractSize.map(ContractSize.fromString).getOrElse(ContractSize.Regular)
-      )
-
-    private def epochToLocalDate(epochSeconds: Long): LocalDate =
-      Instant.ofEpochSecond(epochSeconds).atZone(ZoneOffset.UTC).toLocalDate
-
-    private def epochToZonedDateTime(epochSeconds: Long): ZonedDateTime =
-      ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneOffset.UTC)
-
-    // --- Holders Data Mapping ---
-
-    private def extractMajorHolders(result: YFinanceHoldersResult): Option[MajorHolders] =
-      result.quoteSummary.result.headOption.flatMap { data =>
-        data.majorHoldersBreakdown.flatMap(mapMajorHolders)
-      }
-
-    private def extractInstitutionalHolders(result: YFinanceHoldersResult): List[InstitutionalHolder] =
-      result.quoteSummary.result.headOption
-        .flatMap(_.institutionOwnership)
-        .flatMap(_.ownershipList)
-        .getOrElse(List.empty)
-        .flatMap(mapInstitutionalHolder)
-        .sorted
-
-    private def extractMutualFundHolders(result: YFinanceHoldersResult): List[MutualFundHolder] =
-      result.quoteSummary.result.headOption
-        .flatMap(_.fundOwnership)
-        .flatMap(_.ownershipList)
-        .getOrElse(List.empty)
-        .flatMap(mapMutualFundHolder)
-        .sorted
-
-    private def extractInsiderTransactions(result: YFinanceHoldersResult): List[InsiderTransaction] =
-      result.quoteSummary.result.headOption
-        .flatMap(_.insiderTransactions)
-        .flatMap(_.transactions)
-        .getOrElse(List.empty)
-        .flatMap(mapInsiderTransaction)
-        .sorted
-
-    private def extractInsiderRoster(result: YFinanceHoldersResult): List[InsiderRosterEntry] =
-      result.quoteSummary.result.headOption
-        .flatMap(_.insiderHolders)
-        .flatMap(_.holders)
-        .getOrElse(List.empty)
-        .flatMap(mapInsiderRosterEntry)
-        .sorted
-
-    private def mapToHoldersData(result: YFinanceHoldersResult): Option[HoldersData] =
-      result.quoteSummary.result.headOption.map { data =>
-        HoldersData(
-          majorHolders = data.majorHoldersBreakdown.flatMap(mapMajorHolders),
-          institutionalHolders = data.institutionOwnership
-            .flatMap(_.ownershipList)
-            .getOrElse(List.empty)
-            .flatMap(mapInstitutionalHolder)
-            .sorted,
-          mutualFundHolders = data.fundOwnership
-            .flatMap(_.ownershipList)
-            .getOrElse(List.empty)
-            .flatMap(mapMutualFundHolder)
-            .sorted,
-          insiderTransactions = data.insiderTransactions
-            .flatMap(_.transactions)
-            .getOrElse(List.empty)
-            .flatMap(mapInsiderTransaction)
-            .sorted,
-          insiderRoster = data.insiderHolders
-            .flatMap(_.holders)
-            .getOrElse(List.empty)
-            .flatMap(mapInsiderRosterEntry)
-            .sorted
-        )
-      }
-
-    private def mapMajorHolders(raw: MajorHoldersBreakdownRaw): Option[MajorHolders] =
+    private def mapSearchList(raw: SearchListRaw): Option[SearchList] =
       for {
-        insiders <- raw.insidersPercentHeld.map(_.raw)
-        institutions <- raw.institutionsPercentHeld.map(_.raw)
-        institutionsFloat <- raw.institutionsFloatPercentHeld.map(_.raw)
-        institutionsCount <- raw.institutionsCount.map(_.raw)
-      } yield MajorHolders(insiders, institutions, institutionsFloat, institutionsCount)
-
-    private def mapInstitutionalHolder(raw: OwnershipEntryRaw): Option[InstitutionalHolder] =
-      for {
-        org <- raw.organization
-        reportDate <- raw.reportDate.map(v => epochToLocalDate(v.raw))
-        pctHeld <- raw.pctHeld.map(_.raw)
-        position <- raw.position.map(_.raw)
-        value <- raw.value.map(_.raw)
-      } yield InstitutionalHolder(org, reportDate, pctHeld, position, value)
-
-    private def mapMutualFundHolder(raw: OwnershipEntryRaw): Option[MutualFundHolder] =
-      for {
-        org <- raw.organization
-        reportDate <- raw.reportDate.map(v => epochToLocalDate(v.raw))
-        pctHeld <- raw.pctHeld.map(_.raw)
-        position <- raw.position.map(_.raw)
-        value <- raw.value.map(_.raw)
-      } yield MutualFundHolder(org, reportDate, pctHeld, position, value)
-
-    private def mapInsiderTransaction(raw: InsiderTransactionRaw): Option[InsiderTransaction] =
-      for {
-        filerName <- raw.filerName
-        filerRelation <- raw.filerRelation
-        transactionDate <- raw.startDate.map(v => epochToLocalDate(v.raw))
-        shares <- raw.shares.map(_.raw)
-      } yield InsiderTransaction(
-        filerName = filerName,
-        filerRelation = filerRelation,
-        transactionDate = transactionDate,
-        shares = shares,
-        value = raw.value.map(_.raw),
-        transactionText = raw.transactionText.getOrElse(""),
-        ownershipType = raw.ownership.map(OwnershipType.fromString).getOrElse(OwnershipType.Direct),
-        filerUrl = raw.filerUrl.filter(_.nonEmpty)
-      )
-
-    private def mapInsiderRosterEntry(raw: InsiderHolderRaw): Option[InsiderRosterEntry] =
-      for {
-        name <- raw.name
-        relation <- raw.relation
-      } yield InsiderRosterEntry(
-        name = name,
-        relation = relation,
-        latestTransactionDate = raw.latestTransDate.map(v => epochToLocalDate(v.raw)),
-        latestTransactionType = raw.transactionDescription,
-        positionDirect = raw.positionDirect.map(_.raw),
-        positionDirectDate = raw.positionDirectDate.map(v => epochToLocalDate(v.raw)),
-        positionIndirect = raw.positionIndirect.map(_.raw),
-        positionIndirectDate = raw.positionIndirectDate.map(v => epochToLocalDate(v.raw)),
-        url = raw.url.filter(_.nonEmpty)
-      )
-
-    // --- Financial Statements Mapping ---
-
-    private val DefaultCurrency = "USD"
-
-    private def mapFinancialStatements(
-        ticker: Ticker,
-        result: YFinanceFinancialsResult
-    ): Option[FinancialStatements] = {
-      val byDate = result.byDate
-      if (byDate.isEmpty) return None
-
-      val currency = byDate.values.headOption.map(_.currencyCode).getOrElse(DefaultCurrency)
-
-      Some(
-        FinancialStatements(
-          ticker = ticker,
-          currency = currency,
-          incomeStatements = extractIncomeStatements(result),
-          balanceSheets = extractBalanceSheets(result),
-          cashFlowStatements = extractCashFlowStatements(result)
-        )
-      )
-    }
-
-    private def extractIncomeStatements(result: YFinanceFinancialsResult): List[IncomeStatement] =
-      result.byDate.toList.map { case (date, raw) =>
-        raw.income
-          .into[IncomeStatement]
-          .withFieldConst(_.reportDate, date)
-          .withFieldConst(_.periodType, raw.periodType)
-          .withFieldConst(_.currencyCode, raw.currencyCode)
-          .withFieldRenamed(_.depreciationAndAmortizationInIncomeStatement, _.depreciationAndAmortization)
-          .withFieldRenamed(_.basicEPS, _.basicEps)
-          .withFieldRenamed(_.dilutedEPS, _.dilutedEps)
-          .withFieldRenamed(_.eBIT, _.ebit)
-          .withFieldRenamed(_.eBITDA, _.ebitda)
-          .transform
-      }.sorted
-
-    private def extractBalanceSheets(result: YFinanceFinancialsResult): List[BalanceSheet] =
-      result.byDate.toList.map { case (date, raw) =>
-        raw.balance
-          .into[BalanceSheet]
-          .withFieldConst(_.reportDate, date)
-          .withFieldConst(_.periodType, raw.periodType)
-          .withFieldConst(_.currencyCode, raw.currencyCode)
-          .withFieldRenamed(_.otherShortTermInvestments, _.shortTermInvestments)
-          .withFieldRenamed(_.netPPE, _.netPpe)
-          .withFieldRenamed(_.grossPPE, _.grossPpe)
-          .withFieldRenamed(_.longTermEquityInvestment, _.longTermInvestments)
-          .withFieldRenamed(_.totalNonCurrentLiabilitiesNetMinorityInterest, _.totalNonCurrentLiabilities)
-          .withFieldRenamed(_.totalLiabilitiesNetMinorityInterest, _.totalLiabilities)
-          .withFieldRenamed(_.shareIssued, _.sharesIssued)
-          .transform
-      }.sorted
-
-    private def extractCashFlowStatements(result: YFinanceFinancialsResult): List[CashFlowStatement] =
-      result.byDate.toList.map { case (date, raw) =>
-        raw.cashFlow
-          .into[CashFlowStatement]
-          .withFieldConst(_.reportDate, date)
-          .withFieldConst(_.periodType, raw.periodType)
-          .withFieldConst(_.currencyCode, raw.currencyCode)
-          .withFieldRenamed(_.changeInPayable, _.changeInPayables)
-          .withFieldRenamed(_.netPPEPurchaseAndSale, _.netPpePurchaseAndSale)
-          .transform
-      }.sorted
-
-    // --- Analyst Data Mapping ---
-
-    private def analystQuoteData(result: YFinanceAnalystResult): Option[AnalystQuoteData] =
-      result.quoteSummary.result.headOption
-
-    private def earningsTrendEntries(result: YFinanceAnalystResult): List[EarningsTrendEntryRaw] =
-      analystQuoteData(result).flatMap(_.earningsTrend).flatMap(_.trend).getOrElse(List.empty)
-
-    private def extractPriceTargets(result: YFinanceAnalystResult): Option[AnalystPriceTargets] =
-      analystQuoteData(result).flatMap(_.financialData).flatMap(mapPriceTargets)
-
-    private def extractRecommendations(result: YFinanceAnalystResult): List[RecommendationTrend] =
-      analystQuoteData(result)
-        .flatMap(_.recommendationTrend)
-        .flatMap(_.trend)
-        .getOrElse(List.empty)
-        .flatMap(mapRecommendationTrend)
-        .sorted
-
-    private def extractUpgradeDowngrades(result: YFinanceAnalystResult): List[UpgradeDowngrade] =
-      analystQuoteData(result)
-        .flatMap(_.upgradeDowngradeHistory)
-        .flatMap(_.history)
-        .getOrElse(List.empty)
-        .flatMap(mapUpgradeDowngrade)
-        .sorted
-
-    private def extractEarningsEstimates(result: YFinanceAnalystResult): List[EarningsEstimate] =
-      earningsTrendEntries(result).flatMap(mapEarningsEstimate).sorted
-
-    private def extractRevenueEstimates(result: YFinanceAnalystResult): List[RevenueEstimate] =
-      earningsTrendEntries(result).flatMap(mapRevenueEstimate).sorted
-
-    private def extractEpsTrends(result: YFinanceAnalystResult): List[EpsTrend] =
-      earningsTrendEntries(result).flatMap(mapEpsTrend).sorted
-
-    private def extractEpsRevisionsList(result: YFinanceAnalystResult): List[EpsRevisions] =
-      earningsTrendEntries(result).flatMap(mapEpsRevisions).sorted
-
-    private def extractEarningsHistoryEntries(result: YFinanceAnalystResult): List[EarningsHistory] =
-      analystQuoteData(result)
-        .flatMap(_.earningsHistory)
-        .flatMap(_.history)
-        .getOrElse(List.empty)
-        .flatMap(mapEarningsHistoryEntry)
-        .sorted
-
-    private def extractGrowthEstimates(result: YFinanceAnalystResult): List[GrowthEstimates] = {
-      val data = analystQuoteData(result)
-      val indexTrend = data.flatMap(_.indexTrend)
-      val indexSymbol = indexTrend.flatMap(_.symbol)
-      val indexGrowthByPeriod: Map[String, Double] = indexTrend
-        .flatMap(_.estimates)
-        .getOrElse(List.empty)
-        .flatMap(e => for { p <- e.period; g <- e.growth.map(_.raw) } yield p -> g)
-        .toMap
-
-      earningsTrendEntries(result).flatMap { entry =>
-        entry.period.map { period =>
-          GrowthEstimates(
-            period = period,
-            stockGrowth = entry.growth.map(_.raw),
-            indexGrowth = indexGrowthByPeriod.get(period),
-            indexSymbol = indexSymbol
-          )
-        }
-      }.sorted
-    }
-
-    private def mapToAnalystData(result: YFinanceAnalystResult): Option[AnalystData] =
-      analystQuoteData(result).map { _ =>
-        AnalystData(
-          priceTargets = extractPriceTargets(result),
-          recommendations = extractRecommendations(result),
-          upgradeDowngradeHistory = extractUpgradeDowngrades(result),
-          earningsEstimates = extractEarningsEstimates(result),
-          revenueEstimates = extractRevenueEstimates(result),
-          epsTrends = extractEpsTrends(result),
-          epsRevisions = extractEpsRevisionsList(result),
-          earningsHistory = extractEarningsHistoryEntries(result),
-          growthEstimates = extractGrowthEstimates(result)
-        )
-      }
-
-    private def mapPriceTargets(raw: AnalystFinancialDataRaw): Option[AnalystPriceTargets] =
-      for {
-        currentPrice <- raw.currentPrice.map(_.raw)
-        targetHigh <- raw.targetHighPrice.map(_.raw)
-        targetLow <- raw.targetLowPrice.map(_.raw)
-        targetMean <- raw.targetMeanPrice.map(_.raw)
-        targetMedian <- raw.targetMedianPrice.map(_.raw)
-        numAnalysts <- raw.numberOfAnalystOpinions.map(_.raw)
-        recKey <- raw.recommendationKey
-        recMean <- raw.recommendationMean.map(_.raw)
-      } yield AnalystPriceTargets(
-        currentPrice = currentPrice,
-        targetHigh = targetHigh,
-        targetLow = targetLow,
-        targetMean = targetMean,
-        targetMedian = targetMedian,
-        numberOfAnalysts = numAnalysts,
-        recommendationKey = recKey,
-        recommendationMean = recMean
-      )
-
-    private def mapRecommendationTrend(raw: RecommendationTrendEntryRaw): Option[RecommendationTrend] =
-      raw.period.map { period =>
-        RecommendationTrend(
-          period = period,
-          strongBuy = raw.strongBuy.getOrElse(0),
-          buy = raw.buy.getOrElse(0),
-          hold = raw.hold.getOrElse(0),
-          sell = raw.sell.getOrElse(0),
-          strongSell = raw.strongSell.getOrElse(0)
-        )
-      }
-
-    private def mapUpgradeDowngrade(raw: UpgradeDowngradeEntryRaw): Option[UpgradeDowngrade] =
-      for {
-        epochDate <- raw.epochGradeDate
-        firm <- raw.firm
-        toGrade <- raw.toGrade
-        action <- raw.action
-      } yield UpgradeDowngrade(
-        date = epochToLocalDate(epochDate),
-        firm = firm,
-        toGrade = toGrade,
-        fromGrade = raw.fromGrade.filter(_.nonEmpty),
-        action = UpgradeDowngradeAction.fromString(action)
-      )
-
-    private def mapEarningsEstimate(raw: EarningsTrendEntryRaw): Option[EarningsEstimate] =
-      raw.period.map { period =>
-        EarningsEstimate(
-          period = period,
-          endDate = raw.endDate,
-          avg = raw.earningsEstimate.flatMap(_.avg).map(_.raw),
-          low = raw.earningsEstimate.flatMap(_.low).map(_.raw),
-          high = raw.earningsEstimate.flatMap(_.high).map(_.raw),
-          yearAgoEps = raw.earningsEstimate.flatMap(_.yearAgoEps).map(_.raw),
-          numberOfAnalysts = raw.earningsEstimate.flatMap(_.numberOfAnalysts).map(_.raw),
-          growth = raw.earningsEstimate.flatMap(_.growth).map(_.raw)
-        )
-      }
-
-    private def mapRevenueEstimate(raw: EarningsTrendEntryRaw): Option[RevenueEstimate] =
-      raw.period.map { period =>
-        RevenueEstimate(
-          period = period,
-          endDate = raw.endDate,
-          avg = raw.revenueEstimate.flatMap(_.avg).map(_.raw),
-          low = raw.revenueEstimate.flatMap(_.low).map(_.raw),
-          high = raw.revenueEstimate.flatMap(_.high).map(_.raw),
-          numberOfAnalysts = raw.revenueEstimate.flatMap(_.numberOfAnalysts).map(_.raw),
-          yearAgoRevenue = raw.revenueEstimate.flatMap(_.yearAgoRevenue).map(_.raw),
-          growth = raw.revenueEstimate.flatMap(_.growth).map(_.raw)
-        )
-      }
-
-    private def mapEpsTrend(raw: EarningsTrendEntryRaw): Option[EpsTrend] =
-      raw.period.map { period =>
-        EpsTrend(
-          period = period,
-          current = raw.epsTrend.flatMap(_.current).map(_.raw),
-          sevenDaysAgo = raw.epsTrend.flatMap(_.sevenDaysAgo).map(_.raw),
-          thirtyDaysAgo = raw.epsTrend.flatMap(_.thirtyDaysAgo).map(_.raw),
-          sixtyDaysAgo = raw.epsTrend.flatMap(_.sixtyDaysAgo).map(_.raw),
-          ninetyDaysAgo = raw.epsTrend.flatMap(_.ninetyDaysAgo).map(_.raw)
-        )
-      }
-
-    private def mapEpsRevisions(raw: EarningsTrendEntryRaw): Option[EpsRevisions] =
-      raw.period.map { period =>
-        EpsRevisions(
-          period = period,
-          upLast7Days = raw.epsRevisions.flatMap(_.upLast7days).map(_.raw),
-          upLast30Days = raw.epsRevisions.flatMap(_.upLast30days).map(_.raw),
-          downLast30Days = raw.epsRevisions.flatMap(_.downLast30days).map(_.raw),
-          downLast90Days = raw.epsRevisions.flatMap(_.downLast90days).map(_.raw)
-        )
-      }
-
-    private def mapEarningsHistoryEntry(raw: EarningsHistoryEntryRaw): Option[EarningsHistory] =
-      for {
-        quarter <- raw.quarter.map(v => epochToLocalDate(v.raw))
-        period <- raw.period
-      } yield EarningsHistory(
-        quarter = quarter,
-        period = period,
-        epsActual = raw.epsActual.map(_.raw),
-        epsEstimate = raw.epsEstimate.map(_.raw),
-        epsDifference = raw.epsDifference.map(_.raw),
-        surprisePercent = raw.surprisePercent.map(_.raw)
+        slug <- raw.slug
+        title <- raw.title
+      } yield SearchList(
+        slug = slug,
+        title = title,
+        description = raw.description,
+        canonicalName = raw.canonicalName
       )
   }
 }

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -29,6 +29,8 @@ sealed trait YFinanceGateway[F[_]] {
   def getFinancials(ticker: Ticker, frequency: Frequency, statementType: String = "all"): F[YFinanceFinancialsResult]
 
   def getAnalystData(ticker: Ticker, credentials: YFinanceCredentials): F[YFinanceAnalystResult]
+
+  def search(query: String, quotesCount: Int, newsCount: Int, enableFuzzyQuery: Boolean): F[YFinanceSearchResult]
 }
 
 private object YFinanceGateway {
@@ -66,6 +68,10 @@ private object YFinanceGateway {
 
     private val FinancialsEndpoint =
       uri"https://query2.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/"
+
+    private val SearchEndpoint = uri"https://query2.finance.yahoo.com/v1/finance/search"
+    private val DefaultQuotesQueryId = "tss_match_phrase_query"
+    private val DefaultNewsQueryId = "news_cie_vespa"
 
     def getChart(ticker: Ticker, interval: Interval, range: Range): F[YFinanceQueryResult] = {
       val req =
@@ -224,6 +230,39 @@ private object YFinanceGateway {
       decode[YFinanceAnalystResult](content)
         .fold(
           e => F.raiseError(new Exception(s"Failed to parse analyst response: ${e.getMessage}")),
+          F.pure
+        )
+
+    def search(
+        query: String,
+        quotesCount: Int,
+        newsCount: Int,
+        enableFuzzyQuery: Boolean
+    ): F[YFinanceSearchResult] = {
+      val req = basicRequest.get(
+        SearchEndpoint.withParams(
+          ("q", query),
+          ("quotesCount", quotesCount.toString),
+          ("newsCount", newsCount.toString),
+          ("enableFuzzyQuery", enableFuzzyQuery.toString),
+          ("quotesQueryId", DefaultQuotesQueryId),
+          ("newsQueryId", DefaultNewsQueryId),
+          ("listsCount", quotesCount.toString),
+          ("enableCb", "true"),
+          ("enableNavLinks", "false"),
+          ("enableResearchReports", "false"),
+          ("enableCulturalAssets", "false"),
+          ("recommendedCount", quotesCount.toString)
+        )
+      )
+
+      sendRequest(req, parseSearchContent)
+    }
+
+    private def parseSearchContent(content: String): F[YFinanceSearchResult] =
+      decode[YFinanceSearchResult](content)
+        .fold(
+          e => F.raiseError(new Exception(s"Failed to parse search response: ${e.getMessage}")),
           F.pure
         )
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/SearchResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/SearchResult.scala
@@ -1,0 +1,169 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.ZonedDateTime
+
+/** A single quote result from a Yahoo Finance search.
+  *
+  * @param symbol
+  *   The ticker symbol (e.g., "AAPL")
+  * @param shortName
+  *   Short display name (e.g., "Apple Inc.")
+  * @param longName
+  *   Full legal name (e.g., "Apple Inc.")
+  * @param quoteType
+  *   The instrument type (e.g., "EQUITY", "ETF", "INDEX", "MUTUALFUND", "CURRENCY", "CRYPTOCURRENCY")
+  * @param exchange
+  *   The exchange code (e.g., "NMS")
+  * @param exchangeDisplay
+  *   Human-readable exchange name (e.g., "NASDAQ")
+  * @param sector
+  *   Business sector, if available (e.g., "Technology")
+  * @param industry
+  *   Business industry, if available (e.g., "Consumer Electronics")
+  * @param score
+  *   Relevance score from Yahoo's ranking algorithm
+  */
+final case class QuoteSearchResult(
+    symbol: String,
+    shortName: Option[String],
+    longName: Option[String],
+    quoteType: Option[String],
+    exchange: Option[String],
+    exchangeDisplay: Option[String],
+    sector: Option[String],
+    industry: Option[String],
+    score: Option[Double]
+) {
+
+  /** True if this is an equity/stock. */
+  def isEquity: Boolean = quoteType.contains("EQUITY")
+
+  /** True if this is an ETF. */
+  def isETF: Boolean = quoteType.contains("ETF")
+
+  /** True if this is an index. */
+  def isIndex: Boolean = quoteType.contains("INDEX")
+
+  /** True if this is a mutual fund. */
+  def isMutualFund: Boolean = quoteType.contains("MUTUALFUND")
+
+  /** True if this is a currency pair. */
+  def isCurrency: Boolean = quoteType.contains("CURRENCY")
+
+  /** True if this is a cryptocurrency. */
+  def isCryptocurrency: Boolean = quoteType.contains("CRYPTOCURRENCY")
+
+  /** True if this is a futures contract. */
+  def isFuture: Boolean = quoteType.contains("FUTURE")
+
+  /** Returns the best available display name: longName, then shortName, then symbol. */
+  def displayName: String =
+    longName.orElse(shortName).getOrElse(symbol)
+
+  /** Converts this quote result to a [[Ticker]]. */
+  def toTicker: Ticker = Ticker(symbol)
+}
+
+object QuoteSearchResult {
+  implicit val ordering: Ordering[QuoteSearchResult] =
+    Ordering.by[QuoteSearchResult, Double](_.score.getOrElse(0.0)).reverse
+}
+
+/** A news article from Yahoo Finance search results.
+  *
+  * @param uuid
+  *   Unique identifier for the article
+  * @param title
+  *   Article headline
+  * @param publisher
+  *   Name of the publishing source
+  * @param link
+  *   URL to the full article
+  * @param publishTime
+  *   When the article was published
+  * @param articleType
+  *   Article type (e.g., "STORY")
+  * @param thumbnailUrl
+  *   URL to the highest-resolution thumbnail, if available
+  * @param relatedTickers
+  *   Ticker symbols mentioned in or related to the article
+  */
+final case class NewsItem(
+    uuid: String,
+    title: String,
+    publisher: String,
+    link: String,
+    publishTime: ZonedDateTime,
+    articleType: Option[String],
+    thumbnailUrl: Option[String],
+    relatedTickers: List[String]
+) extends Ordered[NewsItem] {
+
+  override def compare(that: NewsItem): Int =
+    that.publishTime.compareTo(this.publishTime)
+
+  /** True if this news item is related to the given ticker symbol. */
+  def isRelatedTo(symbol: String): Boolean =
+    relatedTickers.exists(_.equalsIgnoreCase(symbol))
+}
+
+object NewsItem {
+  implicit val ordering: Ordering[NewsItem] = Ordering.fromLessThan(_.compare(_) < 0)
+}
+
+/** A curated list from Yahoo Finance search results (e.g., "Most Active", "Day Gainers"). */
+final case class SearchList(
+    slug: String,
+    title: String,
+    description: Option[String],
+    canonicalName: Option[String]
+)
+
+/** Aggregate search results from Yahoo Finance.
+  *
+  * @param quotes
+  *   Matched ticker/company results, filtered to Yahoo Finance securities only
+  * @param news
+  *   Related news articles
+  * @param lists
+  *   Related curated lists
+  * @param totalResults
+  *   Total result count reported by Yahoo
+  */
+final case class SearchResult(
+    quotes: List[QuoteSearchResult],
+    news: List[NewsItem],
+    lists: List[SearchList],
+    totalResults: Int
+) {
+
+  /** True if any results were returned. */
+  def nonEmpty: Boolean = quotes.nonEmpty || news.nonEmpty || lists.nonEmpty
+
+  /** True if no results were returned. */
+  def isEmpty: Boolean = !nonEmpty
+
+  /** Filters quotes to only equities. */
+  def equities: List[QuoteSearchResult] = quotes.filter(_.isEquity)
+
+  /** Filters quotes to only ETFs. */
+  def etfs: List[QuoteSearchResult] = quotes.filter(_.isETF)
+
+  /** Returns the best-matching quote (highest relevance score), if any. */
+  def topQuote: Option[QuoteSearchResult] = quotes.sorted.headOption
+
+  /** Extracts all matched ticker symbols. */
+  def symbols: List[String] = quotes.map(_.symbol)
+
+  /** Extracts all matched tickers as [[Ticker]] values. */
+  def tickers: List[Ticker] = quotes.map(_.toTicker)
+}
+
+object SearchResult {
+  val empty: SearchResult = SearchResult(
+    quotes = List.empty,
+    news = List.empty,
+    lists = List.empty,
+    totalResults = 0
+  )
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceSearchResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/YFinanceSearchResult.scala
@@ -1,0 +1,81 @@
+package org.coinductive.yfinance4s.models
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+private[yfinance4s] final case class YFinanceSearchResult(
+    count: Int,
+    quotes: List[SearchQuoteRaw],
+    news: List[SearchNewsRaw],
+    lists: Option[List[SearchListRaw]]
+)
+
+private[yfinance4s] object YFinanceSearchResult {
+  implicit val decoder: Decoder[YFinanceSearchResult] = deriveDecoder
+}
+
+private[yfinance4s] final case class SearchQuoteRaw(
+    symbol: Option[String],
+    shortname: Option[String],
+    longname: Option[String],
+    quoteType: Option[String],
+    exchange: Option[String],
+    exchDisp: Option[String],
+    sector: Option[String],
+    sectorDisp: Option[String],
+    industry: Option[String],
+    industryDisp: Option[String],
+    score: Option[Double],
+    typeDisp: Option[String],
+    isYahooFinance: Option[Boolean]
+)
+
+private[yfinance4s] object SearchQuoteRaw {
+  implicit val decoder: Decoder[SearchQuoteRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class SearchNewsThumbnailResolution(
+    url: String,
+    width: Int,
+    height: Int,
+    tag: String
+)
+
+private[yfinance4s] object SearchNewsThumbnailResolution {
+  implicit val decoder: Decoder[SearchNewsThumbnailResolution] = deriveDecoder
+}
+
+private[yfinance4s] final case class SearchNewsThumbnailRaw(
+    resolutions: List[SearchNewsThumbnailResolution]
+)
+
+private[yfinance4s] object SearchNewsThumbnailRaw {
+  implicit val decoder: Decoder[SearchNewsThumbnailRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class SearchNewsRaw(
+    uuid: String,
+    title: String,
+    publisher: String,
+    link: String,
+    providerPublishTime: Long,
+    `type`: Option[String],
+    thumbnail: Option[SearchNewsThumbnailRaw],
+    relatedTickers: Option[List[String]]
+)
+
+private[yfinance4s] object SearchNewsRaw {
+  implicit val decoder: Decoder[SearchNewsRaw] = deriveDecoder
+}
+
+private[yfinance4s] final case class SearchListRaw(
+    slug: Option[String],
+    title: Option[String],
+    description: Option[String],
+    pfId: Option[String],
+    canonicalName: Option[String]
+)
+
+private[yfinance4s] object SearchListRaw {
+  implicit val decoder: Decoder[SearchListRaw] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/AnalystDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/AnalystDataSpec.scala
@@ -15,9 +15,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getAnalystPriceTargets should return targets for AAPL") {
+  test("returns analyst price targets with valid ranges for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getAnalystPriceTargets(Ticker("AAPL")).map { result =>
+      client.analysts.getAnalystPriceTargets(Ticker("AAPL")).map { result =>
         assert(result.isDefined, "Result should be defined for AAPL")
         val targets = result.get
 
@@ -33,9 +33,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getRecommendations should return trends for MSFT") {
+  test("returns recommendation trends with current month for MSFT") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getRecommendations(Ticker("MSFT")).map { recommendations =>
+      client.analysts.getRecommendations(Ticker("MSFT")).map { recommendations =>
         assert(recommendations.nonEmpty, "MSFT should have recommendation trends")
 
         // Should have a current month entry
@@ -49,9 +49,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getUpgradeDowngradeHistory should return history for GOOGL") {
+  test("returns upgrade/downgrade history sorted by date for GOOGL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getUpgradeDowngradeHistory(Ticker("GOOGL")).map { history =>
+      client.analysts.getUpgradeDowngradeHistory(Ticker("GOOGL")).map { history =>
         assert(history.nonEmpty, "GOOGL should have upgrade/downgrade history")
 
         // Validate structure
@@ -67,9 +67,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getEarningsEstimates should return estimates for NVDA") {
+  test("returns quarterly and yearly earnings estimates for NVDA") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getEarningsEstimates(Ticker("NVDA")).map { estimates =>
+      client.analysts.getEarningsEstimates(Ticker("NVDA")).map { estimates =>
         assert(estimates.nonEmpty, "NVDA should have earnings estimates")
 
         // Should have both quarterly and yearly estimates
@@ -86,9 +86,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getRevenueEstimates should return estimates for AMZN") {
+  test("returns positive revenue estimates for AMZN") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getRevenueEstimates(Ticker("AMZN")).map { estimates =>
+      client.analysts.getRevenueEstimates(Ticker("AMZN")).map { estimates =>
         assert(estimates.nonEmpty, "AMZN should have revenue estimates")
 
         // Large company should have positive revenue estimates
@@ -101,9 +101,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getEarningsHistory should return historical results for AAPL") {
+  test("returns earnings history sorted by quarter for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getEarningsHistory(Ticker("AAPL")).map { history =>
+      client.analysts.getEarningsHistory(Ticker("AAPL")).map { history =>
         assert(history.nonEmpty, "AAPL should have earnings history")
 
         // Validate structure
@@ -118,9 +118,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getGrowthEstimates should return growth data for MSFT") {
+  test("returns growth estimates with stock growth data for MSFT") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getGrowthEstimates(Ticker("MSFT")).map { estimates =>
+      client.analysts.getGrowthEstimates(Ticker("MSFT")).map { estimates =>
         assert(estimates.nonEmpty, "MSFT should have growth estimates")
 
         // Should have stock growth for at least one period
@@ -129,9 +129,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getAnalystData should return comprehensive data for NVDA") {
+  test("returns comprehensive analyst data for NVDA") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getAnalystData(Ticker("NVDA")).map { dataOpt =>
+      client.analysts.getAnalystData(Ticker("NVDA")).map { dataOpt =>
         assert(dataOpt.isDefined, "Result should be defined for NVDA")
         val data = dataOpt.get
 
@@ -143,9 +143,9 @@ class AnalystDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getAnalystData should work for stocks with limited analyst data") {
+  test("returns analyst data for stock with limited coverage (IBM)") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getAnalystData(Ticker("IBM")).map { dataOpt =>
+      client.analysts.getAnalystData(Ticker("IBM")).map { dataOpt =>
         assert(dataOpt.isDefined, "Result should be defined for IBM")
         assert(dataOpt.get.nonEmpty, "IBM should have analyst data")
       }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/CorporateActionsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/CorporateActionsSpec.scala
@@ -15,9 +15,9 @@ class CorporateActionsSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getCorporateActions should return combined dividends and splits") {
+  test("returns combined dividends and splits for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getCorporateActions(Ticker("AAPL"), Interval.`1Day`, Range.`5Years`).map { actionsOpt =>
+      client.charts.getCorporateActions(Ticker("AAPL"), Interval.`1Day`, Range.`5Years`).map { actionsOpt =>
         assert(actionsOpt.isDefined, "Result should be defined for AAPL")
         val actions = actionsOpt.get
 
@@ -33,9 +33,9 @@ class CorporateActionsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getCorporateActions cumulative split factor should calculate correctly") {
+  test("cumulative split factor matches product of individual factors") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getCorporateActions(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { actionsOpt =>
+      client.charts.getCorporateActions(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { actionsOpt =>
         actionsOpt.foreach { actions =>
           val cumulativeFactor = actions.cumulativeSplitFactor
 
@@ -55,9 +55,9 @@ class CorporateActionsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getChart should include corporate actions in ChartResult") {
+  test("embeds corporate actions in chart result") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getChart(Ticker("AAPL"), Interval.`1Day`, Range.`1Year`).map { chartOpt =>
+      client.charts.getChart(Ticker("AAPL"), Interval.`1Day`, Range.`1Year`).map { chartOpt =>
         assert(chartOpt.isDefined, "Chart should be defined for AAPL")
         val chart = chartOpt.get
 

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/DividendsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/DividendsSpec.scala
@@ -16,9 +16,9 @@ class DividendsSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getDividends should return dividends for a dividend-paying stock (AAPL)") {
+  test("returns dividends for dividend-paying stock (AAPL)") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getDividends(Ticker("AAPL"), Interval.`1Day`, Range.`1Year`).map { dividendsOpt =>
+      client.charts.getDividends(Ticker("AAPL"), Interval.`1Day`, Range.`1Year`).map { dividendsOpt =>
         assert(dividendsOpt.isDefined, "Result should be defined for AAPL")
         val dividends = dividendsOpt.get
 
@@ -41,12 +41,12 @@ class DividendsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getDividends with date range should filter appropriately") {
+  test("filters dividends within specified date range") {
     YFinanceClient.resource[IO](config).use { client =>
       val now = ZonedDateTime.now()
       val sixMonthsAgo = now.minusMonths(6)
 
-      client.getDividends(Ticker("AAPL"), Interval.`1Day`, sixMonthsAgo, now).map { dividendsOpt =>
+      client.charts.getDividends(Ticker("AAPL"), Interval.`1Day`, sixMonthsAgo, now).map { dividendsOpt =>
         assert(dividendsOpt.isDefined, "Result should be defined")
         val dividends = dividendsOpt.get
 
@@ -64,9 +64,9 @@ class DividendsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getDividends should handle Max range for full dividend history") {
+  test("returns full dividend history with Max range") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getDividends(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { dividendsOpt =>
+      client.charts.getDividends(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { dividendsOpt =>
         assert(dividendsOpt.isDefined, "Result should be defined")
         val dividends = dividendsOpt.get
 

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/FinancialStatementsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/FinancialStatementsSpec.scala
@@ -15,9 +15,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getFinancialStatements should return yearly financial data for AAPL") {
+  test("returns yearly financial data for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getFinancialStatements(Ticker("AAPL"), Frequency.Yearly).map { result =>
+      client.financials.getFinancialStatements(Ticker("AAPL"), Frequency.Yearly).map { result =>
         assert(result.isDefined, "Result should be defined for AAPL")
         val financials = result.get
 
@@ -43,9 +43,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getFinancialStatements should return quarterly data for MSFT") {
+  test("returns quarterly financial data sorted by date for MSFT") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getFinancialStatements(Ticker("MSFT"), Frequency.Quarterly).map { result =>
+      client.financials.getFinancialStatements(Ticker("MSFT"), Frequency.Quarterly).map { result =>
         assert(result.isDefined, "Result should be defined for MSFT")
         val financials = result.get
 
@@ -61,9 +61,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getIncomeStatements should return income data for GOOGL") {
+  test("returns income statements with valid margins for GOOGL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getIncomeStatements(Ticker("GOOGL")).map { statements =>
+      client.financials.getIncomeStatements(Ticker("GOOGL")).map { statements =>
         assert(statements.nonEmpty, "GOOGL should have income statements")
 
         statements.foreach { stmt =>
@@ -91,9 +91,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getBalanceSheets should return balance sheet data for NVDA") {
+  test("returns balance sheets with valid ratios for NVDA") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getBalanceSheets(Ticker("NVDA")).map { sheets =>
+      client.financials.getBalanceSheets(Ticker("NVDA")).map { sheets =>
         assert(sheets.nonEmpty, "NVDA should have balance sheets")
 
         sheets.foreach { sheet =>
@@ -120,9 +120,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getCashFlowStatements should return cash flow data for AMZN") {
+  test("returns cash flow statements for AMZN") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getCashFlowStatements(Ticker("AMZN")).map { statements =>
+      client.financials.getCashFlowStatements(Ticker("AMZN")).map { statements =>
         assert(statements.nonEmpty, "AMZN should have cash flow statements")
 
         statements.foreach { stmt =>
@@ -142,9 +142,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getFinancialStatements should support trailing frequency") {
+  test("supports trailing (TTM) frequency for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getFinancialStatements(Ticker("AAPL"), Frequency.Trailing).map { result =>
+      client.financials.getFinancialStatements(Ticker("AAPL"), Frequency.Trailing).map { result =>
         assert(result.isDefined, "Trailing result should be defined for AAPL")
         val financials = result.get
 
@@ -154,9 +154,9 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("cross-statement metrics should calculate correctly for AAPL") {
+  test("calculates cross-statement metrics (ROA, ROE, asset turnover) for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getFinancialStatements(Ticker("AAPL")).map { result =>
+      client.financials.getFinancialStatements(Ticker("AAPL")).map { result =>
         assert(result.isDefined, "Result should be defined for AAPL")
         val financials = result.get
 
@@ -183,10 +183,10 @@ class FinancialStatementsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getFinancialStatements should work for stocks without all data") {
+  test("returns financial data for stock with limited data (IBM)") {
     YFinanceClient.resource[IO](config).use { client =>
       // Use a company that should have financials
-      client.getFinancialStatements(Ticker("IBM")).map { result =>
+      client.financials.getFinancialStatements(Ticker("IBM")).map { result =>
         assert(result.isDefined, "Result should be defined for IBM")
         // IBM should have at least some financial data
         val financials = result.get

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/HoldersDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/HoldersDataSpec.scala
@@ -15,9 +15,9 @@ class HoldersDataSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getMajorHolders should return ownership breakdown for AAPL") {
+  test("returns ownership breakdown for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getMajorHolders(Ticker("AAPL")).map { holdersOpt =>
+      client.holders.getMajorHolders(Ticker("AAPL")).map { holdersOpt =>
         assert(holdersOpt.isDefined, "Result should be defined for AAPL")
         val holders = holdersOpt.get
 
@@ -40,9 +40,9 @@ class HoldersDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getInstitutionalHolders should return top holders for MSFT") {
+  test("returns top institutional holders for MSFT sorted by percentage") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getInstitutionalHolders(Ticker("MSFT")).map { holders =>
+      client.holders.getInstitutionalHolders(Ticker("MSFT")).map { holders =>
         // Should have institutional holders
         assert(holders.nonEmpty, "MSFT should have institutional holders")
 
@@ -60,9 +60,9 @@ class HoldersDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getMutualFundHolders should return fund holders for GOOGL") {
+  test("returns mutual fund holders for GOOGL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getMutualFundHolders(Ticker("GOOGL")).map { holders =>
+      client.holders.getMutualFundHolders(Ticker("GOOGL")).map { holders =>
         // Should have mutual fund holders
         assert(holders.nonEmpty, "GOOGL should have mutual fund holders")
 
@@ -74,9 +74,9 @@ class HoldersDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getInsiderTransactions should return recent transactions for AAPL") {
+  test("returns recent insider transactions for AAPL sorted by date") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getInsiderTransactions(Ticker("AAPL")).map { transactions =>
+      client.holders.getInsiderTransactions(Ticker("AAPL")).map { transactions =>
         // AAPL typically has insider activity
         assert(transactions.nonEmpty, "AAPL should have insider transactions")
 
@@ -93,9 +93,9 @@ class HoldersDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getInsiderRoster should return insider positions for TSLA") {
+  test("returns insider positions for TSLA") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getInsiderRoster(Ticker("TSLA")).map { roster =>
+      client.holders.getInsiderRoster(Ticker("TSLA")).map { roster =>
         // Should have insider roster
         assert(roster.nonEmpty, "TSLA should have insider roster")
 
@@ -108,9 +108,9 @@ class HoldersDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getHoldersData should return comprehensive data for NVDA") {
+  test("returns comprehensive holders data for NVDA") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getHoldersData(Ticker("NVDA")).map { dataOpt =>
+      client.holders.getHoldersData(Ticker("NVDA")).map { dataOpt =>
         assert(dataOpt.isDefined, "Result should be defined for NVDA")
         val data = dataOpt.get
 
@@ -123,10 +123,10 @@ class HoldersDataSpec extends CatsEffectSuite {
     }
   }
 
-  test("getHoldersData should work for stocks with limited holder data") {
+  test("returns holders data for stock with limited data (IBM)") {
     YFinanceClient.resource[IO](config).use { client =>
       // Use a smaller company that should still have some holder data
-      client.getHoldersData(Ticker("IBM")).map { dataOpt =>
+      client.holders.getHoldersData(Ticker("IBM")).map { dataOpt =>
         assert(dataOpt.isDefined, "Result should be defined for IBM")
         // IBM should have at least some holders data
         assert(dataOpt.get.nonEmpty, "IBM should have holders data")

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/MultiTickerDownloadSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/MultiTickerDownloadSpec.scala
@@ -17,7 +17,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("downloadCharts should return data for multiple valid tickers") {
+  test("returns chart data for multiple valid tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT"), Ticker("GOOGL"))
 
@@ -33,7 +33,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadCharts with date range should return data") {
+  test("returns chart data within date range for multiple tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT"))
       val since = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
@@ -48,7 +48,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadCharts should fail when any ticker is invalid") {
+  test("fails when any ticker is invalid") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"), Ticker("INVALIDTICKER123"))
 
@@ -58,7 +58,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadCharts should respect parallelism parameter") {
+  test("respects parallelism parameter") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(
         Ticker("AAPL"),
@@ -74,7 +74,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadStocks should return data for multiple valid tickers") {
+  test("returns stock data for multiple valid tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT"))
 
@@ -86,7 +86,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadStocks should fail when any ticker is invalid") {
+  test("fails when any stock ticker is invalid") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"), Ticker("INVALIDTICKER123"))
 
@@ -96,7 +96,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadFinancialStatements should return data for multiple tickers") {
+  test("returns financial statements for multiple tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT"))
 
@@ -109,7 +109,7 @@ class MultiTickerDownloadSpec extends CatsEffectSuite {
     }
   }
 
-  test("downloadCharts for single ticker in NonEmptyList should work") {
+  test("returns chart data for single ticker in NonEmptyList") {
     YFinanceClient.resource[IO](config).use { client =>
       val tickers = NonEmptyList.of(Ticker("AAPL"))
 

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/OptionsChainSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/OptionsChainSpec.scala
@@ -18,9 +18,9 @@ class OptionsChainSpec extends CatsEffectSuite {
 
   val testTicker: Ticker = Ticker("AAPL")
 
-  test("getOptionExpirations should return sorted list of expiration dates for AAPL") {
+  test("returns sorted future expiration dates for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getOptionExpirations(testTicker).map { expirationsOpt =>
+      client.options.getOptionExpirations(testTicker).map { expirationsOpt =>
         assert(expirationsOpt.isDefined, "Expirations should be defined for AAPL")
 
         val expirations = expirationsOpt.get
@@ -38,15 +38,15 @@ class OptionsChainSpec extends CatsEffectSuite {
     }
   }
 
-  test("getOptionChain should return valid chain for nearest expiration") {
+  test("returns valid option chain for nearest expiration") {
     YFinanceClient.resource[IO](config).use { client =>
       for {
-        expirationsOpt <- client.getOptionExpirations(testTicker)
+        expirationsOpt <- client.options.getOptionExpirations(testTicker)
         _ = assert(expirationsOpt.isDefined, "Need expirations to test chain")
         expirations = expirationsOpt.get
         nearestExpiration = expirations.head
 
-        chainOpt <- client.getOptionChain(testTicker, nearestExpiration)
+        chainOpt <- client.options.getOptionChain(testTicker, nearestExpiration)
       } yield {
         assert(chainOpt.isDefined, s"Chain should exist for $nearestExpiration")
 
@@ -75,9 +75,9 @@ class OptionsChainSpec extends CatsEffectSuite {
     }
   }
 
-  test("getFullOptionChain should return complete data for AAPL") {
+  test("returns complete option chain data for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getFullOptionChain(testTicker).map { fullChainOpt =>
+      client.options.getFullOptionChain(testTicker).map { fullChainOpt =>
         assert(fullChainOpt.isDefined, "Full chain should be defined")
 
         val fullChain = fullChainOpt.get
@@ -102,9 +102,9 @@ class OptionsChainSpec extends CatsEffectSuite {
     }
   }
 
-  test("implied volatility should be positive (converted to percentage)") {
+  test("implied volatility is positive for all contracts") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getFullOptionChain(testTicker).map { fullChainOpt =>
+      client.options.getFullOptionChain(testTicker).map { fullChainOpt =>
         assert(fullChainOpt.isDefined)
 
         val chain = fullChainOpt.get.nearestChain.get

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/SearchSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/SearchSpec.scala
@@ -1,0 +1,129 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.Ticker
+
+import scala.concurrent.duration.*
+
+class SearchSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  test("returns quotes for well-known company name") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("Apple").map { result =>
+        assert(result.nonEmpty, "Search for 'Apple' should return results")
+        assert(result.quotes.nonEmpty, "Should have quote results")
+        assert(
+          result.quotes.exists(_.symbol == "AAPL"),
+          s"AAPL should appear in results: ${result.symbols}"
+        )
+      }
+    }
+  }
+
+  test("returns quotes for ticker symbol") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("MSFT").map { result =>
+        assert(result.quotes.nonEmpty, "Search for 'MSFT' should return quotes")
+        assert(
+          result.quotes.exists(_.symbol == "MSFT"),
+          s"MSFT should appear in results: ${result.symbols}"
+        )
+        val msft = result.quotes.find(_.symbol == "MSFT").get
+        assert(msft.isEquity, "MSFT should be an equity")
+      }
+    }
+  }
+
+  test("returns news items with valid structure") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("Tesla", newsCount = 3).map { result =>
+        result.news.foreach { newsItem =>
+          assert(newsItem.title.nonEmpty, "News title should not be empty")
+          assert(newsItem.publisher.nonEmpty, "News publisher should not be empty")
+          assert(newsItem.link.nonEmpty, "News link should not be empty")
+          assert(newsItem.uuid.nonEmpty, "News UUID should not be empty")
+        }
+      }
+    }
+  }
+
+  test("returns quote results with valid structure") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("NVDA").map { result =>
+        assert(result.quotes.nonEmpty, "Should have quote results for NVDA")
+        val nvda = result.quotes.find(_.symbol == "NVDA")
+        assert(nvda.isDefined, "NVDA should be in results")
+        val q = nvda.get
+        assert(q.symbol == "NVDA", "Symbol should be NVDA")
+        assert(q.exchangeDisplay.isDefined, "Exchange display should be defined")
+        assert(q.displayName.nonEmpty, "Display name should not be empty")
+        assert(q.toTicker == Ticker("NVDA"), "toTicker should produce correct Ticker")
+      }
+    }
+  }
+
+  test("respects maxResults parameter") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("Bank", maxResults = 3).map { result =>
+        assert(result.quotes.size <= 3, s"Should have at most 3 quotes, got ${result.quotes.size}")
+      }
+    }
+  }
+
+  test("filters out non-Yahoo entities") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("Apple").map { result =>
+        result.quotes.foreach { q =>
+          assert(q.symbol.nonEmpty, s"All quotes should have a symbol, found: $q")
+        }
+      }
+    }
+  }
+
+  test("returns empty results for nonsense query") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("xyznonexistentticker12345").map { result =>
+        assert(result.quotes.isEmpty, "Should have no quote results for nonsense query")
+      }
+    }
+  }
+
+  test("returns results for misspelled queries when fuzzy query enabled") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("Aple", enableFuzzyQuery = true).map { result =>
+        assert(result.quotes.nonEmpty, "Fuzzy search for 'Aple' should return results")
+      }
+    }
+  }
+
+  test("returns results for broad query") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("S&P 500").map { result =>
+        assert(result.quotes.nonEmpty, "Search for 'S&P 500' should return results")
+        val types = result.quotes.flatMap(_.quoteType).distinct
+        assert(types.nonEmpty, s"Should have type information: $types")
+      }
+    }
+  }
+
+  test("provides symbols, tickers, and topQuote convenience accessors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.search("Amazon").map { result =>
+        assert(result.nonEmpty, "Should have results")
+        assert(result.symbols.nonEmpty, "symbols should not be empty")
+        assert(result.tickers.nonEmpty, "tickers should not be empty")
+
+        val top = result.topQuote
+        assert(top.isDefined, "topQuote should be defined")
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/SplitsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/SplitsSpec.scala
@@ -15,9 +15,9 @@ class SplitsSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getSplits should return splits for a stock with split history (AAPL)") {
+  test("returns splits for stock with split history (AAPL)") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { splitsOpt =>
+      client.charts.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { splitsOpt =>
         assert(splitsOpt.isDefined, "Result should be defined for AAPL")
         val splits = splitsOpt.get
 
@@ -39,9 +39,9 @@ class SplitsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getSplits should identify forward and reverse splits correctly") {
+  test("identifies forward and reverse splits correctly") {
     YFinanceClient.resource[IO](config).use { client =>
-      client.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { splitsOpt =>
+      client.charts.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.Max).map { splitsOpt =>
         splitsOpt.foreach { splits =>
           splits.foreach { split =>
             // Apple's splits have been forward splits
@@ -57,10 +57,10 @@ class SplitsSpec extends CatsEffectSuite {
     }
   }
 
-  test("getSplits should return empty list for stocks without splits in range") {
+  test("returns empty list when no splits in range") {
     YFinanceClient.resource[IO](config).use { client =>
       // Use a short range where most stocks won't have splits
-      client.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.`1Month`).map { splitsOpt =>
+      client.charts.getSplits(Ticker("AAPL"), Interval.`1Day`, Range.`1Month`).map { splitsOpt =>
         assert(splitsOpt.isDefined, "Result should be defined")
         // Likely empty for 1 month, but structure should be valid
         splitsOpt.foreach { splits =>

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/TickersSpec.scala
@@ -18,7 +18,7 @@ class TickersSpec extends CatsEffectSuite {
 
   // --- Fail-Fast Tests ---
 
-  test("history should return chart data for all tickers") {
+  test("returns chart data for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.history(Interval.`1Day`, Range.`1Month`).map { results =>
@@ -32,7 +32,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("history with date range should return chart data") {
+  test("returns chart data within date range") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       val since = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC)
@@ -46,7 +46,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("info should return stock data for all tickers") {
+  test("returns stock data for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.info.map { results =>
@@ -57,7 +57,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("financials should return financial statements for all tickers") {
+  test("returns financial statements for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.financials().map { results =>
@@ -69,7 +69,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("dividends should return dividend events for all tickers") {
+  test("returns dividend events for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.dividends(Interval.`1Day`, Range.Max).map { results =>
@@ -81,7 +81,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("splits should return split events for all tickers") {
+  test("returns split events for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.splits(Interval.`1Day`, Range.Max).map { results =>
@@ -90,7 +90,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("corporateActions should return combined actions for all tickers") {
+  test("returns combined corporate actions for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.corporateActions(Interval.`1Day`, Range.Max).map { results =>
@@ -99,7 +99,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("holdersData should return holders information for all tickers") {
+  test("returns holders information for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.holdersData.map { results =>
@@ -108,7 +108,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("analystData should return analyst information for all tickers") {
+  test("returns analyst information for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.analystData.map { results =>
@@ -117,7 +117,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("optionExpirations should return expiration dates for all tickers") {
+  test("returns option expiration dates for all tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.optionExpirations.map { results =>
@@ -129,7 +129,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("history should fail when any ticker is invalid") {
+  test("fails when any ticker is invalid") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "INVALIDTICKER123")
       t.history(Interval.`1Day`, Range.`1Month`).attempt.map { result =>
@@ -140,7 +140,7 @@ class TickersSpec extends CatsEffectSuite {
 
   // --- Error-Tolerant Tests ---
 
-  test("attemptHistory should return Right for valid tickers") {
+  test("returns Right for valid tickers in error-tolerant mode") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT")
       t.attemptHistory(Interval.`1Day`, Range.`1Month`).map { results =>
@@ -152,7 +152,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("attemptHistory should return Left for invalid tickers without failing") {
+  test("returns Left for invalid tickers without failing") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "INVALIDTICKER123")
       t.attemptHistory(Interval.`1Day`, Range.`1Month`).map { results =>
@@ -163,7 +163,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("attemptInfo should return Right for valid and Left for invalid") {
+  test("returns Right for valid and Left for invalid tickers") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "INVALIDTICKER123")
       t.attemptInfo.map { results =>
@@ -176,7 +176,7 @@ class TickersSpec extends CatsEffectSuite {
 
   // --- Chaining Tests ---
 
-  test("add then history should include the added ticker") {
+  test("includes added ticker in subsequent history call") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.single[IO](client, Ticker("AAPL")).add(Ticker("MSFT"))
       t.history(Interval.`1Day`, Range.`1Month`).map { results =>
@@ -187,7 +187,7 @@ class TickersSpec extends CatsEffectSuite {
     }
   }
 
-  test("withParallelism should work with data methods") {
+  test("respects parallelism setting in data methods") {
     YFinanceClient.resource[IO](config).use { client =>
       val t = Tickers.of[IO](client, "AAPL", "MSFT", "GOOGL").withParallelism(1)
       t.history(Interval.`1Day`, Range.`1Month`).map { results =>

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/YFinanceClientSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/YFinanceClientSpec.scala
@@ -14,11 +14,11 @@ class YFinanceClientSpec extends CatsEffectSuite {
     retries = 3
   )
 
-  test("getStock should return correct symbol, longName and exchangeName for AAPL") {
+  test("returns symbol, longName, and exchangeName for AAPL") {
     YFinanceClient.resource[IO](config).use { client =>
       val ticker = Ticker("AAPL")
 
-      client.getStock(ticker).map { stockResultOpt =>
+      client.charts.getStock(ticker).map { stockResultOpt =>
         assert(stockResultOpt.isDefined, "Stock result should be defined for AAPL")
 
         val stockResult = stockResultOpt.get

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/AnalystDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/AnalystDataSpec.scala
@@ -20,49 +20,49 @@ class AnalystDataSpec extends FunSuite {
     recommendationMean = 1.8
   )
 
-  test("meanUpsidePercent should calculate positive upside correctly") {
+  test("calculates positive upside percent from current to mean target") {
     // (215 - 200) / 200 * 100 = 7.5%
     assert(Math.abs(priceTargets.meanUpsidePercent - 7.5) < 0.001)
   }
 
-  test("meanUpsidePercent should calculate negative downside correctly") {
+  test("calculates negative downside when current exceeds mean target") {
     val overpriced = priceTargets.copy(currentPrice = 230.0)
     // (215 - 230) / 230 * 100 = -6.521...
     assert(overpriced.meanUpsidePercent < 0)
   }
 
-  test("meanUpsidePercent should return 0 when current price is 0") {
+  test("returns zero upside when current price is zero") {
     val zeroPrice = priceTargets.copy(currentPrice = 0.0)
     assertEquals(zeroPrice.meanUpsidePercent, 0.0)
   }
 
-  test("medianUpsidePercent should calculate correctly") {
+  test("calculates median upside percent") {
     // (220 - 200) / 200 * 100 = 10.0%
     assert(Math.abs(priceTargets.medianUpsidePercent - 10.0) < 0.001)
   }
 
-  test("targetRange should calculate high minus low") {
+  test("calculates target range as high minus low") {
     // 250 - 180 = 70
     assert(Math.abs(priceTargets.targetRange - 70.0) < 0.001)
   }
 
-  test("targetSpreadPercent should calculate spread relative to mean") {
+  test("calculates target spread as percentage of mean") {
     // 70 / 215 * 100 = 32.558...
     assert(priceTargets.targetSpreadPercent > 32.0 && priceTargets.targetSpreadPercent < 33.0)
   }
 
-  test("targetSpreadPercent should return 0 when mean is 0") {
+  test("returns zero spread when mean target is zero") {
     val zeroMean = priceTargets.copy(targetMean = 0.0)
     assertEquals(zeroMean.targetSpreadPercent, 0.0)
   }
 
-  test("isBelowAllTargets should return true when price below lowest target") {
+  test("detects price below all analyst targets") {
     val cheapStock = priceTargets.copy(currentPrice = 170.0)
     assert(cheapStock.isBelowAllTargets)
     assert(!priceTargets.isBelowAllTargets)
   }
 
-  test("isAboveAllTargets should return true when price above highest target") {
+  test("detects price above all analyst targets") {
     val expensiveStock = priceTargets.copy(currentPrice = 260.0)
     assert(expensiveStock.isAboveAllTargets)
     assert(!priceTargets.isAboveAllTargets)
@@ -79,48 +79,48 @@ class AnalystDataSpec extends FunSuite {
     strongSell = 0
   )
 
-  test("totalAnalysts should sum all categories") {
+  test("sums all analyst categories") {
     assertEquals(recTrend.totalAnalysts, 49)
   }
 
-  test("totalBullish should sum strongBuy and buy") {
+  test("sums strong buy and buy into bullish count") {
     assertEquals(recTrend.totalBullish, 40)
   }
 
-  test("totalBearish should sum sell and strongSell") {
+  test("sums sell and strong sell into bearish count") {
     assertEquals(recTrend.totalBearish, 1)
   }
 
-  test("bullishPercent should calculate correctly") {
+  test("calculates bullish percent of total analysts") {
     // 40 / 49 * 100 = 81.63...
     assert(recTrend.bullishPercent > 81.0 && recTrend.bullishPercent < 82.0)
   }
 
-  test("bearishPercent should return 0 when no analysts") {
+  test("returns zero bearish percent when no analysts") {
     val empty = recTrend.copy(strongBuy = 0, buy = 0, hold = 0, sell = 0, strongSell = 0)
     assertEquals(empty.bearishPercent, 0.0)
   }
 
-  test("netSentiment should be positive when more bulls") {
+  test("net sentiment is positive when more bulls than bears") {
     assert(recTrend.netSentiment > 0)
     assertEquals(recTrend.netSentiment, 39) // 40 - 1
   }
 
-  test("netSentiment should be negative when more bears") {
+  test("net sentiment is negative when more bears than bulls") {
     val bearish = recTrend.copy(strongBuy = 0, buy = 1, sell = 10, strongSell = 5)
     assert(bearish.netSentiment < 0)
   }
 
-  test("isBullish should return true when bullish > 50%") {
+  test("is bullish when majority of analysts are bullish") {
     assert(recTrend.isBullish)
   }
 
-  test("isBullish should return false when bullish <= 50%") {
+  test("is not bullish when majority are neutral or bearish") {
     val neutral = recTrend.copy(strongBuy = 1, buy = 1, hold = 10, sell = 1, strongSell = 1)
     assert(!neutral.isBullish)
   }
 
-  test("RecommendationTrend ordering should sort current month first") {
+  test("sorts recommendation trends with current month first") {
     val trends = List(
       recTrend.copy(period = "-2m"),
       recTrend.copy(period = "0m"),
@@ -141,32 +141,32 @@ class AnalystDataSpec extends FunSuite {
     action = UpgradeDowngradeAction.Upgrade
   )
 
-  test("isUpgrade should return true for upgrade actions") {
+  test("identifies upgrade actions") {
     assert(upgrade.isUpgrade)
     assert(!upgrade.isDowngrade)
     assert(!upgrade.isInitiation)
     assert(!upgrade.isMaintained)
   }
 
-  test("isDowngrade should return true for downgrade actions") {
+  test("identifies downgrade actions") {
     val downgrade = upgrade.copy(action = UpgradeDowngradeAction.Downgrade)
     assert(downgrade.isDowngrade)
     assert(!downgrade.isUpgrade)
   }
 
-  test("isInitiation should return true for init actions") {
+  test("identifies initiation actions") {
     val initiation = upgrade.copy(action = UpgradeDowngradeAction.Initiation, fromGrade = None)
     assert(initiation.isInitiation)
   }
 
-  test("isMaintained should return true for main and reit actions") {
+  test("identifies maintained and reiterated actions") {
     val maintained = upgrade.copy(action = UpgradeDowngradeAction.Maintained)
     val reiterated = upgrade.copy(action = UpgradeDowngradeAction.Reiterated)
     assert(maintained.isMaintained)
     assert(reiterated.isMaintained)
   }
 
-  test("UpgradeDowngradeAction.fromString should handle known actions") {
+  test("parses known upgrade/downgrade action strings") {
     assertEquals(UpgradeDowngradeAction.fromString("up"), UpgradeDowngradeAction.Upgrade)
     assertEquals(UpgradeDowngradeAction.fromString("down"), UpgradeDowngradeAction.Downgrade)
     assertEquals(UpgradeDowngradeAction.fromString("main"), UpgradeDowngradeAction.Maintained)
@@ -174,13 +174,13 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(UpgradeDowngradeAction.fromString("init"), UpgradeDowngradeAction.Initiation)
   }
 
-  test("UpgradeDowngradeAction.fromString should handle unknown actions with Other") {
+  test("wraps unknown action strings in Other") {
     val other = UpgradeDowngradeAction.fromString("suspend")
     assertEquals(other, UpgradeDowngradeAction.Other("suspend"))
     assertEquals(other.value, "suspend")
   }
 
-  test("UpgradeDowngrade ordering should sort most recent first") {
+  test("sorts upgrade/downgrade events most recent first") {
     val events = List(
       upgrade.copy(date = LocalDate.of(2023, 6, 1)),
       upgrade.copy(date = LocalDate.of(2024, 3, 15)),
@@ -210,36 +210,36 @@ class AnalystDataSpec extends FunSuite {
     growth = Some(0.12)
   )
 
-  test("EarningsEstimate estimateRange should calculate high minus low") {
+  test("calculates earnings estimate range as high minus low") {
     val range = earningsEst.estimateRange
     assert(range.isDefined)
     assert(Math.abs(range.get - 0.80) < 0.001)
   }
 
-  test("EarningsEstimate estimateSpreadPercent should calculate spread relative to average") {
+  test("calculates earnings estimate spread as percentage of average") {
     val spread = earningsEst.estimateSpreadPercent
     assert(spread.isDefined)
     // 0.80 / 2.04 * 100 = 39.21...
     assert(spread.get > 39.0 && spread.get < 40.0)
   }
 
-  test("EarningsEstimate estimateSpreadPercent should handle zero average") {
+  test("returns no estimate spread when average is zero") {
     val zeroAvg = earningsEst.copy(avg = Some(0.0))
     assertEquals(zeroAvg.estimateSpreadPercent, None)
   }
 
-  test("EarningsEstimate isQuarterly should identify quarterly periods") {
+  test("identifies quarterly earnings estimate periods") {
     assert(earningsEst.isQuarterly)
     assert(!earningsEst.isYearly)
   }
 
-  test("EarningsEstimate isYearly should identify yearly periods") {
+  test("identifies yearly earnings estimate periods") {
     val yearly = earningsEst.copy(period = "0y")
     assert(yearly.isYearly)
     assert(!yearly.isQuarterly)
   }
 
-  test("EarningsEstimate estimateRange should return None when data is missing") {
+  test("returns no earnings estimate range when data is absent") {
     val noHigh = earningsEst.copy(high = None)
     assertEquals(noHigh.estimateRange, None)
   }
@@ -257,24 +257,24 @@ class AnalystDataSpec extends FunSuite {
     growth = Some(-0.029)
   )
 
-  test("RevenueEstimate estimateRange should calculate high minus low") {
+  test("calculates revenue estimate range as high minus low") {
     val range = revenueEst.estimateRange
     assert(range.isDefined)
     assertEquals(range.get, 55838000000L - 48955000000L)
   }
 
-  test("RevenueEstimate isQuarterly should identify quarterly periods") {
+  test("identifies quarterly revenue estimate periods") {
     assert(revenueEst.isQuarterly)
     assert(!revenueEst.isYearly)
   }
 
-  test("RevenueEstimate isYearly should identify yearly periods") {
+  test("identifies yearly revenue estimate periods") {
     val yearly = revenueEst.copy(period = "+1y")
     assert(yearly.isYearly)
     assert(!yearly.isQuarterly)
   }
 
-  test("RevenueEstimate estimateRange should return None when data is missing") {
+  test("returns no revenue estimate range when data is absent") {
     val noData = revenueEst.copy(high = None, low = None)
     assertEquals(noData.estimateRange, None)
   }
@@ -290,34 +290,34 @@ class AnalystDataSpec extends FunSuite {
     ninetyDaysAgo = Some(2.07)
   )
 
-  test("changeSevenDays should calculate difference") {
+  test("calculates EPS change over seven days") {
     val change = epsTrend.changeSevenDays
     assert(change.isDefined)
     assert(Math.abs(change.get - 0.02) < 0.001)
   }
 
-  test("changeThirtyDays should calculate difference") {
+  test("calculates EPS change over thirty days") {
     val change = epsTrend.changeThirtyDays
     assert(change.isDefined)
     assert(Math.abs(change.get - 0.04) < 0.001)
   }
 
-  test("changeNinetyDays should calculate difference") {
+  test("calculates EPS change over ninety days") {
     val change = epsTrend.changeNinetyDays
     assert(change.isDefined)
     assert(Math.abs(change.get - (-0.03)) < 0.001)
   }
 
-  test("isTrendingUp should return true for positive 30-day change") {
+  test("trends up when 30-day EPS change is positive") {
     assertEquals(epsTrend.isTrendingUp, Some(true))
   }
 
-  test("isTrendingUp should return false for negative 30-day change") {
+  test("trends down when 30-day EPS change is negative") {
     val declining = epsTrend.copy(current = Some(1.95))
     assertEquals(declining.isTrendingUp, Some(false))
   }
 
-  test("EpsTrend change methods should return None when data is missing") {
+  test("returns no EPS trend data when current estimate is absent") {
     val noData = epsTrend.copy(current = None)
     assertEquals(noData.changeSevenDays, None)
     assertEquals(noData.changeThirtyDays, None)
@@ -335,20 +335,20 @@ class AnalystDataSpec extends FunSuite {
     downLast90Days = Some(3)
   )
 
-  test("netRevisions30Days should calculate up minus down") {
+  test("calculates net EPS revisions as ups minus downs") {
     assertEquals(epsRevisions.netRevisions30Days, Some(8))
   }
 
-  test("isPositiveTrend should return true when more ups") {
+  test("has positive revision trend when ups exceed downs") {
     assertEquals(epsRevisions.isPositiveTrend, Some(true))
   }
 
-  test("isPositiveTrend should return false when more downs") {
+  test("has negative revision trend when downs exceed ups") {
     val negative = epsRevisions.copy(upLast30Days = Some(1), downLast30Days = Some(5))
     assertEquals(negative.isPositiveTrend, Some(false))
   }
 
-  test("netRevisions30Days should return None when data is missing") {
+  test("returns no revision data when values are absent") {
     val noData = epsRevisions.copy(upLast30Days = None)
     assertEquals(noData.netRevisions30Days, None)
     assertEquals(noData.isPositiveTrend, None)
@@ -365,32 +365,32 @@ class AnalystDataSpec extends FunSuite {
     surprisePercent = Some(6.3)
   )
 
-  test("isBeat should return true when positive difference") {
+  test("identifies earnings beat when EPS exceeds estimate") {
     assertEquals(earningsHistoryEntry.isBeat, Some(true))
     assertEquals(earningsHistoryEntry.isMiss, Some(false))
   }
 
-  test("isMiss should return true when negative difference") {
+  test("identifies earnings miss when EPS falls short") {
     val miss = earningsHistoryEntry.copy(epsDifference = Some(-0.05))
     assertEquals(miss.isMiss, Some(true))
     assertEquals(miss.isBeat, Some(false))
   }
 
-  test("isMet should return true when zero difference") {
+  test("identifies met earnings when EPS matches estimate") {
     val met = earningsHistoryEntry.copy(epsDifference = Some(0.0))
     assertEquals(met.isMet, Some(true))
     assertEquals(met.isBeat, Some(false))
     assertEquals(met.isMiss, Some(false))
   }
 
-  test("EarningsHistory isBeat should return None when data is missing") {
+  test("returns no beat/miss status when EPS difference is absent") {
     val noData = earningsHistoryEntry.copy(epsDifference = None)
     assertEquals(noData.isBeat, None)
     assertEquals(noData.isMiss, None)
     assertEquals(noData.isMet, None)
   }
 
-  test("EarningsHistory ordering should sort most recent quarter first") {
+  test("sorts earnings history most recent quarter first") {
     val entries = List(
       earningsHistoryEntry.copy(quarter = LocalDate.of(2023, 6, 30)),
       earningsHistoryEntry.copy(quarter = LocalDate.of(2024, 3, 31)),
@@ -416,22 +416,22 @@ class AnalystDataSpec extends FunSuite {
     indexSymbol = Some("SP5")
   )
 
-  test("isOutperforming should return true when stock growth exceeds index") {
+  test("outperforms when stock growth exceeds index") {
     assertEquals(growthEst.isOutperforming, Some(true))
   }
 
-  test("isOutperforming should return false when stock underperforms") {
+  test("underperforms when stock growth trails index") {
     val underperforming = growthEst.copy(stockGrowth = Some(0.05))
     assertEquals(underperforming.isOutperforming, Some(false))
   }
 
-  test("growthDifferential should calculate difference") {
+  test("calculates growth differential as stock minus index") {
     val diff = growthEst.growthDifferential
     assert(diff.isDefined)
     assert(Math.abs(diff.get - 0.04) < 0.001)
   }
 
-  test("isOutperforming should return None when data is missing") {
+  test("returns no performance comparison when growth data is absent") {
     val noStock = growthEst.copy(stockGrowth = None)
     assertEquals(noStock.isOutperforming, None)
     assertEquals(noStock.growthDifferential, None)
@@ -443,41 +443,41 @@ class AnalystDataSpec extends FunSuite {
 
   // --- AnalystData tests ---
 
-  test("isEmpty should return true for empty AnalystData") {
+  test("empty instance is empty") {
     assert(AnalystData.empty.isEmpty)
   }
 
-  test("nonEmpty should return true when priceTargets is present") {
+  test("is non-empty when price targets are present") {
     val withTargets = AnalystData.empty.copy(priceTargets = Some(priceTargets))
     assert(withTargets.nonEmpty)
   }
 
-  test("nonEmpty should return true when recommendations is present") {
+  test("is non-empty when recommendations are present") {
     val withRecs = AnalystData.empty.copy(recommendations = List(recTrend))
     assert(withRecs.nonEmpty)
   }
 
-  test("nonEmpty should return true when earningsEstimates is present") {
+  test("is non-empty when earnings estimates are present") {
     val withEstimates = AnalystData.empty.copy(earningsEstimates = List(earningsEst))
     assert(withEstimates.nonEmpty)
   }
 
-  test("nonEmpty should return true when upgradeDowngradeHistory is present") {
+  test("is non-empty when upgrade/downgrade history is present") {
     val withHistory = AnalystData.empty.copy(upgradeDowngradeHistory = List(upgrade))
     assert(withHistory.nonEmpty)
   }
 
-  test("nonEmpty should return true when earningsHistory is present") {
+  test("is non-empty when earnings history is present") {
     val withEarnings = AnalystData.empty.copy(earningsHistory = List(earningsHistoryEntry))
     assert(withEarnings.nonEmpty)
   }
 
-  test("nonEmpty should return true when growthEstimates is present") {
+  test("is non-empty when growth estimates are present") {
     val withGrowth = AnalystData.empty.copy(growthEstimates = List(growthEst))
     assert(withGrowth.nonEmpty)
   }
 
-  test("currentRecommendation should find period 0m") {
+  test("finds current month recommendation (0m)") {
     val data = AnalystData.empty.copy(recommendations =
       List(
         recTrend.copy(period = "-1m"),
@@ -490,7 +490,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(current.get.period, "0m")
   }
 
-  test("currentRecommendation should return None when no 0m period") {
+  test("returns no current recommendation when 0m period absent") {
     val data = AnalystData.empty.copy(recommendations =
       List(
         recTrend.copy(period = "-1m"),
@@ -500,7 +500,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(data.currentRecommendation, None)
   }
 
-  test("currentQuarterEarningsEstimate should find period 0q") {
+  test("finds current quarter earnings estimate (0q)") {
     val data = AnalystData.empty.copy(earningsEstimates =
       List(
         earningsEst.copy(period = "+1q"),
@@ -513,7 +513,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(current.get.period, "0q")
   }
 
-  test("currentQuarterRevenueEstimate should find period 0q") {
+  test("finds current quarter revenue estimate (0q)") {
     val data = AnalystData.empty.copy(revenueEstimates =
       List(
         revenueEst.copy(period = "+1q"),
@@ -525,7 +525,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(current.get.period, "0q")
   }
 
-  test("currentYearEarningsEstimate should find period 0y") {
+  test("finds current year earnings estimate (0y)") {
     val data = AnalystData.empty.copy(earningsEstimates =
       List(
         earningsEst.copy(period = "0q"),
@@ -538,7 +538,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(current.get.period, "0y")
   }
 
-  test("consecutiveBeats should count consecutive beats from most recent") {
+  test("counts consecutive earnings beats from most recent") {
     val history = List(
       EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", Some(1.5), Some(1.4), Some(0.1), Some(7.0)),
       EarningsHistory(LocalDate.of(2023, 12, 31), "-2q", Some(1.3), Some(1.2), Some(0.1), Some(8.0)),
@@ -551,7 +551,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(data.consecutiveBeats, 2)
   }
 
-  test("consecutiveBeats should return 0 when most recent is a miss") {
+  test("consecutive beats is zero when most recent is a miss") {
     val history = List(
       EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", Some(1.3), Some(1.4), Some(-0.1), Some(-7.0)),
       EarningsHistory(LocalDate.of(2023, 12, 31), "-2q", Some(1.3), Some(1.2), Some(0.1), Some(8.0))
@@ -560,7 +560,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(data.consecutiveBeats, 0)
   }
 
-  test("recentUpgrades should filter and limit upgrades") {
+  test("filters and limits recent upgrades") {
     val events = List(
       UpgradeDowngrade(LocalDate.of(2024, 3, 1), "A", "Buy", Some("Hold"), UpgradeDowngradeAction.Upgrade),
       UpgradeDowngrade(LocalDate.of(2024, 2, 1), "B", "Hold", Some("Buy"), UpgradeDowngradeAction.Downgrade),
@@ -576,7 +576,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(upgrades(1).firm, "C")
   }
 
-  test("recentDowngrades should filter and limit downgrades") {
+  test("filters and limits recent downgrades") {
     val events = List(
       UpgradeDowngrade(LocalDate.of(2024, 3, 1), "A", "Buy", Some("Hold"), UpgradeDowngradeAction.Upgrade),
       UpgradeDowngrade(LocalDate.of(2024, 2, 1), "B", "Hold", Some("Buy"), UpgradeDowngradeAction.Downgrade),
@@ -589,7 +589,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(downgrades.head.firm, "B")
   }
 
-  test("earningsBeatRate should calculate percentage of beats") {
+  test("calculates earnings beat rate as percentage") {
     val history = List(
       EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", Some(1.5), Some(1.4), Some(0.1), Some(7.0)),
       EarningsHistory(LocalDate.of(2023, 12, 31), "-2q", Some(1.3), Some(1.2), Some(0.1), Some(8.0)),
@@ -603,11 +603,11 @@ class AnalystDataSpec extends FunSuite {
     assert(Math.abs(rate.get - 75.0) < 0.001)
   }
 
-  test("earningsBeatRate should return None for empty history") {
+  test("returns no beat rate for empty history") {
     assertEquals(AnalystData.empty.earningsBeatRate, None)
   }
 
-  test("earningsBeatRate should return None when all epsDifference is None") {
+  test("returns no beat rate when all EPS differences are absent") {
     val history = List(
       EarningsHistory(LocalDate.of(2024, 3, 31), "-1q", None, None, None, None)
     )
@@ -615,7 +615,7 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(data.earningsBeatRate, None)
   }
 
-  test("empty AnalystData should return None for all accessors") {
+  test("empty instance returns defaults for all accessors") {
     val data = AnalystData.empty
     assertEquals(data.currentRecommendation, None)
     assertEquals(data.currentQuarterEarningsEstimate, None)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/BalanceSheetSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/BalanceSheetSpec.scala
@@ -48,21 +48,21 @@ class BalanceSheetSpec extends FunSuite {
     investedCapital = Some(163604000000.0)
   )
 
-  test("currentRatio should calculate correctly") {
+  test("calculates current ratio from current assets and liabilities") {
     val ratio = sampleSheet.currentRatio
     assert(ratio.isDefined)
     // 152987000000 / 176392000000 ~ 0.8673
     assert(Math.abs(ratio.get - 0.8673) < 0.001)
   }
 
-  test("quickRatio should calculate correctly") {
+  test("calculates quick ratio excluding inventory") {
     val ratio = sampleSheet.quickRatio
     assert(ratio.isDefined)
     // (152987000000 - 7286000000) / 176392000000 ~ 0.8260
     assert(Math.abs(ratio.get - 0.8260) < 0.001)
   }
 
-  test("quickRatio should handle missing inventory") {
+  test("treats missing inventory as zero in quick ratio") {
     val sheet = sampleSheet.copy(inventory = None)
     val ratio = sheet.quickRatio
     assert(ratio.isDefined)
@@ -71,55 +71,55 @@ class BalanceSheetSpec extends FunSuite {
     assert(Math.abs(ratio.get - 0.8673) < 0.001)
   }
 
-  test("debtToEquity should calculate correctly") {
+  test("calculates debt-to-equity ratio") {
     val ratio = sampleSheet.debtToEquity
     assert(ratio.isDefined)
     // 106654000000 / 56950000000 ~ 1.8727
     assert(Math.abs(ratio.get - 1.8727) < 0.001)
   }
 
-  test("debtToAssets should calculate correctly") {
+  test("calculates debt-to-assets ratio") {
     val ratio = sampleSheet.debtToAssets
     assert(ratio.isDefined)
     // 106654000000 / 364980000000 ~ 0.2922
     assert(Math.abs(ratio.get - 0.2922) < 0.001)
   }
 
-  test("bookValuePerShare should calculate correctly") {
+  test("calculates book value per share") {
     val bvps = sampleSheet.bookValuePerShare
     assert(bvps.isDefined)
     // 56950000000 / 15550000000 ~ 3.66
     assert(Math.abs(bvps.get - 3.66) < 0.01)
   }
 
-  test("tangibleBookValuePerShare should calculate correctly") {
+  test("calculates tangible book value per share") {
     val tbvps = sampleSheet.tangibleBookValuePerShare
     assert(tbvps.isDefined)
     // 56950000000 / 15550000000 ~ 3.66
     assert(Math.abs(tbvps.get - 3.66) < 0.01)
   }
 
-  test("currentRatio should return None when currentLiabilities is zero") {
+  test("returns no current ratio when current liabilities is zero") {
     val sheet = sampleSheet.copy(currentLiabilities = Some(0.0))
     assertEquals(sheet.currentRatio, None)
   }
 
-  test("currentRatio should return None when currentLiabilities is missing") {
+  test("returns no current ratio when current liabilities is absent") {
     val sheet = sampleSheet.copy(currentLiabilities = None)
     assertEquals(sheet.currentRatio, None)
   }
 
-  test("debtToEquity should return None when stockholdersEquity is zero") {
+  test("returns no debt-to-equity when equity is zero") {
     val sheet = sampleSheet.copy(stockholdersEquity = Some(0.0))
     assertEquals(sheet.debtToEquity, None)
   }
 
-  test("bookValuePerShare should return None when shares is zero") {
+  test("returns no book value per share when shares is zero") {
     val sheet = sampleSheet.copy(ordinarySharesNumber = Some(0.0))
     assertEquals(sheet.bookValuePerShare, None)
   }
 
-  test("balance sheets should sort by date descending") {
+  test("sorts by report date descending") {
     val older = sampleSheet.copy(reportDate = LocalDate.of(2023, 9, 28))
     val newer = sampleSheet.copy(reportDate = LocalDate.of(2024, 9, 28))
     val sorted = List(older, newer).sorted

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CashFlowStatementSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CashFlowStatementSpec.scala
@@ -40,14 +40,14 @@ class CashFlowStatementSpec extends FunSuite {
     freeCashFlow = Some(108807000000.0)
   )
 
-  test("calculatedFreeCashFlow should calculate correctly") {
+  test("calculates free cash flow from operating cash flow minus capex") {
     val fcf = sampleStatement.calculatedFreeCashFlow
     assert(fcf.isDefined)
     // 118254000000 - abs(-9447000000) = 108807000000
     assertEquals(fcf.get, 108807000000.0)
   }
 
-  test("calculatedFreeCashFlow should handle positive capex value") {
+  test("handles positive capex value in free cash flow calculation") {
     // Some APIs report capex as positive
     val stmt = sampleStatement.copy(capitalExpenditure = Some(9447000000.0))
     val fcf = stmt.calculatedFreeCashFlow
@@ -55,7 +55,7 @@ class CashFlowStatementSpec extends FunSuite {
     assertEquals(fcf.get, 108807000000.0)
   }
 
-  test("freeCashFlowYield should calculate correctly") {
+  test("calculates free cash flow yield from market cap") {
     val marketCap = 3000000000000.0 // $3 trillion
     val fcfYield = sampleStatement.freeCashFlowYield(marketCap)
     assert(fcfYield.isDefined)
@@ -63,7 +63,7 @@ class CashFlowStatementSpec extends FunSuite {
     assert(Math.abs(fcfYield.get - 0.0363) < 0.001)
   }
 
-  test("freeCashFlowYield should use API freeCashFlow when available") {
+  test("prefers API free cash flow value for yield calculation") {
     val stmt = sampleStatement.copy(freeCashFlow = Some(100000000000.0))
     val marketCap = 3000000000000.0
     val fcfYield = stmt.freeCashFlowYield(marketCap)
@@ -72,7 +72,7 @@ class CashFlowStatementSpec extends FunSuite {
     assert(Math.abs(fcfYield.get - 0.0333) < 0.001)
   }
 
-  test("freeCashFlowYield should fall back to calculated when API value missing") {
+  test("falls back to calculated FCF when API value is absent") {
     val stmt = sampleStatement.copy(freeCashFlow = None)
     val marketCap = 3000000000000.0
     val fcfYield = stmt.freeCashFlowYield(marketCap)
@@ -81,28 +81,28 @@ class CashFlowStatementSpec extends FunSuite {
     assert(Math.abs(fcfYield.get - 0.0363) < 0.001)
   }
 
-  test("cashFlowToNetIncomeRatio should calculate correctly") {
+  test("calculates cash flow to net income ratio") {
     val ratio = sampleStatement.cashFlowToNetIncomeRatio
     assert(ratio.isDefined)
     // 118254000000 / 94663000000 ~ 1.249
     assert(Math.abs(ratio.get - 1.249) < 0.001)
   }
 
-  test("capexToOperatingCashFlow should calculate correctly") {
+  test("calculates capex to operating cash flow ratio") {
     val ratio = sampleStatement.capexToOperatingCashFlow
     assert(ratio.isDefined)
     // abs(-9447000000) / 118254000000 ~ 0.0799
     assert(Math.abs(ratio.get - 0.0799) < 0.001)
   }
 
-  test("netDebtChange should calculate correctly") {
+  test("calculates net debt change from repayment and issuance") {
     val change = sampleStatement.netDebtChange
     assert(change.isDefined)
     // abs(-12941000000) - abs(5000000000) = 7941000000
     assertEquals(change.get, 7941000000.0)
   }
 
-  test("netDebtChange should handle missing repayment") {
+  test("treats missing repayment as zero in net debt change") {
     val stmt = sampleStatement.copy(repaymentOfDebt = None)
     val change = stmt.netDebtChange
     assert(change.isDefined)
@@ -110,7 +110,7 @@ class CashFlowStatementSpec extends FunSuite {
     assertEquals(change.get, -5000000000.0)
   }
 
-  test("netDebtChange should handle missing issuance") {
+  test("treats missing issuance as zero in net debt change") {
     val stmt = sampleStatement.copy(issuanceOfDebt = None)
     val change = stmt.netDebtChange
     assert(change.isDefined)
@@ -118,17 +118,17 @@ class CashFlowStatementSpec extends FunSuite {
     assertEquals(change.get, 12941000000.0)
   }
 
-  test("cashFlowToNetIncomeRatio should return None when netIncome is zero") {
+  test("returns no cash flow ratio when net income is zero") {
     val stmt = sampleStatement.copy(netIncomeFromContinuingOperations = Some(0.0))
     assertEquals(stmt.cashFlowToNetIncomeRatio, None)
   }
 
-  test("capexToOperatingCashFlow should return None when operating cash flow is zero") {
+  test("returns no capex ratio when operating cash flow is zero") {
     val stmt = sampleStatement.copy(operatingCashFlow = Some(0.0))
     assertEquals(stmt.capexToOperatingCashFlow, None)
   }
 
-  test("cash flow statements should sort by date descending") {
+  test("sorts by report date descending") {
     val older = sampleStatement.copy(reportDate = LocalDate.of(2023, 9, 28))
     val newer = sampleStatement.copy(reportDate = LocalDate.of(2024, 9, 28))
     val sorted = List(older, newer).sorted

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CorporateActionsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CorporateActionsSpec.scala
@@ -7,7 +7,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 class CorporateActionsSpec extends FunSuite {
 
-  test("empty should have no dividends or splits") {
+  test("empty instance has no dividends or splits") {
     val empty = CorporateActions.empty
     assert(empty.isEmpty)
     assert(!empty.nonEmpty)
@@ -15,13 +15,13 @@ class CorporateActionsSpec extends FunSuite {
     assertEquals(empty.splits, List.empty)
   }
 
-  test("isEmpty should return true when both lists are empty") {
+  test("is empty when both lists are empty") {
     val actions = CorporateActions(List.empty, List.empty)
     assert(actions.isEmpty)
     assert(!actions.nonEmpty)
   }
 
-  test("isEmpty should return false when dividends exist") {
+  test("is non-empty when dividends exist") {
     val dividend = DividendEvent(
       exDate = ZonedDateTime.now(),
       amount = 0.24
@@ -31,7 +31,7 @@ class CorporateActionsSpec extends FunSuite {
     assert(actions.nonEmpty)
   }
 
-  test("isEmpty should return false when splits exist") {
+  test("is non-empty when splits exist") {
     val split = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 4,
@@ -43,7 +43,7 @@ class CorporateActionsSpec extends FunSuite {
     assert(actions.nonEmpty)
   }
 
-  test("totalDividendAmount should sum all dividend amounts") {
+  test("sums all dividend amounts") {
     val dividends = List(
       DividendEvent(ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC), 0.24),
       DividendEvent(ZonedDateTime.of(2024, 4, 1, 0, 0, 0, 0, ZoneOffset.UTC), 0.24),
@@ -55,17 +55,17 @@ class CorporateActionsSpec extends FunSuite {
     assert(Math.abs(actions.totalDividendAmount - 0.98) < 0.001)
   }
 
-  test("totalDividendAmount should return 0 when no dividends") {
+  test("total dividend amount is zero when no dividends") {
     val actions = CorporateActions(List.empty, List.empty)
     assertEquals(actions.totalDividendAmount, 0.0)
   }
 
-  test("cumulativeSplitFactor should return 1.0 when no splits") {
+  test("cumulative split factor is 1.0 when no splits") {
     val actions = CorporateActions(List.empty, List.empty)
     assertEquals(actions.cumulativeSplitFactor, 1.0)
   }
 
-  test("cumulativeSplitFactor should return single split factor") {
+  test("cumulative split factor equals single split factor") {
     val split = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 4,
@@ -76,7 +76,7 @@ class CorporateActionsSpec extends FunSuite {
     assertEquals(actions.cumulativeSplitFactor, 4.0)
   }
 
-  test("cumulativeSplitFactor should multiply multiple split factors") {
+  test("multiplies multiple split factors cumulatively") {
     val splits = List(
       SplitEvent(ZonedDateTime.of(2014, 6, 9, 0, 0, 0, 0, ZoneOffset.UTC), 7, 1, "7:1"),
       SplitEvent(ZonedDateTime.of(2020, 8, 31, 0, 0, 0, 0, ZoneOffset.UTC), 4, 1, "4:1")
@@ -85,7 +85,7 @@ class CorporateActionsSpec extends FunSuite {
     assertEquals(actions.cumulativeSplitFactor, 28.0)
   }
 
-  test("dividendCount should return correct count") {
+  test("counts dividends correctly") {
     val dividends = List(
       DividendEvent(ZonedDateTime.now(), 0.24),
       DividendEvent(ZonedDateTime.now(), 0.24),
@@ -95,7 +95,7 @@ class CorporateActionsSpec extends FunSuite {
     assertEquals(actions.dividendCount, 3)
   }
 
-  test("splitCount should return correct count") {
+  test("counts splits correctly") {
     val splits = List(
       SplitEvent(ZonedDateTime.now(), 7, 1, "7:1"),
       SplitEvent(ZonedDateTime.now(), 4, 1, "4:1")

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
@@ -8,7 +8,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 class DividendEventSpec extends FunSuite {
 
-  test("fromRaw should convert timestamp to ZonedDateTime correctly") {
+  test("converts raw timestamp to ZonedDateTime") {
     val raw = DividendEventRaw(amount = 0.24, date = 1704067200L)
     val event = DividendEvent.fromRaw("1704067200", raw)
 
@@ -19,7 +19,7 @@ class DividendEventSpec extends FunSuite {
     assertEquals(event.exDate.getZone, ZoneOffset.UTC)
   }
 
-  test("yieldAt should calculate dividend yield correctly") {
+  test("calculates dividend yield at given share price") {
     val event = DividendEvent(
       exDate = ZonedDateTime.now(),
       amount = 0.24
@@ -30,7 +30,7 @@ class DividendEventSpec extends FunSuite {
     assert(Math.abs(yieldValue - 0.0024) < 0.0001)
   }
 
-  test("yieldAt should return 0 for zero share price") {
+  test("returns zero yield for zero share price") {
     val event = DividendEvent(
       exDate = ZonedDateTime.now(),
       amount = 0.24
@@ -39,7 +39,7 @@ class DividendEventSpec extends FunSuite {
     assertEquals(event.yieldAt(0.0), 0.0)
   }
 
-  test("yieldAt should return 0 for negative share price") {
+  test("returns zero yield for negative share price") {
     val event = DividendEvent(
       exDate = ZonedDateTime.now(),
       amount = 0.24
@@ -48,7 +48,7 @@ class DividendEventSpec extends FunSuite {
     assertEquals(event.yieldAt(-10.0), 0.0)
   }
 
-  test("ordering should sort by exDate chronologically") {
+  test("sorts by ex-date chronologically") {
     val event1 = DividendEvent(
       exDate = ZonedDateTime.of(2024, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC),
       amount = 0.20

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/FinancialStatementsSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/FinancialStatementsSpec.scala
@@ -119,93 +119,93 @@ class FinancialStatementsSpec extends FunSuite {
     cashFlowStatements = List(sampleCashFlowStatement)
   )
 
-  test("returnOnAssets should calculate correctly") {
+  test("calculates return on assets from net income and total assets") {
     val roa = sampleFinancials.returnOnAssets
     assert(roa.isDefined)
     // 94663000000 / 364980000000 ~ 0.2594
     assert(Math.abs(roa.get - 0.2594) < 0.001)
   }
 
-  test("returnOnEquity should calculate correctly") {
+  test("calculates return on equity from net income and equity") {
     val roe = sampleFinancials.returnOnEquity
     assert(roe.isDefined)
     // 94663000000 / 56950000000 ~ 1.662
     assert(Math.abs(roe.get - 1.662) < 0.001)
   }
 
-  test("assetTurnover should calculate correctly") {
+  test("calculates asset turnover from revenue and total assets") {
     val turnover = sampleFinancials.assetTurnover
     assert(turnover.isDefined)
     // 383285000000 / 364980000000 ~ 1.050
     assert(Math.abs(turnover.get - 1.050) < 0.001)
   }
 
-  test("interestCoverage should calculate correctly") {
+  test("calculates interest coverage from EBIT and interest expense") {
     val coverage = sampleFinancials.interestCoverage
     assert(coverage.isDefined)
     // 113033000000 / abs(3000000000) ~ 37.68
     assert(Math.abs(coverage.get - 37.68) < 0.01)
   }
 
-  test("returnOnAssets should return None when totalAssets is zero") {
+  test("returns no ROA when total assets is zero") {
     val modified = sampleFinancials.copy(
       balanceSheets = List(sampleBalanceSheet.copy(totalAssets = Some(0.0)))
     )
     assertEquals(modified.returnOnAssets, None)
   }
 
-  test("returnOnAssets should return None when totalAssets is missing") {
+  test("returns no ROA when total assets is absent") {
     val modified = sampleFinancials.copy(
       balanceSheets = List(sampleBalanceSheet.copy(totalAssets = None))
     )
     assertEquals(modified.returnOnAssets, None)
   }
 
-  test("returnOnEquity should return None when stockholdersEquity is zero") {
+  test("returns no ROE when stockholders equity is zero") {
     val modified = sampleFinancials.copy(
       balanceSheets = List(sampleBalanceSheet.copy(stockholdersEquity = Some(0.0)))
     )
     assertEquals(modified.returnOnEquity, None)
   }
 
-  test("interestCoverage should return None when interestExpense is zero") {
+  test("returns no interest coverage when interest expense is zero") {
     val modified = sampleFinancials.copy(
       incomeStatements = List(sampleIncomeStatement.copy(interestExpense = Some(0.0)))
     )
     assertEquals(modified.interestCoverage, None)
   }
 
-  test("interestCoverage should return None when interestExpense is missing") {
+  test("returns no interest coverage when interest expense is absent") {
     val modified = sampleFinancials.copy(
       incomeStatements = List(sampleIncomeStatement.copy(interestExpense = None))
     )
     assertEquals(modified.interestCoverage, None)
   }
 
-  test("nonEmpty should return true when any statements exist") {
+  test("is non-empty when any statements exist") {
     assert(sampleFinancials.nonEmpty)
   }
 
-  test("nonEmpty should return false when all statements are empty") {
+  test("is empty when all statement lists are empty") {
     val empty = FinancialStatements.empty(Ticker("TEST"))
     assert(!empty.nonEmpty)
   }
 
-  test("isEmpty should return true when no statements exist") {
+  test("reports empty when no statements exist") {
     val empty = FinancialStatements.empty(Ticker("TEST"))
     assert(empty.isEmpty)
   }
 
-  test("latestIncomeStatement should return the first statement") {
+  test("returns most recent income statement") {
     assertEquals(sampleFinancials.latestIncomeStatement, Some(sampleIncomeStatement))
   }
 
-  test("latestIncomeStatement should return None when no statements exist") {
+  test("returns no latest income statement when list is empty") {
     val empty = sampleFinancials.copy(incomeStatements = List.empty)
     assertEquals(empty.latestIncomeStatement, None)
   }
 
-  test("periodCount should return the maximum of all statement counts") {
+  test("period count equals maximum across all statement types") {
     val multi = sampleFinancials.copy(
       incomeStatements =
         List(sampleIncomeStatement, sampleIncomeStatement.copy(reportDate = LocalDate.of(2023, 9, 28))),

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/HoldersDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/HoldersDataSpec.scala
@@ -7,11 +7,11 @@ import java.time.LocalDate
 
 class HoldersDataSpec extends FunSuite {
 
-  test("isEmpty should return true for empty HoldersData") {
+  test("empty instance is empty") {
     assert(HoldersData.empty.isEmpty)
   }
 
-  test("nonEmpty should return true when majorHolders is present") {
+  test("is non-empty when major holders are present") {
     val withMajor = HoldersData(
       majorHolders = Some(MajorHolders(0.05, 0.60, 0.62, 1000)),
       institutionalHolders = List.empty,
@@ -23,7 +23,7 @@ class HoldersDataSpec extends FunSuite {
     assert(withMajor.nonEmpty)
   }
 
-  test("nonEmpty should return true when institutionalHolders is present") {
+  test("is non-empty when institutional holders are present") {
     val withInstitutional = HoldersData(
       majorHolders = None,
       institutionalHolders = List(InstitutionalHolder("A", LocalDate.now(), 0.05, 100, 1000)),
@@ -35,7 +35,7 @@ class HoldersDataSpec extends FunSuite {
     assert(withInstitutional.nonEmpty)
   }
 
-  test("nonEmpty should return true when mutualFundHolders is present") {
+  test("is non-empty when mutual fund holders are present") {
     val withFunds = HoldersData(
       majorHolders = None,
       institutionalHolders = List.empty,
@@ -47,7 +47,7 @@ class HoldersDataSpec extends FunSuite {
     assert(withFunds.nonEmpty)
   }
 
-  test("nonEmpty should return true when insiderTransactions is present") {
+  test("is non-empty when insider transactions are present") {
     val withTransactions = HoldersData(
       majorHolders = None,
       institutionalHolders = List.empty,
@@ -61,7 +61,7 @@ class HoldersDataSpec extends FunSuite {
     assert(withTransactions.nonEmpty)
   }
 
-  test("nonEmpty should return true when insiderRoster is present") {
+  test("is non-empty when insider roster is present") {
     val withRoster = HoldersData(
       majorHolders = None,
       institutionalHolders = List.empty,
@@ -73,7 +73,7 @@ class HoldersDataSpec extends FunSuite {
     assert(withRoster.nonEmpty)
   }
 
-  test("totalInstitutionalCount should sum both holder lists") {
+  test("sums institutional and mutual fund holders") {
     val data = HoldersData(
       majorHolders = None,
       institutionalHolders = List(
@@ -90,7 +90,7 @@ class HoldersDataSpec extends FunSuite {
     assertEquals(data.totalInstitutionalCount, 3)
   }
 
-  test("topInstitutionalPercentage should sum percentages") {
+  test("sums top institutional holder percentages") {
     val data = HoldersData(
       majorHolders = None,
       institutionalHolders = List(
@@ -105,7 +105,7 @@ class HoldersDataSpec extends FunSuite {
     assert(Math.abs(data.topInstitutionalPercentage - 0.15) < 0.001)
   }
 
-  test("topMutualFundPercentage should sum percentages") {
+  test("sums top mutual fund holder percentages") {
     val data = HoldersData(
       majorHolders = None,
       institutionalHolders = List.empty,
@@ -120,7 +120,7 @@ class HoldersDataSpec extends FunSuite {
     assert(Math.abs(data.topMutualFundPercentage - 0.05) < 0.001)
   }
 
-  test("insiderPurchases and insiderSales should filter correctly") {
+  test("separates insider purchases from sales") {
     val purchase = InsiderTransaction("A", "CEO", LocalDate.now(), 1000, None, "Buy", OwnershipType.Direct, None)
     val sale = InsiderTransaction("B", "CFO", LocalDate.now(), -500, None, "Sell", OwnershipType.Direct, None)
 
@@ -138,7 +138,7 @@ class HoldersDataSpec extends FunSuite {
     assertEquals(data.insiderSales.head.filerName, "B")
   }
 
-  test("netInsiderShares should calculate net sentiment") {
+  test("calculates net insider share sentiment") {
     val purchase = InsiderTransaction("A", "CEO", LocalDate.now(), 1000, None, "Buy", OwnershipType.Direct, None)
     val sale = InsiderTransaction("B", "CFO", LocalDate.now(), -300, None, "Sell", OwnershipType.Direct, None)
 
@@ -153,7 +153,7 @@ class HoldersDataSpec extends FunSuite {
     assertEquals(data.netInsiderShares, 700L) // 1000 - 300
   }
 
-  test("netInsiderShares with only sales should be negative") {
+  test("net insider shares is negative when only sales exist") {
     val sale1 = InsiderTransaction("A", "CEO", LocalDate.now(), -1000, None, "Sell", OwnershipType.Direct, None)
     val sale2 = InsiderTransaction("B", "CFO", LocalDate.now(), -500, None, "Sell", OwnershipType.Direct, None)
 
@@ -168,7 +168,7 @@ class HoldersDataSpec extends FunSuite {
     assertEquals(data.netInsiderShares, -1500L)
   }
 
-  test("empty HoldersData should return zero for all aggregations") {
+  test("empty instance returns zero for all aggregations") {
     val data = HoldersData.empty
 
     assertEquals(data.topInstitutionalPercentage, 0.0)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IncomeStatementSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IncomeStatementSpec.scala
@@ -37,62 +37,62 @@ class IncomeStatementSpec extends FunSuite {
     ebitda = Some(124478000000.0)
   )
 
-  test("grossMargin should calculate correctly") {
+  test("calculates gross margin from gross profit and revenue") {
     val margin = sampleStatement.grossMargin
     assert(margin.isDefined)
     // 169148000000 / 383285000000 ~ 0.4413
     assert(Math.abs(margin.get - 0.4413) < 0.001)
   }
 
-  test("operatingMargin should calculate correctly") {
+  test("calculates operating margin from operating income and revenue") {
     val margin = sampleStatement.operatingMargin
     assert(margin.isDefined)
     // 110436000000 / 383285000000 ~ 0.2881
     assert(Math.abs(margin.get - 0.2881) < 0.001)
   }
 
-  test("netMargin should calculate correctly") {
+  test("calculates net margin from net income and revenue") {
     val margin = sampleStatement.netMargin
     assert(margin.isDefined)
     // 94663000000 / 383285000000 ~ 0.2470
     assert(Math.abs(margin.get - 0.2470) < 0.001)
   }
 
-  test("ebitdaMargin should calculate correctly") {
+  test("calculates EBITDA margin from EBITDA and revenue") {
     val margin = sampleStatement.ebitdaMargin
     assert(margin.isDefined)
     // 124478000000 / 383285000000 ~ 0.3248
     assert(Math.abs(margin.get - 0.3248) < 0.001)
   }
 
-  test("effectiveTaxRate should calculate correctly") {
+  test("calculates effective tax rate from tax provision and pretax income") {
     val rate = sampleStatement.effectiveTaxRate
     assert(rate.isDefined)
     // 18370000000 / 113033000000 ~ 0.1625
     assert(Math.abs(rate.get - 0.1625) < 0.001)
   }
 
-  test("grossMargin should return None when revenue is zero") {
+  test("returns no gross margin when revenue is zero") {
     val stmt = sampleStatement.copy(totalRevenue = Some(0.0))
     assertEquals(stmt.grossMargin, None)
   }
 
-  test("grossMargin should return None when grossProfit is missing") {
+  test("returns no gross margin when gross profit is absent") {
     val stmt = sampleStatement.copy(grossProfit = None)
     assertEquals(stmt.grossMargin, None)
   }
 
-  test("grossMargin should return None when totalRevenue is missing") {
+  test("returns no gross margin when total revenue is absent") {
     val stmt = sampleStatement.copy(totalRevenue = None)
     assertEquals(stmt.grossMargin, None)
   }
 
-  test("effectiveTaxRate should return None when pretaxIncome is zero") {
+  test("returns no effective tax rate when pretax income is zero") {
     val stmt = sampleStatement.copy(pretaxIncome = Some(0.0))
     assertEquals(stmt.effectiveTaxRate, None)
   }
 
-  test("income statements should sort by date descending") {
+  test("sorts by report date descending") {
     val older = sampleStatement.copy(reportDate = LocalDate.of(2023, 9, 28))
     val newer = sampleStatement.copy(reportDate = LocalDate.of(2024, 9, 28))
     val sorted = List(older, newer).sorted

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InsiderRosterEntrySpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InsiderRosterEntrySpec.scala
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 class InsiderRosterEntrySpec extends FunSuite {
 
-  test("totalPosition should sum direct and indirect holdings") {
+  test("sums direct and indirect holdings") {
     val entry = InsiderRosterEntry(
       name = "John Doe",
       relation = "CEO",
@@ -23,7 +23,7 @@ class InsiderRosterEntrySpec extends FunSuite {
     assertEquals(entry.totalPosition, 150000L)
   }
 
-  test("totalPosition should handle None values") {
+  test("treats absent holdings as zero when summing") {
     val entry = InsiderRosterEntry(
       name = "Jane Smith",
       relation = "CFO",
@@ -39,7 +39,7 @@ class InsiderRosterEntrySpec extends FunSuite {
     assertEquals(entry.totalPosition, 100000L)
   }
 
-  test("totalPosition should return 0 when both positions are None") {
+  test("returns zero position when both holdings are absent") {
     val entry = InsiderRosterEntry(
       name = "Test User",
       relation = "Director",
@@ -55,7 +55,7 @@ class InsiderRosterEntrySpec extends FunSuite {
     assertEquals(entry.totalPosition, 0L)
   }
 
-  test("hasPosition should return true when totalPosition > 0") {
+  test("has position when total holdings are positive") {
     val withPosition = InsiderRosterEntry("A", "CEO", None, None, Some(100L), None, None, None, None)
     val withoutPosition = InsiderRosterEntry("B", "CFO", None, None, None, None, None, None, None)
 
@@ -63,7 +63,7 @@ class InsiderRosterEntrySpec extends FunSuite {
     assert(!withoutPosition.hasPosition)
   }
 
-  test("hasIndirectHoldings should detect indirect positions") {
+  test("detects indirect holdings") {
     val withIndirect = InsiderRosterEntry("A", "CEO", None, None, Some(100L), None, Some(50L), None, None)
     val withoutIndirect = InsiderRosterEntry("B", "CFO", None, None, Some(100L), None, None, None, None)
     val zeroIndirect = InsiderRosterEntry("C", "COO", None, None, Some(100L), None, Some(0L), None, None)
@@ -73,7 +73,7 @@ class InsiderRosterEntrySpec extends FunSuite {
     assert(!zeroIndirect.hasIndirectHoldings)
   }
 
-  test("ordering should sort by total position descending") {
+  test("sorts by total position descending") {
     val e1 = InsiderRosterEntry("A", "CEO", None, None, Some(100L), None, Some(50L), None, None) // 150
     val e2 = InsiderRosterEntry("B", "CFO", None, None, Some(200L), None, None, None, None) // 200
     val e3 = InsiderRosterEntry("C", "COO", None, None, Some(50L), None, Some(25L), None, None) // 75
@@ -83,7 +83,7 @@ class InsiderRosterEntrySpec extends FunSuite {
     assertEquals(sorted.map(_.name), List("B", "A", "C"))
   }
 
-  test("hasPosition with only indirect holdings") {
+  test("has position with only indirect holdings") {
     val indirectOnly = InsiderRosterEntry("A", "CEO", None, None, None, None, Some(100L), None, None)
 
     assert(indirectOnly.hasPosition)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InsiderTransactionSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InsiderTransactionSpec.scala
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 class InsiderTransactionSpec extends FunSuite {
 
-  test("isPurchase should return true for positive shares") {
+  test("identifies purchase when shares are positive") {
     val purchase = InsiderTransaction(
       filerName = "John Doe",
       filerRelation = "CEO",
@@ -23,7 +23,7 @@ class InsiderTransactionSpec extends FunSuite {
     assert(!purchase.isSale)
   }
 
-  test("isSale should return true for negative shares") {
+  test("identifies sale when shares are negative") {
     val sale = InsiderTransaction(
       filerName = "Jane Smith",
       filerRelation = "CFO",
@@ -39,7 +39,7 @@ class InsiderTransactionSpec extends FunSuite {
     assert(!sale.isPurchase)
   }
 
-  test("sharesTraded should return absolute value") {
+  test("reports absolute shares traded") {
     val sale = InsiderTransaction(
       filerName = "Test",
       filerRelation = "Director",
@@ -54,7 +54,7 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(sale.sharesTraded, 5000L)
   }
 
-  test("pricePerShare should calculate from value and shares") {
+  test("calculates price per share from value and shares") {
     val transaction = InsiderTransaction(
       filerName = "Test",
       filerRelation = "CEO",
@@ -69,7 +69,7 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(transaction.pricePerShare, Some(150.0))
   }
 
-  test("pricePerShare should return None when value is None") {
+  test("returns no price per share when value is absent") {
     val transaction = InsiderTransaction(
       filerName = "Test",
       filerRelation = "CEO",
@@ -84,7 +84,7 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(transaction.pricePerShare, None)
   }
 
-  test("pricePerShare should return None when value is zero") {
+  test("returns no price per share when value is zero") {
     val transaction = InsiderTransaction(
       filerName = "Test",
       filerRelation = "CEO",
@@ -99,7 +99,7 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(transaction.pricePerShare, None)
   }
 
-  test("ordering should sort by date descending (most recent first)") {
+  test("sorts by transaction date descending") {
     val t1 = InsiderTransaction("A", "CEO", LocalDate.of(2024, 1, 1), 100, None, "", OwnershipType.Direct, None)
     val t2 = InsiderTransaction("B", "CFO", LocalDate.of(2024, 3, 1), 200, None, "", OwnershipType.Direct, None)
     val t3 = InsiderTransaction("C", "COO", LocalDate.of(2024, 2, 1), 150, None, "", OwnershipType.Direct, None)
@@ -109,7 +109,7 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(sorted.map(_.filerName), List("B", "C", "A"))
   }
 
-  test("OwnershipType.fromString should parse correctly") {
+  test("parses ownership type from string") {
     assertEquals(OwnershipType.fromString("D"), OwnershipType.Direct)
     assertEquals(OwnershipType.fromString("I"), OwnershipType.Indirect)
     assertEquals(OwnershipType.fromString("d"), OwnershipType.Direct)
@@ -117,7 +117,7 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(OwnershipType.fromString("unknown"), OwnershipType.Direct) // Default
   }
 
-  test("OwnershipType.value should return correct string") {
+  test("represents ownership type as string") {
     assertEquals(OwnershipType.Direct.value, "D")
     assertEquals(OwnershipType.Indirect.value, "I")
   }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InstitutionalHolderSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InstitutionalHolderSpec.scala
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 class InstitutionalHolderSpec extends FunSuite {
 
-  test("percentHeldFormatted should convert decimal to percentage") {
+  test("formats decimal holdings as percentage") {
     val holder = InstitutionalHolder(
       organization = "Vanguard",
       reportDate = LocalDate.of(2024, 9, 30),
@@ -19,7 +19,7 @@ class InstitutionalHolderSpec extends FunSuite {
     assert(Math.abs(holder.percentHeldFormatted - 9.01) < 0.001)
   }
 
-  test("averageCostPerShare should calculate correctly") {
+  test("calculates average cost per share from market value and shares") {
     val holder = InstitutionalHolder(
       organization = "BlackRock",
       reportDate = LocalDate.of(2024, 9, 30),
@@ -31,7 +31,7 @@ class InstitutionalHolderSpec extends FunSuite {
     assertEquals(holder.averageCostPerShare, Some(150.0))
   }
 
-  test("averageCostPerShare should return None for zero shares") {
+  test("returns no average cost when shares are zero") {
     val holder = InstitutionalHolder(
       organization = "Empty Fund",
       reportDate = LocalDate.of(2024, 9, 30),
@@ -43,7 +43,7 @@ class InstitutionalHolderSpec extends FunSuite {
     assertEquals(holder.averageCostPerShare, None)
   }
 
-  test("ordering should sort by percentage descending") {
+  test("sorts by percentage held descending") {
     val holder1 = InstitutionalHolder("A", LocalDate.now(), 0.05, 100, 1000)
     val holder2 = InstitutionalHolder("B", LocalDate.now(), 0.10, 200, 2000)
     val holder3 = InstitutionalHolder("C", LocalDate.now(), 0.02, 50, 500)
@@ -53,7 +53,7 @@ class InstitutionalHolderSpec extends FunSuite {
     assertEquals(sorted.map(_.organization), List("B", "A", "C"))
   }
 
-  test("orderingByDate should sort by date descending") {
+  test("sorts by report date descending") {
     val holder1 = InstitutionalHolder("A", LocalDate.of(2024, 1, 1), 0.05, 100, 1000)
     val holder2 = InstitutionalHolder("B", LocalDate.of(2024, 6, 1), 0.05, 100, 1000)
     val holder3 = InstitutionalHolder("C", LocalDate.of(2024, 3, 1), 0.05, 100, 1000)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MajorHoldersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MajorHoldersSpec.scala
@@ -5,7 +5,7 @@ import org.coinductive.yfinance4s.models.MajorHolders
 
 class MajorHoldersSpec extends FunSuite {
 
-  test("retailPercentHeld should calculate remaining percentage") {
+  test("calculates retail percent as remainder of insider and institutional") {
     val holders = MajorHolders(
       insidersPercentHeld = 0.05,
       institutionsPercentHeld = 0.60,
@@ -17,7 +17,7 @@ class MajorHoldersSpec extends FunSuite {
     assert(Math.abs(holders.retailPercentHeld - 0.35) < 0.001)
   }
 
-  test("isInstitutionallyDominated should return true when institutions hold >50%") {
+  test("is institutionally dominated when institutions hold >50%") {
     val dominated = MajorHolders(0.01, 0.60, 0.62, 1000)
     val notDominated = MajorHolders(0.01, 0.40, 0.42, 500)
 
@@ -25,7 +25,7 @@ class MajorHoldersSpec extends FunSuite {
     assert(!notDominated.isInstitutionallyDominated)
   }
 
-  test("hasSignificantInsiderOwnership should return true when insiders hold >5%") {
+  test("has significant insider ownership when insiders hold >5%") {
     val significant = MajorHolders(0.10, 0.50, 0.52, 1000)
     val notSignificant = MajorHolders(0.02, 0.60, 0.62, 1000)
 
@@ -33,14 +33,14 @@ class MajorHoldersSpec extends FunSuite {
     assert(!notSignificant.hasSignificantInsiderOwnership)
   }
 
-  test("retailPercentHeld should not be negative") {
+  test("retail percent floors at zero when percentages exceed 100%") {
     // Edge case: percentages exceed 100% (can happen with rounding)
     val holders = MajorHolders(0.50, 0.60, 0.62, 1000)
 
     assertEquals(holders.retailPercentHeld, 0.0)
   }
 
-  test("isInstitutionallyDominated boundary at exactly 50%") {
+  test("institutional domination boundary is exclusive at 50%") {
     val atBoundary = MajorHolders(0.01, 0.50, 0.52, 500)
     val justAbove = MajorHolders(0.01, 0.501, 0.52, 500)
 
@@ -48,7 +48,7 @@ class MajorHoldersSpec extends FunSuite {
     assert(justAbove.isInstitutionallyDominated)
   }
 
-  test("hasSignificantInsiderOwnership boundary at exactly 5%") {
+  test("significant insider ownership boundary is exclusive at 5%") {
     val atBoundary = MajorHolders(0.05, 0.50, 0.52, 1000)
     val justAbove = MajorHolders(0.051, 0.50, 0.52, 1000)
 

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MutualFundHolderSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MutualFundHolderSpec.scala
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 class MutualFundHolderSpec extends FunSuite {
 
-  test("percentHeldFormatted should convert decimal to percentage") {
+  test("formats decimal holdings as percentage") {
     val holder = MutualFundHolder(
       organization = "Vanguard Total Stock Market Index Fund",
       reportDate = LocalDate.of(2024, 9, 30),
@@ -19,7 +19,7 @@ class MutualFundHolderSpec extends FunSuite {
     assert(Math.abs(holder.percentHeldFormatted - 3.12) < 0.001)
   }
 
-  test("averageCostPerShare should calculate correctly") {
+  test("calculates average cost per share from market value and shares") {
     val holder = MutualFundHolder(
       organization = "Fidelity Growth Fund",
       reportDate = LocalDate.of(2024, 9, 30),
@@ -31,7 +31,7 @@ class MutualFundHolderSpec extends FunSuite {
     assertEquals(holder.averageCostPerShare, Some(200.0))
   }
 
-  test("averageCostPerShare should return None for zero shares") {
+  test("returns no average cost when shares are zero") {
     val holder = MutualFundHolder(
       organization = "Empty Fund",
       reportDate = LocalDate.of(2024, 9, 30),
@@ -43,7 +43,7 @@ class MutualFundHolderSpec extends FunSuite {
     assertEquals(holder.averageCostPerShare, None)
   }
 
-  test("ordering should sort by percentage descending") {
+  test("sorts by percentage held descending") {
     val holder1 = MutualFundHolder("Fund A", LocalDate.now(), 0.02, 100, 1000)
     val holder2 = MutualFundHolder("Fund B", LocalDate.now(), 0.05, 200, 2000)
     val holder3 = MutualFundHolder("Fund C", LocalDate.now(), 0.01, 50, 500)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SearchResultSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SearchResultSpec.scala
@@ -1,0 +1,241 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+import java.time.{ZoneOffset, ZonedDateTime}
+
+class SearchResultSpec extends FunSuite {
+
+  // --- QuoteSearchResult tests ---
+
+  private val appleQuote = QuoteSearchResult(
+    symbol = "AAPL",
+    shortName = Some("Apple Inc."),
+    longName = Some("Apple Inc."),
+    quoteType = Some("EQUITY"),
+    exchange = Some("NMS"),
+    exchangeDisplay = Some("NASDAQ"),
+    sector = Some("Technology"),
+    industry = Some("Consumer Electronics"),
+    score = Some(25305.0)
+  )
+
+  private val spyEtf = QuoteSearchResult(
+    symbol = "SPY",
+    shortName = Some("SPDR S&P 500 ETF Trust"),
+    longName = Some("SPDR S&P 500 ETF Trust"),
+    quoteType = Some("ETF"),
+    exchange = Some("PCX"),
+    exchangeDisplay = Some("NYSEArca"),
+    sector = None,
+    industry = None,
+    score = Some(20000.0)
+  )
+
+  private val btcCrypto = QuoteSearchResult(
+    symbol = "BTC-USD",
+    shortName = Some("Bitcoin USD"),
+    longName = Some("Bitcoin USD"),
+    quoteType = Some("CRYPTOCURRENCY"),
+    exchange = Some("CCC"),
+    exchangeDisplay = Some("CCC"),
+    sector = None,
+    industry = None,
+    score = Some(15000.0)
+  )
+
+  test("identifies EQUITY quote type correctly") {
+    assert(appleQuote.isEquity)
+    assert(!appleQuote.isETF)
+    assert(!appleQuote.isIndex)
+    assert(!appleQuote.isCryptocurrency)
+  }
+
+  test("identifies ETF quote type correctly") {
+    assert(spyEtf.isETF)
+    assert(!spyEtf.isEquity)
+  }
+
+  test("identifies CRYPTOCURRENCY quote type correctly") {
+    assert(btcCrypto.isCryptocurrency)
+    assert(!btcCrypto.isEquity)
+  }
+
+  test("identifies MUTUALFUND quote type correctly") {
+    val fund = appleQuote.copy(quoteType = Some("MUTUALFUND"))
+    assert(fund.isMutualFund)
+  }
+
+  test("identifies INDEX quote type correctly") {
+    val index = appleQuote.copy(quoteType = Some("INDEX"))
+    assert(index.isIndex)
+  }
+
+  test("identifies CURRENCY quote type correctly") {
+    val currency = appleQuote.copy(quoteType = Some("CURRENCY"))
+    assert(currency.isCurrency)
+  }
+
+  test("identifies FUTURE quote type correctly") {
+    val future = appleQuote.copy(quoteType = Some("FUTURE"))
+    assert(future.isFuture)
+  }
+
+  test("prefers longName for display") {
+    assertEquals(appleQuote.displayName, "Apple Inc.")
+  }
+
+  test("falls back to shortName when longName is absent") {
+    val noLong = appleQuote.copy(longName = None)
+    assertEquals(noLong.displayName, "Apple Inc.")
+  }
+
+  test("falls back to symbol when both names are absent") {
+    val noNames = appleQuote.copy(longName = None, shortName = None)
+    assertEquals(noNames.displayName, "AAPL")
+  }
+
+  test("converts symbol to Ticker") {
+    assertEquals(appleQuote.toTicker, Ticker("AAPL"))
+  }
+
+  test("sorts quotes by relevance score descending") {
+    val quotes = List(
+      appleQuote.copy(score = Some(100.0)),
+      appleQuote.copy(symbol = "B", score = Some(500.0)),
+      appleQuote.copy(symbol = "C", score = Some(250.0))
+    )
+    val sorted = quotes.sorted
+    assertEquals(sorted.map(_.symbol), List("B", "C", "AAPL"))
+  }
+
+  test("ranks quotes without scores last") {
+    val quotes = List(
+      appleQuote.copy(symbol = "A", score = None),
+      appleQuote.copy(symbol = "B", score = Some(100.0))
+    )
+    val sorted = quotes.sorted
+    assertEquals(sorted.map(_.symbol), List("B", "A"))
+  }
+
+  test("all type checks return false when quoteType is None") {
+    val noType = appleQuote.copy(quoteType = None)
+    assert(!noType.isEquity)
+    assert(!noType.isETF)
+    assert(!noType.isIndex)
+    assert(!noType.isMutualFund)
+    assert(!noType.isCurrency)
+    assert(!noType.isCryptocurrency)
+    assert(!noType.isFuture)
+  }
+
+  // --- NewsItem tests ---
+
+  private val newsItem = NewsItem(
+    uuid = "abc-123",
+    title = "Apple Reports Record Revenue",
+    publisher = "Reuters",
+    link = "https://example.com/article",
+    publishTime = ZonedDateTime.of(2024, 6, 15, 10, 30, 0, 0, ZoneOffset.UTC),
+    articleType = Some("STORY"),
+    thumbnailUrl = Some("https://example.com/thumb.jpg"),
+    relatedTickers = List("AAPL", "MSFT")
+  )
+
+  test("matches related tickers case-insensitively") {
+    assert(newsItem.isRelatedTo("AAPL"))
+    assert(newsItem.isRelatedTo("aapl"))
+    assert(newsItem.isRelatedTo("MSFT"))
+    assert(!newsItem.isRelatedTo("GOOGL"))
+  }
+
+  test("sorts news most recent first") {
+    val older = newsItem.copy(
+      uuid = "older",
+      publishTime = ZonedDateTime.of(2024, 6, 14, 10, 0, 0, 0, ZoneOffset.UTC)
+    )
+    val newer = newsItem.copy(
+      uuid = "newer",
+      publishTime = ZonedDateTime.of(2024, 6, 16, 10, 0, 0, 0, ZoneOffset.UTC)
+    )
+    val sorted = List(older, newsItem, newer).sorted
+    assertEquals(sorted.map(_.uuid), List("newer", "abc-123", "older"))
+  }
+
+  test("reports no related tickers when list is empty") {
+    val noTickers = newsItem.copy(relatedTickers = List.empty)
+    assert(!noTickers.isRelatedTo("AAPL"))
+  }
+
+  // --- SearchResult tests ---
+
+  private val searchResult = SearchResult(
+    quotes = List(appleQuote, spyEtf, btcCrypto),
+    news = List(newsItem),
+    lists = List.empty,
+    totalResults = 3
+  )
+
+  test("is non-empty when quotes exist") {
+    assert(searchResult.nonEmpty)
+  }
+
+  test("is empty when no quotes, news, or lists exist") {
+    assert(SearchResult.empty.isEmpty)
+  }
+
+  test("is non-empty when only news exists") {
+    val newsOnly = SearchResult(
+      quotes = List.empty,
+      news = List(newsItem),
+      lists = List.empty,
+      totalResults = 0
+    )
+    assert(newsOnly.nonEmpty)
+  }
+
+  test("filters equities from mixed quote types") {
+    val equities = searchResult.equities
+    assertEquals(equities.size, 1)
+    assertEquals(equities.head.symbol, "AAPL")
+  }
+
+  test("filters ETFs from mixed quote types") {
+    val etfs = searchResult.etfs
+    assertEquals(etfs.size, 1)
+    assertEquals(etfs.head.symbol, "SPY")
+  }
+
+  test("returns highest-scored quote as top result") {
+    val top = searchResult.topQuote
+    assert(top.isDefined)
+    assertEquals(top.get.symbol, "AAPL")
+  }
+
+  test("returns no top quote when results are empty") {
+    assertEquals(SearchResult.empty.topQuote, None)
+  }
+
+  test("extracts all ticker symbols from quotes") {
+    assertEquals(searchResult.symbols, List("AAPL", "SPY", "BTC-USD"))
+  }
+
+  test("extracts all Ticker values from quotes") {
+    assertEquals(searchResult.tickers, List(Ticker("AAPL"), Ticker("SPY"), Ticker("BTC-USD")))
+  }
+
+  test("empty result has zero counts and empty lists") {
+    val empty = SearchResult.empty
+    assert(empty.isEmpty)
+    assert(empty.quotes.isEmpty)
+    assert(empty.news.isEmpty)
+    assert(empty.lists.isEmpty)
+    assertEquals(empty.totalResults, 0)
+    assertEquals(empty.equities, List.empty[QuoteSearchResult])
+    assertEquals(empty.etfs, List.empty[QuoteSearchResult])
+    assertEquals(empty.topQuote, None)
+    assertEquals(empty.symbols, List.empty[String])
+    assertEquals(empty.tickers, List.empty[Ticker])
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
@@ -8,7 +8,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 class SplitEventSpec extends FunSuite {
 
-  test("fromRaw should convert timestamp correctly") {
+  test("converts raw timestamp correctly") {
     val raw = SplitEventRaw(
       date = 1598832000L,
       numerator = 4,
@@ -24,7 +24,7 @@ class SplitEventSpec extends FunSuite {
     assertEquals(event.exDate.getMonthValue, 8)
   }
 
-  test("factor should calculate split ratio as decimal for forward split") {
+  test("calculates forward split factor (4:1 = 4.0)") {
     val forward4to1 = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 4,
@@ -34,7 +34,7 @@ class SplitEventSpec extends FunSuite {
     assertEquals(forward4to1.factor, 4.0)
   }
 
-  test("factor should calculate split ratio as decimal for reverse split") {
+  test("calculates reverse split factor (1:10 = 0.1)") {
     val reverse1to10 = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 1,
@@ -44,7 +44,7 @@ class SplitEventSpec extends FunSuite {
     assertEquals(reverse1to10.factor, 0.1)
   }
 
-  test("isForwardSplit should identify forward splits") {
+  test("identifies forward splits (numerator > denominator)") {
     val forwardSplit = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 4,
@@ -55,7 +55,7 @@ class SplitEventSpec extends FunSuite {
     assert(!forwardSplit.isReverseSplit)
   }
 
-  test("isReverseSplit should identify reverse splits") {
+  test("identifies reverse splits (numerator < denominator)") {
     val reverseSplit = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 1,
@@ -66,7 +66,7 @@ class SplitEventSpec extends FunSuite {
     assert(!reverseSplit.isForwardSplit)
   }
 
-  test("equal numerator and denominator should be neither forward nor reverse") {
+  test("1:1 ratio is neither forward nor reverse") {
     val noChange = SplitEvent(
       exDate = ZonedDateTime.now(),
       numerator = 1,
@@ -78,7 +78,7 @@ class SplitEventSpec extends FunSuite {
     assertEquals(noChange.factor, 1.0)
   }
 
-  test("ordering should sort by exDate chronologically") {
+  test("sorts by ex-date chronologically") {
     val event1 = SplitEvent(
       exDate = ZonedDateTime.of(2014, 6, 9, 0, 0, 0, 0, ZoneOffset.UTC),
       numerator = 7,

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
@@ -3,7 +3,7 @@ package org.coinductive.yfinance4s.unit
 import cats.Id
 import cats.data.NonEmptyList
 import munit.FunSuite
-import org.coinductive.yfinance4s.{Tickers, YFinanceClient}
+import org.coinductive.yfinance4s.*
 import org.coinductive.yfinance4s.models.*
 
 import java.time.{LocalDate, ZonedDateTime}
@@ -13,7 +13,7 @@ class TickersSpec extends FunSuite {
   /** Stub client for unit tests. All methods throw NotImplementedError but are never called since unit tests only
     * exercise pure operations on Tickers (add, remove, contains, etc.).
     */
-  private val client: YFinanceClient[Id] = new YFinanceClient[Id] {
+  private val stubCharts: Charts[Id] = new Charts[Id] {
     def getChart(ticker: Ticker, interval: Interval, range: Range): Option[ChartResult] = ???
     def getChart(ticker: Ticker, interval: Interval, since: ZonedDateTime, until: ZonedDateTime): Option[ChartResult] =
       ???
@@ -39,19 +39,31 @@ class TickersSpec extends FunSuite {
         since: ZonedDateTime,
         until: ZonedDateTime
     ): Option[CorporateActions] = ???
+  }
+
+  private val stubOptions: Options[Id] = new Options[Id] {
     def getOptionExpirations(ticker: Ticker): Option[List[LocalDate]] = ???
     def getOptionChain(ticker: Ticker, expirationDate: LocalDate): Option[OptionChain] = ???
     def getFullOptionChain(ticker: Ticker): Option[FullOptionChain] = ???
+  }
+
+  private val stubHolders: Holders[Id] = new Holders[Id] {
     def getMajorHolders(ticker: Ticker): Option[MajorHolders] = ???
     def getInstitutionalHolders(ticker: Ticker): List[InstitutionalHolder] = ???
     def getMutualFundHolders(ticker: Ticker): List[MutualFundHolder] = ???
     def getInsiderTransactions(ticker: Ticker): List[InsiderTransaction] = ???
     def getInsiderRoster(ticker: Ticker): List[InsiderRosterEntry] = ???
     def getHoldersData(ticker: Ticker): Option[HoldersData] = ???
+  }
+
+  private val stubFinancials: Financials[Id] = new Financials[Id] {
     def getFinancialStatements(ticker: Ticker, frequency: Frequency): Option[FinancialStatements] = ???
     def getIncomeStatements(ticker: Ticker, frequency: Frequency): List[IncomeStatement] = ???
     def getBalanceSheets(ticker: Ticker, frequency: Frequency): List[BalanceSheet] = ???
     def getCashFlowStatements(ticker: Ticker, frequency: Frequency): List[CashFlowStatement] = ???
+  }
+
+  private val stubAnalysts: Analysts[Id] = new Analysts[Id] {
     def getAnalystPriceTargets(ticker: Ticker): Option[AnalystPriceTargets] = ???
     def getRecommendations(ticker: Ticker): List[RecommendationTrend] = ???
     def getUpgradeDowngradeHistory(ticker: Ticker): List[UpgradeDowngrade] = ???
@@ -62,46 +74,55 @@ class TickersSpec extends FunSuite {
     def getAnalystData(ticker: Ticker): Option[AnalystData] = ???
   }
 
+  private val client: YFinanceClient[Id] = new YFinanceClient[Id] {
+    val charts: Charts[Id] = stubCharts
+    val options: Options[Id] = stubOptions
+    val holders: Holders[Id] = stubHolders
+    val financials: Financials[Id] = stubFinancials
+    val analysts: Analysts[Id] = stubAnalysts
+    def search(query: String, maxResults: Int, newsCount: Int, enableFuzzyQuery: Boolean): SearchResult = ???
+  }
+
   // --- Factory Tests ---
 
-  test("Tickers.of should create from string varargs") {
+  test("creates ticker collection from string varargs") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     assertEquals(t.size, 2)
     assertEquals(t.tickers, NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT")))
   }
 
-  test("Tickers.of should deduplicate input tickers") {
+  test("deduplicates input tickers on creation") {
     val t = Tickers.of[Id](client, "AAPL", "AAPL", "MSFT", "MSFT")
     assertEquals(t.size, 2)
     assertEquals(t.tickers, NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT")))
   }
 
-  test("Tickers.apply should create from NonEmptyList") {
+  test("creates ticker collection from NonEmptyList") {
     val nel = NonEmptyList.of(Ticker("AAPL"), Ticker("GOOGL"))
     val t = Tickers[Id](client, nel)
     assertEquals(t.tickers, nel)
     assertEquals(t.size, 2)
   }
 
-  test("Tickers.single should create with one ticker") {
+  test("creates single-ticker collection") {
     val t = Tickers.single[Id](client, Ticker("AAPL"))
     assertEquals(t.size, 1)
     assertEquals(t.tickers.head, Ticker("AAPL"))
   }
 
-  test("Tickers.apply should use default parallelism of 4") {
+  test("defaults parallelism to 4") {
     val t = Tickers[Id](client, NonEmptyList.one(Ticker("AAPL")))
     assertEquals(t.parallelism, 4)
   }
 
-  test("Tickers.apply should accept custom parallelism") {
+  test("accepts custom parallelism") {
     val t = Tickers[Id](client, NonEmptyList.one(Ticker("AAPL")), parallelism = 8)
     assertEquals(t.parallelism, 8)
   }
 
   // --- Ticker List Manipulation Tests ---
 
-  test("add should append a new ticker") {
+  test("appends a new ticker") {
     val t = Tickers.of[Id](client, "AAPL")
     val t2 = t.add(Ticker("MSFT"))
     assertEquals(t2.size, 2)
@@ -109,14 +130,14 @@ class TickersSpec extends FunSuite {
     assert(t2.contains(Ticker("MSFT")))
   }
 
-  test("add should not duplicate an existing ticker") {
+  test("ignores duplicate when adding existing ticker") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     val t2 = t.add(Ticker("AAPL"))
     assertEquals(t2.size, 2)
     assertEquals(t2.tickers, t.tickers)
   }
 
-  test("addAll should append multiple new tickers") {
+  test("appends multiple new tickers") {
     val t = Tickers.of[Id](client, "AAPL")
     val t2 = t.addAll(NonEmptyList.of(Ticker("MSFT"), Ticker("GOOGL")))
     assertEquals(t2.size, 3)
@@ -125,14 +146,14 @@ class TickersSpec extends FunSuite {
     assert(t2.contains(Ticker("GOOGL")))
   }
 
-  test("addAll should deduplicate when adding") {
+  test("deduplicates when adding multiple tickers") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     val t2 = t.addAll(NonEmptyList.of(Ticker("MSFT"), Ticker("GOOGL")))
     assertEquals(t2.size, 3)
     assertEquals(t2.tickers, NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT"), Ticker("GOOGL")))
   }
 
-  test("remove should return Some when ticker exists and list has multiple elements") {
+  test("removes ticker from multi-element list") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     val result = t.remove(Ticker("AAPL"))
     assert(result.isDefined)
@@ -140,48 +161,48 @@ class TickersSpec extends FunSuite {
     assertEquals(result.get.tickers.head, Ticker("MSFT"))
   }
 
-  test("remove should return None when removing the only ticker") {
+  test("returns None when removing the only ticker") {
     val t = Tickers.single[Id](client, Ticker("AAPL"))
     val result = t.remove(Ticker("AAPL"))
     assertEquals(result, None)
   }
 
-  test("remove should return unchanged tickers when ticker not in list") {
+  test("returns unchanged list when removing absent ticker") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     val result = t.remove(Ticker("GOOGL"))
     assert(result.isDefined)
     assertEquals(result.get.tickers, t.tickers)
   }
 
-  test("contains should return true for existing ticker") {
+  test("finds existing ticker in collection") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     assert(t.contains(Ticker("AAPL")))
     assert(t.contains(Ticker("MSFT")))
   }
 
-  test("contains should return false for non-existing ticker") {
+  test("does not find absent ticker in collection") {
     val t = Tickers.of[Id](client, "AAPL")
     assert(!t.contains(Ticker("MSFT")))
   }
 
-  test("size should return number of tickers") {
+  test("reports correct collection size") {
     assertEquals(Tickers.single[Id](client, Ticker("AAPL")).size, 1)
     assertEquals(Tickers.of[Id](client, "AAPL", "MSFT", "GOOGL").size, 3)
   }
 
-  test("symbols should return string representations") {
+  test("extracts string symbols from tickers") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     assertEquals(t.symbols, NonEmptyList.of("AAPL", "MSFT"))
   }
 
-  test("withParallelism should return new instance with updated value") {
+  test("updates parallelism without mutating original") {
     val t = Tickers.of[Id](client, "AAPL")
     val t2 = t.withParallelism(8)
     assertEquals(t2.parallelism, 8)
     assertEquals(t.parallelism, 4) // original unchanged
   }
 
-  test("withParallelism should preserve tickers") {
+  test("preserves tickers when updating parallelism") {
     val t = Tickers.of[Id](client, "AAPL", "MSFT")
     val t2 = t.withParallelism(2)
     assertEquals(t2.tickers, t.tickers)


### PR DESCRIPTION
- Adding search(query) method to YFinanceClient with configurable maxResults, newsCount, and fuzzy matching
- Adding SearchResult, QuoteSearchResult, NewsItem, SearchList domain models
- Adding YFinanceSearchResult raw API model and Gateway endpoint (/v1/finance/search)