### PR TITLE
Moving internal raw API response models to models.internal sub-package

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Analysts.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Analysts.scala
@@ -5,6 +5,7 @@ import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import org.coinductive.yfinance4s.Mapping.*
 import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
 
 /** Algebra for analyst data (price targets, recommendations, estimates, etc.). */
 trait Analysts[F[_]] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Charts.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Charts.scala
@@ -3,7 +3,8 @@ package org.coinductive.yfinance4s
 import cats.Functor
 import cats.syntax.functor.*
 import org.coinductive.yfinance4s.models.*
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.InstrumentData
+import org.coinductive.yfinance4s.models.internal.{YFinanceQueryResult, YFinanceQuoteResult}
+import org.coinductive.yfinance4s.models.internal.YFinanceQueryResult.InstrumentData
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Financials.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Financials.scala
@@ -4,6 +4,7 @@ import cats.Functor
 import cats.syntax.functor.*
 import io.scalaland.chimney.dsl.*
 import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.YFinanceFinancialsResult
 
 /** Algebra for financial statements data. */
 trait Financials[F[_]] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Holders.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Holders.scala
@@ -5,6 +5,7 @@ import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import org.coinductive.yfinance4s.Mapping.*
 import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
 
 /** Algebra for holders and insider data. */
 trait Holders[F[_]] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Options.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Options.scala
@@ -5,6 +5,7 @@ import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import org.coinductive.yfinance4s.Mapping.*
 import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
 
 import java.time.{LocalDate, ZoneOffset}
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -8,6 +8,7 @@ import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import org.coinductive.yfinance4s.Mapping.*
 import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
 
 import java.time.ZonedDateTime
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -4,6 +4,7 @@ import cats.effect.{Async, Resource, Sync}
 import cats.syntax.show.*
 import io.circe.parser.decode
 import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
 import retry.{RetryPolicies, RetryPolicy, Sleep}
 import sttp.client3.{SttpBackend, UriContext, basicRequest}
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceScrapper.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceScrapper.scala
@@ -7,7 +7,8 @@ import cats.syntax.functor.*
 import cats.syntax.show.*
 import io.circe.parser.decode
 import org.coinductive.yfinance4s.html.PlatformHtmlParser
-import org.coinductive.yfinance4s.models.{Ticker, YFinanceQuoteResult}
+import org.coinductive.yfinance4s.models.Ticker
+import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult
 import retry.{RetryPolicies, RetryPolicy, Sleep}
 import sttp.client3.{SttpBackend, UriContext, basicRequest}
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/DividendEvent.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/DividendEvent.scala
@@ -1,6 +1,6 @@
 package org.coinductive.yfinance4s.models
 
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.DividendEventRaw
+import org.coinductive.yfinance4s.models.internal.YFinanceQueryResult.DividendEventRaw
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/SplitEvent.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/SplitEvent.scala
@@ -1,6 +1,6 @@
 package org.coinductive.yfinance4s.models
 
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.SplitEventRaw
+import org.coinductive.yfinance4s.models.internal.YFinanceQueryResult.SplitEventRaw
 
 import java.time.{Instant, ZoneOffset, ZonedDateTime}
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceAnalystResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceAnalystResult.scala
@@ -1,8 +1,8 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import io.circe.{Decoder, HCursor}
 import io.circe.generic.semiauto.deriveDecoder
-import org.coinductive.yfinance4s.models.YFinanceQuoteResult.Value
+import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult.Value
 
 // --- Top-level result wrapper ---
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceFinancialsResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceFinancialsResult.scala
@@ -1,4 +1,4 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import io.circe.{Decoder, Json}
 import io.circe.generic.semiauto.deriveDecoder

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceHoldersResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceHoldersResult.scala
@@ -1,8 +1,8 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import org.coinductive.yfinance4s.models.YFinanceQuoteResult.Value
+import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult.Value
 
 /** Raw API response for holders data from Quote Summary endpoint. */
 private[yfinance4s] final case class YFinanceHoldersResult(

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceOptionsResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceOptionsResult.scala
@@ -1,4 +1,4 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceQueryResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceQueryResult.scala
@@ -1,9 +1,9 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import cats.data.NonEmptyList
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.Chart
+import org.coinductive.yfinance4s.models.internal.YFinanceQueryResult.Chart
 
 private[yfinance4s] final case class YFinanceQueryResult(chart: Chart)
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceQuoteResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceQuoteResult.scala
@@ -1,11 +1,11 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import cats.syntax.either.*
 import cats.syntax.traverse.*
 import io.circe.generic.semiauto.deriveDecoder
 import io.circe.parser.decode
 import io.circe.{Decoder, DecodingFailure, HCursor, Json}
-import org.coinductive.yfinance4s.models.YFinanceQuoteResult.{Fundamentals, Summary}
+import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult.{Fundamentals, Summary}
 
 private[yfinance4s] final case class YFinanceQuoteResult(summary: Summary, fundamentals: Fundamentals)
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceSearchResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceSearchResult.scala
@@ -1,4 +1,4 @@
-package org.coinductive.yfinance4s.models
+package org.coinductive.yfinance4s.models.internal
 
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
@@ -2,7 +2,7 @@ package org.coinductive.yfinance4s.unit
 
 import munit.FunSuite
 import org.coinductive.yfinance4s.models.DividendEvent
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.DividendEventRaw
+import org.coinductive.yfinance4s.models.internal.YFinanceQueryResult.DividendEventRaw
 
 import java.time.{ZoneOffset, ZonedDateTime}
 

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
@@ -2,7 +2,7 @@ package org.coinductive.yfinance4s.unit
 
 import munit.FunSuite
 import org.coinductive.yfinance4s.models.SplitEvent
-import org.coinductive.yfinance4s.models.YFinanceQueryResult.SplitEventRaw
+import org.coinductive.yfinance4s.models.internal.YFinanceQueryResult.SplitEventRaw
 
 import java.time.{ZoneOffset, ZonedDateTime}
 


### PR DESCRIPTION
Separate private[yfinance4s] raw response types (YFinanceQueryResult, YFinanceQuoteResult, etc.) from public domain models by relocating them to a dedicated models.internal package, making the public/internal API boundary explicit in the package structure.