### PR TITLE
Adding stock screener with type-safe query DSL and predefined screens

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Analysts.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Analysts.scala
@@ -37,7 +37,10 @@ trait Analysts[F[_]] {
 
 private[yfinance4s] object Analysts {
 
-  final class Impl[F[_]: Monad](
+  def apply[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Analysts[F] =
+    new AnalystsImpl(gateway, auth)
+
+  private final class AnalystsImpl[F[_]: Monad](
       gateway: YFinanceGateway[F],
       auth: YFinanceAuth[F]
   ) extends Analysts[F] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Charts.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Charts.scala
@@ -61,7 +61,10 @@ trait Charts[F[_]] {
 
 private[yfinance4s] object Charts {
 
-  final class Impl[F[_]: Functor](
+  def apply[F[_]: Functor](gateway: YFinanceGateway[F], scrapper: YFinanceScrapper[F]): Charts[F] =
+    new ChartsImpl(gateway, scrapper)
+
+  private final class ChartsImpl[F[_]: Functor](
       gateway: YFinanceGateway[F],
       scrapper: YFinanceScrapper[F]
   ) extends Charts[F] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Financials.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Financials.scala
@@ -38,7 +38,10 @@ private[yfinance4s] object Financials {
 
   private val DefaultCurrency = "USD"
 
-  final class Impl[F[_]: Functor](gateway: YFinanceGateway[F]) extends Financials[F] {
+  def apply[F[_]: Functor](gateway: YFinanceGateway[F]): Financials[F] =
+    new FinancialsImpl(gateway)
+
+  private final class FinancialsImpl[F[_]: Functor](gateway: YFinanceGateway[F]) extends Financials[F] {
 
     def getFinancialStatements(
         ticker: Ticker,

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Holders.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Holders.scala
@@ -31,7 +31,10 @@ trait Holders[F[_]] {
 
 private[yfinance4s] object Holders {
 
-  final class Impl[F[_]: Monad](
+  def apply[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Holders[F] =
+    new HoldersImpl(gateway, auth)
+
+  private final class HoldersImpl[F[_]: Monad](
       gateway: YFinanceGateway[F],
       auth: YFinanceAuth[F]
   ) extends Holders[F] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Options.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Options.scala
@@ -24,7 +24,10 @@ trait Options[F[_]] {
 
 private[yfinance4s] object Options {
 
-  final class Impl[F[_]: Monad](
+  def apply[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Options[F] =
+    new OptionsImpl(gateway, auth)
+
+  private final class OptionsImpl[F[_]: Monad](
       gateway: YFinanceGateway[F],
       auth: YFinanceAuth[F]
   ) extends Options[F] {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Screener.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Screener.scala
@@ -1,0 +1,129 @@
+package org.coinductive.yfinance4s
+
+import cats.Monad
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import io.circe.Json
+import io.circe.syntax.*
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
+
+/** Algebra for stock and fund screening via Yahoo Finance.
+  *
+  * Build queries with [[models.EquityQuery]] or [[models.FundQuery]], then run them:
+  * {{{
+  * val query = EquityQuery.and(
+  *   EquityQuery.gt("percentchange", 3),
+  *   EquityQuery.eq("region", "us"),
+  *   EquityQuery.gte("intradaymarketcap", 2000000000L)
+  * )
+  * client.screener.screenEquities(query)
+  * }}}
+  *
+  * Or use predefined screens:
+  * {{{
+  * client.screener.screenPredefined(PredefinedScreen.DayGainers)
+  * }}}
+  */
+trait Screener[F[_]] {
+
+  /** Runs a custom equity (stock) screener query. */
+  def screenEquities(
+      query: ScreenerQuery,
+      config: ScreenerConfig = ScreenerConfig.Default
+  ): F[ScreenerResult]
+
+  /** Runs a custom mutual fund screener query. */
+  def screenFunds(
+      query: ScreenerQuery,
+      config: ScreenerConfig = ScreenerConfig.Default
+  ): F[ScreenerResult]
+
+  /** Runs a predefined screener query by name. */
+  def screenPredefined(
+      screen: PredefinedScreen,
+      count: Int = Screener.DefaultCount
+  ): F[ScreenerResult]
+}
+
+private[yfinance4s] object Screener {
+
+  val DefaultCount = 25
+
+  def apply[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Screener[F] =
+    new ScreenerImpl(gateway, auth)
+
+  private final class ScreenerImpl[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F])
+      extends Screener[F] {
+
+    private val EquityQuoteType = "EQUITY"
+    private val FundQuoteType = "MUTUALFUND"
+    private val DefaultUserId = ""
+    private val DefaultUserIdType = "guid"
+
+    def screenEquities(query: ScreenerQuery, config: ScreenerConfig): F[ScreenerResult] =
+      screenCustom(query, EquityQuoteType, config)
+
+    def screenFunds(query: ScreenerQuery, config: ScreenerConfig): F[ScreenerResult] =
+      screenCustom(query, FundQuoteType, config)
+
+    def screenPredefined(screen: PredefinedScreen, count: Int): F[ScreenerResult] =
+      gateway.screenPredefined(screen.screenId, count).map(mapScreenerResult)
+
+    // --- Private Helpers ---
+
+    private def screenCustom(query: ScreenerQuery, quoteType: String, config: ScreenerConfig): F[ScreenerResult] = {
+      val body = buildRequestBody(query, quoteType, config)
+      auth.getCredentials.flatMap { credentials =>
+        gateway.screenCustom(body, credentials).map(mapScreenerResult)
+      }
+    }
+
+    private def buildRequestBody(query: ScreenerQuery, quoteType: String, config: ScreenerConfig): String = {
+      val json = Json.obj(
+        "offset" -> Json.fromInt(config.offset),
+        "size" -> Json.fromInt(config.count),
+        "sortField" -> Json.fromString(config.sortField),
+        "sortType" -> Json.fromString(config.sortOrder.apiValue),
+        "userId" -> Json.fromString(DefaultUserId),
+        "userIdType" -> Json.fromString(DefaultUserIdType),
+        "quoteType" -> Json.fromString(quoteType),
+        "query" -> query.asJson
+      )
+      json.noSpaces
+    }
+
+    private def mapScreenerResult(raw: YFinanceScreenerResult): ScreenerResult =
+      ScreenerResult(
+        quotes = raw.quotes.flatMap(mapScreenerQuote),
+        total = raw.total
+      )
+
+    private def mapScreenerQuote(raw: ScreenerQuoteRaw): Option[ScreenerQuote] =
+      raw.symbol.map { sym =>
+        ScreenerQuote(
+          symbol = sym,
+          shortName = raw.shortName,
+          longName = raw.longName,
+          quoteType = raw.quoteType,
+          exchange = raw.exchange,
+          exchangeDisplay = raw.exchangeDisp,
+          sector = raw.sectorDisp.orElse(raw.sector),
+          industry = raw.industryDisp.orElse(raw.industry),
+          regularMarketPrice = raw.regularMarketPrice,
+          regularMarketChange = raw.regularMarketChange,
+          regularMarketChangePercent = raw.regularMarketChangePercent,
+          regularMarketVolume = raw.regularMarketVolume,
+          marketCap = raw.marketCap,
+          trailingPE = raw.trailingPE,
+          forwardPE = raw.forwardPE,
+          priceToBook = raw.priceToBook,
+          fiftyTwoWeekHigh = raw.fiftyTwoWeekHigh,
+          fiftyTwoWeekLow = raw.fiftyTwoWeekLow,
+          dividendYield = raw.dividendYield,
+          epsTrailingTwelveMonths = raw.epsTrailingTwelveMonths,
+          averageDailyVolume3Month = raw.averageDailyVolume3Month
+        )
+      }
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -37,6 +37,9 @@ trait YFinanceClient[F[_]] {
   /** Analyst data (price targets, recommendations, estimates, etc.). */
   def analysts: Analysts[F]
 
+  /** Stock and fund screener. */
+  def screener: Screener[F]
+
   /** Searches Yahoo Finance for tickers, companies, and news.
     *
     * @param query
@@ -130,7 +133,7 @@ object YFinanceClient {
       gateway <- YFinanceGateway.resource[F](config.connectTimeout, config.readTimeout, config.retries)
       scrapper <- YFinanceScrapper.resource[F](config.connectTimeout, config.readTimeout, config.retries)
       auth <- YFinanceAuth.resource[F](config.connectTimeout, config.readTimeout, config.retries)
-    } yield new Impl(gateway, scrapper, auth)
+    } yield new YFinanceClientImpl(gateway, scrapper, auth)
 
   private def downloadMulti[F[_], A](
       tickers: NonEmptyList[Ticker],
@@ -142,17 +145,18 @@ object YFinanceClient {
       }
       .map(_.toMap)
 
-  private final class Impl[F[_]: Monad](
+  private final class YFinanceClientImpl[F[_]: Monad](
       gateway: YFinanceGateway[F],
       scrapper: YFinanceScrapper[F],
       auth: YFinanceAuth[F]
   ) extends YFinanceClient[F] {
 
-    val charts: Charts[F] = new Charts.Impl(gateway, scrapper)
-    val options: Options[F] = new Options.Impl(gateway, auth)
-    val holders: Holders[F] = new Holders.Impl(gateway, auth)
-    val financials: Financials[F] = new Financials.Impl(gateway)
-    val analysts: Analysts[F] = new Analysts.Impl(gateway, auth)
+    val charts: Charts[F] = Charts(gateway, scrapper)
+    val options: Options[F] = Options(gateway, auth)
+    val holders: Holders[F] = Holders(gateway, auth)
+    val financials: Financials[F] = Financials(gateway)
+    val analysts: Analysts[F] = Analysts(gateway, auth)
+    val screener: Screener[F] = Screener(gateway, auth)
 
     def search(
         query: String,

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -32,6 +32,10 @@ sealed trait YFinanceGateway[F[_]] {
   def getAnalystData(ticker: Ticker, credentials: YFinanceCredentials): F[YFinanceAnalystResult]
 
   def search(query: String, quotesCount: Int, newsCount: Int, enableFuzzyQuery: Boolean): F[YFinanceSearchResult]
+
+  def screenCustom(body: String, credentials: YFinanceCredentials): F[YFinanceScreenerResult]
+
+  def screenPredefined(screenId: String, count: Int): F[YFinanceScreenerResult]
 }
 
 private object YFinanceGateway {
@@ -71,8 +75,18 @@ private object YFinanceGateway {
       uri"https://query2.finance.yahoo.com/ws/fundamentals-timeseries/v1/finance/timeseries/"
 
     private val SearchEndpoint = uri"https://query2.finance.yahoo.com/v1/finance/search"
+    private val ScreenerEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/screener"
+    private val PredefinedScreenerEndpoint =
+      uri"https://query1.finance.yahoo.com/v1/finance/screener/predefined/saved"
     private val DefaultQuotesQueryId = "tss_match_phrase_query"
     private val DefaultNewsQueryId = "news_cie_vespa"
+
+    private val ScreenerQueryParams = Map(
+      "corsDomain" -> "finance.yahoo.com",
+      "formatted" -> "false",
+      "lang" -> "en-US",
+      "region" -> "US"
+    )
 
     def getChart(ticker: Ticker, interval: Interval, range: Range): F[YFinanceQueryResult] = {
       val req =
@@ -264,6 +278,35 @@ private object YFinanceGateway {
       decode[YFinanceSearchResult](content)
         .fold(
           e => F.raiseError(new Exception(s"Failed to parse search response: ${e.getMessage}")),
+          F.pure
+        )
+
+    def screenCustom(body: String, credentials: YFinanceCredentials): F[YFinanceScreenerResult] = {
+      val params = ScreenerQueryParams ++ Map("crumb" -> credentials.crumb)
+      val req = basicRequest
+        .post(ScreenerEndpoint.withParams(params))
+        .body(body)
+        .contentType("application/json")
+        .headers(YFinanceAuth.apiHeaders *)
+        .header("Cookie", credentials.cookies.mkString("; "))
+
+      sendRequest(req, parseScreenerContent)
+    }
+
+    def screenPredefined(screenId: String, count: Int): F[YFinanceScreenerResult] = {
+      val params = ScreenerQueryParams ++ Map(
+        "scrIds" -> screenId,
+        "count" -> count.toString
+      )
+      val req = basicRequest.get(PredefinedScreenerEndpoint.withParams(params))
+
+      sendRequest(req, parseScreenerContent)
+    }
+
+    private def parseScreenerContent(content: String): F[YFinanceScreenerResult] =
+      decode[YFinanceScreenerResult](content)
+        .fold(
+          e => F.raiseError(new Exception(s"Failed to parse screener response: ${e.getMessage}")),
           F.pure
         )
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/PredefinedScreen.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/PredefinedScreen.scala
@@ -1,0 +1,74 @@
+package org.coinductive.yfinance4s.models
+
+/** A named predefined screener query available on Yahoo Finance.
+  *
+  * These correspond to Yahoo's built-in screens accessible via the `/v1/finance/screener/predefined/saved` endpoint.
+  *
+  * @param screenId
+  *   The Yahoo API identifier (e.g., `"day_gainers"`)
+  */
+sealed abstract class PredefinedScreen(val screenId: String)
+
+object PredefinedScreen {
+  case object AggressiveSmallCaps extends PredefinedScreen("aggressive_small_caps")
+  case object DayGainers extends PredefinedScreen("day_gainers")
+  case object DayLosers extends PredefinedScreen("day_losers")
+  case object GrowthTechnologyStocks extends PredefinedScreen("growth_technology_stocks")
+  case object MostActives extends PredefinedScreen("most_actives")
+  case object MostShortedStocks extends PredefinedScreen("most_shorted_stocks")
+  case object SmallCapGainers extends PredefinedScreen("small_cap_gainers")
+  case object UndervaluedGrowthStocks extends PredefinedScreen("undervalued_growth_stocks")
+  case object UndervaluedLargeCaps extends PredefinedScreen("undervalued_large_caps")
+  case object ConservativeForeignFunds extends PredefinedScreen("conservative_foreign_funds")
+  case object HighYieldBond extends PredefinedScreen("high_yield_bond")
+  case object PortfolioAnchors extends PredefinedScreen("portfolio_anchors")
+  case object SolidLargeGrowthFunds extends PredefinedScreen("solid_large_growth_funds")
+  case object SolidMidcapGrowthFunds extends PredefinedScreen("solid_midcap_growth_funds")
+  case object TopMutualFunds extends PredefinedScreen("top_mutual_funds")
+
+  /** All predefined screens. */
+  val values: List[PredefinedScreen] = List(
+    AggressiveSmallCaps,
+    DayGainers,
+    DayLosers,
+    GrowthTechnologyStocks,
+    MostActives,
+    MostShortedStocks,
+    SmallCapGainers,
+    UndervaluedGrowthStocks,
+    UndervaluedLargeCaps,
+    ConservativeForeignFunds,
+    HighYieldBond,
+    PortfolioAnchors,
+    SolidLargeGrowthFunds,
+    SolidMidcapGrowthFunds,
+    TopMutualFunds
+  )
+
+  /** Equity-focused predefined screens. */
+  val equityScreens: List[PredefinedScreen] = List(
+    AggressiveSmallCaps,
+    DayGainers,
+    DayLosers,
+    GrowthTechnologyStocks,
+    MostActives,
+    MostShortedStocks,
+    SmallCapGainers,
+    UndervaluedGrowthStocks,
+    UndervaluedLargeCaps
+  )
+
+  /** Fund-focused predefined screens. */
+  val fundScreens: List[PredefinedScreen] = List(
+    ConservativeForeignFunds,
+    HighYieldBond,
+    PortfolioAnchors,
+    SolidLargeGrowthFunds,
+    SolidMidcapGrowthFunds,
+    TopMutualFunds
+  )
+
+  /** Looks up a predefined screen by its Yahoo API identifier. */
+  def fromScreenId(id: String): Option[PredefinedScreen] =
+    values.find(_.screenId == id)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ScreenerQuery.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ScreenerQuery.scala
@@ -1,0 +1,186 @@
+package org.coinductive.yfinance4s.models
+
+import io.circe.{Encoder, Json}
+
+/** A value used as an operand in a screener query filter — either a string or a number. */
+sealed trait ScreenerValue {
+  private[yfinance4s] def toJson: Json
+}
+
+object ScreenerValue {
+  final case class StringVal(value: String) extends ScreenerValue {
+    private[yfinance4s] def toJson: Json = Json.fromString(value)
+  }
+
+  final case class NumericVal(value: Double) extends ScreenerValue {
+    private[yfinance4s] def toJson: Json =
+      if (value == math.floor(value) && !value.isInfinite) Json.fromLong(value.toLong)
+      else Json.fromDoubleOrNull(value)
+  }
+
+  def apply(s: String): ScreenerValue = StringVal(s)
+  def apply(n: Double): ScreenerValue = NumericVal(n)
+  def apply(n: Int): ScreenerValue = NumericVal(n.toDouble)
+  def apply(n: Long): ScreenerValue = NumericVal(n.toDouble)
+
+  implicit val encoder: Encoder[ScreenerValue] = Encoder.instance(_.toJson)
+}
+
+/** A recursive query tree for Yahoo Finance screener filters.
+  *
+  * Build queries using the [[EquityQuery]] or [[FundQuery]] companion builders, then pass them to
+  * [[org.coinductive.yfinance4s.Screener Screener]] methods.
+  *
+  * {{{
+  * val query = EquityQuery.and(
+  *   EquityQuery.gt("percentchange", 3),
+  *   EquityQuery.eq("region", "us"),
+  *   EquityQuery.gte("intradaymarketcap", 2000000000L)
+  * )
+  * client.screener.screenEquities(query)
+  * }}}
+  */
+sealed trait ScreenerQuery
+
+object ScreenerQuery {
+  final case class Eq(field: String, value: ScreenerValue) extends ScreenerQuery
+  final case class Gt(field: String, value: Double) extends ScreenerQuery
+  final case class Gte(field: String, value: Double) extends ScreenerQuery
+  final case class Lt(field: String, value: Double) extends ScreenerQuery
+  final case class Lte(field: String, value: Double) extends ScreenerQuery
+  final case class Between(field: String, low: Double, high: Double) extends ScreenerQuery
+  final case class IsIn(field: String, values: List[ScreenerValue]) extends ScreenerQuery {
+    require(values.nonEmpty, "IS-IN requires at least one value")
+  }
+  final case class And(operands: List[ScreenerQuery]) extends ScreenerQuery {
+    require(operands.size >= 2, "AND requires at least 2 operands")
+  }
+  final case class Or(operands: List[ScreenerQuery]) extends ScreenerQuery {
+    require(operands.size >= 2, "OR requires at least 2 operands")
+  }
+
+  implicit val encoder: Encoder[ScreenerQuery] = Encoder.instance(encodeQuery)
+
+  private def encodeQuery(q: ScreenerQuery): Json = q match {
+    case Eq(field, value) =>
+      Json.obj("operator" -> Json.fromString("EQ"), "operands" -> Json.arr(Json.fromString(field), value.toJson))
+
+    case Gt(field, value) =>
+      comparisonJson("GT", field, value)
+
+    case Gte(field, value) =>
+      comparisonJson("GTE", field, value)
+
+    case Lt(field, value) =>
+      comparisonJson("LT", field, value)
+
+    case Lte(field, value) =>
+      comparisonJson("LTE", field, value)
+
+    case Between(field, low, high) =>
+      Json.obj(
+        "operator" -> Json.fromString("BTWN"),
+        "operands" -> Json.arr(Json.fromString(field), numericJson(low), numericJson(high))
+      )
+
+    case IsIn(field, values) =>
+      // IS-IN expands to OR of EQ queries per Yahoo API wire format
+      val eqOps = values.map(v => encodeQuery(Eq(field, v)))
+      Json.obj("operator" -> Json.fromString("OR"), "operands" -> Json.arr(eqOps *))
+
+    case And(operands) =>
+      Json.obj("operator" -> Json.fromString("AND"), "operands" -> Json.arr(operands.map(encodeQuery) *))
+
+    case Or(operands) =>
+      Json.obj("operator" -> Json.fromString("OR"), "operands" -> Json.arr(operands.map(encodeQuery) *))
+  }
+
+  private def comparisonJson(op: String, field: String, value: Double): Json =
+    Json.obj("operator" -> Json.fromString(op), "operands" -> Json.arr(Json.fromString(field), numericJson(value)))
+
+  private def numericJson(value: Double): Json =
+    if (value == math.floor(value) && !value.isInfinite) Json.fromLong(value.toLong)
+    else Json.fromDoubleOrNull(value)
+}
+
+/** Builder for equity (stock) screener queries. Queries built with this object will be sent with `quoteType =
+  * "EQUITY"`.
+  *
+  * {{{
+  * val q = EquityQuery.and(
+  *   EquityQuery.gt("percentchange", 3),
+  *   EquityQuery.eq("region", "us")
+  * )
+  * }}}
+  */
+object EquityQuery {
+  def eq(field: String, value: String): ScreenerQuery = ScreenerQuery.Eq(field, ScreenerValue(value))
+  def eq(field: String, value: Double): ScreenerQuery = ScreenerQuery.Eq(field, ScreenerValue(value))
+  def eq(field: String, value: Int): ScreenerQuery = ScreenerQuery.Eq(field, ScreenerValue(value))
+
+  def gt(field: String, value: Double): ScreenerQuery = ScreenerQuery.Gt(field, value)
+  def gt(field: String, value: Int): ScreenerQuery = ScreenerQuery.Gt(field, value.toDouble)
+  def gt(field: String, value: Long): ScreenerQuery = ScreenerQuery.Gt(field, value.toDouble)
+
+  def gte(field: String, value: Double): ScreenerQuery = ScreenerQuery.Gte(field, value)
+  def gte(field: String, value: Int): ScreenerQuery = ScreenerQuery.Gte(field, value.toDouble)
+  def gte(field: String, value: Long): ScreenerQuery = ScreenerQuery.Gte(field, value.toDouble)
+
+  def lt(field: String, value: Double): ScreenerQuery = ScreenerQuery.Lt(field, value)
+  def lt(field: String, value: Int): ScreenerQuery = ScreenerQuery.Lt(field, value.toDouble)
+  def lt(field: String, value: Long): ScreenerQuery = ScreenerQuery.Lt(field, value.toDouble)
+
+  def lte(field: String, value: Double): ScreenerQuery = ScreenerQuery.Lte(field, value)
+  def lte(field: String, value: Int): ScreenerQuery = ScreenerQuery.Lte(field, value.toDouble)
+  def lte(field: String, value: Long): ScreenerQuery = ScreenerQuery.Lte(field, value.toDouble)
+
+  def between(field: String, low: Double, high: Double): ScreenerQuery = ScreenerQuery.Between(field, low, high)
+  def between(field: String, low: Long, high: Long): ScreenerQuery =
+    ScreenerQuery.Between(field, low.toDouble, high.toDouble)
+
+  def isIn(field: String, values: Seq[ScreenerValue]): ScreenerQuery = ScreenerQuery.IsIn(field, values.toList)
+
+  def and(operands: ScreenerQuery*): ScreenerQuery = ScreenerQuery.And(operands.toList)
+  def or(operands: ScreenerQuery*): ScreenerQuery = ScreenerQuery.Or(operands.toList)
+}
+
+/** Builder for mutual fund screener queries. Queries built with this object will be sent with `quoteType =
+  * "MUTUALFUND"`.
+  *
+  * {{{
+  * val q = FundQuery.and(
+  *   FundQuery.eq("categoryname", "Large Growth"),
+  *   FundQuery.isIn("performanceratingoverall", Seq(ScreenerValue(4), ScreenerValue(5)))
+  * )
+  * }}}
+  */
+object FundQuery {
+  def eq(field: String, value: String): ScreenerQuery = ScreenerQuery.Eq(field, ScreenerValue(value))
+  def eq(field: String, value: Double): ScreenerQuery = ScreenerQuery.Eq(field, ScreenerValue(value))
+  def eq(field: String, value: Int): ScreenerQuery = ScreenerQuery.Eq(field, ScreenerValue(value))
+
+  def gt(field: String, value: Double): ScreenerQuery = ScreenerQuery.Gt(field, value)
+  def gt(field: String, value: Int): ScreenerQuery = ScreenerQuery.Gt(field, value.toDouble)
+  def gt(field: String, value: Long): ScreenerQuery = ScreenerQuery.Gt(field, value.toDouble)
+
+  def gte(field: String, value: Double): ScreenerQuery = ScreenerQuery.Gte(field, value)
+  def gte(field: String, value: Int): ScreenerQuery = ScreenerQuery.Gte(field, value.toDouble)
+  def gte(field: String, value: Long): ScreenerQuery = ScreenerQuery.Gte(field, value.toDouble)
+
+  def lt(field: String, value: Double): ScreenerQuery = ScreenerQuery.Lt(field, value)
+  def lt(field: String, value: Int): ScreenerQuery = ScreenerQuery.Lt(field, value.toDouble)
+  def lt(field: String, value: Long): ScreenerQuery = ScreenerQuery.Lt(field, value.toDouble)
+
+  def lte(field: String, value: Double): ScreenerQuery = ScreenerQuery.Lte(field, value)
+  def lte(field: String, value: Int): ScreenerQuery = ScreenerQuery.Lte(field, value.toDouble)
+  def lte(field: String, value: Long): ScreenerQuery = ScreenerQuery.Lte(field, value.toDouble)
+
+  def between(field: String, low: Double, high: Double): ScreenerQuery = ScreenerQuery.Between(field, low, high)
+  def between(field: String, low: Long, high: Long): ScreenerQuery =
+    ScreenerQuery.Between(field, low.toDouble, high.toDouble)
+
+  def isIn(field: String, values: Seq[ScreenerValue]): ScreenerQuery = ScreenerQuery.IsIn(field, values.toList)
+
+  def and(operands: ScreenerQuery*): ScreenerQuery = ScreenerQuery.And(operands.toList)
+  def or(operands: ScreenerQuery*): ScreenerQuery = ScreenerQuery.Or(operands.toList)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ScreenerResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/ScreenerResult.scala
@@ -1,0 +1,203 @@
+package org.coinductive.yfinance4s.models
+
+/** Sort order for screener results. */
+sealed trait SortOrder {
+  private[yfinance4s] def apiValue: String
+}
+
+object SortOrder {
+  case object Asc extends SortOrder { val apiValue = "ASC" }
+  case object Desc extends SortOrder { val apiValue = "DESC" }
+}
+
+/** Configuration for a custom screener query.
+  *
+  * @param sortField
+  *   Field to sort results by (e.g., `"ticker"`, `"percentchange"`, `"dayvolume"`)
+  * @param sortOrder
+  *   Sort direction
+  * @param offset
+  *   Number of results to skip (for pagination)
+  * @param count
+  *   Maximum number of results to return (max 250)
+  */
+final case class ScreenerConfig(
+    sortField: String = ScreenerConfig.DefaultSortField,
+    sortOrder: SortOrder = SortOrder.Desc,
+    offset: Int = ScreenerConfig.DefaultOffset,
+    count: Int = ScreenerConfig.DefaultCount
+) {
+  require(count >= 1 && count <= ScreenerConfig.MaxCount, s"count must be between 1 and ${ScreenerConfig.MaxCount}")
+  require(offset >= 0, "offset must be non-negative")
+}
+
+object ScreenerConfig {
+  val DefaultSortField = "ticker"
+  val DefaultOffset = 0
+  val DefaultCount = 25
+  val MaxCount = 250
+
+  val Default: ScreenerConfig = ScreenerConfig()
+}
+
+/** A single quote from a screener result.
+  *
+  * @param symbol
+  *   Ticker symbol (e.g., "AAPL")
+  * @param shortName
+  *   Short display name
+  * @param longName
+  *   Full legal name
+  * @param quoteType
+  *   Instrument type ("EQUITY", "MUTUALFUND", etc.)
+  * @param exchange
+  *   Exchange code (e.g., "NMS", "NYQ")
+  * @param exchangeDisplay
+  *   Human-readable exchange name (e.g., "NASDAQ")
+  * @param sector
+  *   Business sector
+  * @param industry
+  *   Business industry
+  * @param regularMarketPrice
+  *   Current/last market price
+  * @param regularMarketChange
+  *   Absolute price change
+  * @param regularMarketChangePercent
+  *   Percentage price change
+  * @param regularMarketVolume
+  *   Trading volume
+  * @param marketCap
+  *   Market capitalization
+  * @param trailingPE
+  *   Trailing P/E ratio
+  * @param forwardPE
+  *   Forward P/E ratio
+  * @param priceToBook
+  *   Price-to-book ratio
+  * @param fiftyTwoWeekHigh
+  *   52-week high price
+  * @param fiftyTwoWeekLow
+  *   52-week low price
+  * @param dividendYield
+  *   Dividend yield (as decimal, e.g. 0.005 for 0.5%)
+  * @param epsTrailingTwelveMonths
+  *   Trailing 12-month earnings per share
+  * @param averageDailyVolume3Month
+  *   3-month average daily trading volume
+  */
+final case class ScreenerQuote(
+    symbol: String,
+    shortName: Option[String],
+    longName: Option[String],
+    quoteType: Option[String],
+    exchange: Option[String],
+    exchangeDisplay: Option[String],
+    sector: Option[String],
+    industry: Option[String],
+    regularMarketPrice: Option[Double],
+    regularMarketChange: Option[Double],
+    regularMarketChangePercent: Option[Double],
+    regularMarketVolume: Option[Long],
+    marketCap: Option[Long],
+    trailingPE: Option[Double],
+    forwardPE: Option[Double],
+    priceToBook: Option[Double],
+    fiftyTwoWeekHigh: Option[Double],
+    fiftyTwoWeekLow: Option[Double],
+    dividendYield: Option[Double],
+    epsTrailingTwelveMonths: Option[Double],
+    averageDailyVolume3Month: Option[Long]
+) {
+
+  /** Best available display name: longName -> shortName -> symbol. */
+  def displayName: String = longName.orElse(shortName).getOrElse(symbol)
+
+  /** Converts this quote to a [[Ticker]]. */
+  def toTicker: Ticker = Ticker(symbol)
+
+  /** True if this is an equity/stock. */
+  def isEquity: Boolean = quoteType.contains("EQUITY")
+
+  /** True if this is a mutual fund. */
+  def isMutualFund: Boolean = quoteType.contains("MUTUALFUND")
+
+  /** True if this is an ETF. */
+  def isETF: Boolean = quoteType.contains("ETF")
+
+  /** Distance from 52-week high as a percentage (negative means below high). */
+  def distanceFrom52WeekHigh: Option[Double] =
+    for {
+      price <- regularMarketPrice
+      high <- fiftyTwoWeekHigh
+      if high > 0
+    } yield (price - high) / high * 100.0
+
+  /** Distance from 52-week low as a percentage (positive means above low). */
+  def distanceFrom52WeekLow: Option[Double] =
+    for {
+      price <- regularMarketPrice
+      low <- fiftyTwoWeekLow
+      if low > 0
+    } yield (price - low) / low * 100.0
+}
+
+object ScreenerQuote {
+
+  /** Orders quotes by market cap descending (largest first), with None-cap quotes last. */
+  implicit val ordering: Ordering[ScreenerQuote] =
+    Ordering.by[ScreenerQuote, Long](_.marketCap.getOrElse(0L)).reverse
+}
+
+/** Aggregate screener results from Yahoo Finance.
+  *
+  * @param quotes
+  *   Matched securities
+  * @param total
+  *   Total number of matches on Yahoo's side (may be larger than `quotes.size` due to pagination)
+  */
+final case class ScreenerResult(
+    quotes: List[ScreenerQuote],
+    total: Int
+) {
+
+  /** True if any results were returned. */
+  def nonEmpty: Boolean = quotes.nonEmpty
+
+  /** True if no results were returned. */
+  def isEmpty: Boolean = quotes.isEmpty
+
+  /** Number of quotes in this page of results. */
+  def size: Int = quotes.size
+
+  /** True if there are more results available beyond this page. */
+  def hasMore: Boolean = total > quotes.size
+
+  /** Extracts all matched ticker symbols. */
+  def symbols: List[String] = quotes.map(_.symbol)
+
+  /** Extracts all matched tickers as [[Ticker]] values. */
+  def tickers: List[Ticker] = quotes.map(_.toTicker)
+
+  /** Filters to equity quotes only. */
+  def equities: List[ScreenerQuote] = quotes.filter(_.isEquity)
+
+  /** Filters to mutual fund quotes only. */
+  def funds: List[ScreenerQuote] = quotes.filter(_.isMutualFund)
+
+  /** Filters to ETF quotes only. */
+  def etfs: List[ScreenerQuote] = quotes.filter(_.isETF)
+
+  /** Returns the quote with the highest market cap, if any. */
+  def largestByMarketCap: Option[ScreenerQuote] = quotes.sorted.headOption
+
+  /** Returns quotes filtered to a specific sector. */
+  def bySector(sector: String): List[ScreenerQuote] =
+    quotes.filter(_.sector.contains(sector))
+
+  /** Returns all distinct sectors present in the results. */
+  def sectors: List[String] = quotes.flatMap(_.sector).distinct
+}
+
+object ScreenerResult {
+  val empty: ScreenerResult = ScreenerResult(quotes = List.empty, total = 0)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceScreenerResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceScreenerResult.scala
@@ -1,0 +1,59 @@
+package org.coinductive.yfinance4s.models.internal
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+
+/** Raw Yahoo Finance screener API response.
+  *
+  * Wraps the `finance.result[0]` object which contains the total count and list of quote objects.
+  */
+private[yfinance4s] final case class YFinanceScreenerResult(
+    total: Int,
+    quotes: List[ScreenerQuoteRaw]
+)
+
+private[yfinance4s] object YFinanceScreenerResult {
+
+  /** Decoder that unwraps the `finance.result[0]` envelope. */
+  implicit val decoder: Decoder[YFinanceScreenerResult] = Decoder.instance { c =>
+    val result = c.downField("finance").downField("result").downArray
+    for {
+      total <- result.downField("total").as[Option[Int]]
+      quotes <- result.downField("quotes").as[Option[List[ScreenerQuoteRaw]]]
+    } yield YFinanceScreenerResult(
+      total = total.getOrElse(0),
+      quotes = quotes.getOrElse(List.empty)
+    )
+  }
+}
+
+/** Raw quote data from screener response. Field names match Yahoo's JSON exactly. */
+private[yfinance4s] final case class ScreenerQuoteRaw(
+    symbol: Option[String],
+    shortName: Option[String],
+    longName: Option[String],
+    quoteType: Option[String],
+    exchange: Option[String],
+    exchangeDisp: Option[String],
+    sector: Option[String],
+    sectorDisp: Option[String],
+    industry: Option[String],
+    industryDisp: Option[String],
+    regularMarketPrice: Option[Double],
+    regularMarketChange: Option[Double],
+    regularMarketChangePercent: Option[Double],
+    regularMarketVolume: Option[Long],
+    marketCap: Option[Long],
+    trailingPE: Option[Double],
+    forwardPE: Option[Double],
+    priceToBook: Option[Double],
+    fiftyTwoWeekHigh: Option[Double],
+    fiftyTwoWeekLow: Option[Double],
+    dividendYield: Option[Double],
+    epsTrailingTwelveMonths: Option[Double],
+    averageDailyVolume3Month: Option[Long]
+)
+
+private[yfinance4s] object ScreenerQuoteRaw {
+  implicit val decoder: Decoder[ScreenerQuoteRaw] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/OptionsChainSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/OptionsChainSpec.scala
@@ -102,7 +102,7 @@ class OptionsChainSpec extends CatsEffectSuite {
     }
   }
 
-  test("implied volatility is positive for all contracts") {
+  test("implied volatility is non-negative and mostly positive") {
     YFinanceClient.resource[IO](config).use { client =>
       client.options.getFullOptionChain(testTicker).map { fullChainOpt =>
         assert(fullChainOpt.isDefined)
@@ -112,11 +112,18 @@ class OptionsChainSpec extends CatsEffectSuite {
 
         assert(ivValues.nonEmpty, "Should have IV values")
 
-        // IV should be positive; very high values (>1000%) are possible for
-        // illiquid or far OTM options and are not necessarily data errors
+        // IV is non-negative; Yahoo returns 0.0 for illiquid contracts with
+        // no recent trades or bid/ask to compute from
         ivValues.foreach { iv =>
-          assert(iv > 0, s"IV should be positive: $iv")
+          assert(iv >= 0, s"IV should be non-negative: $iv")
         }
+
+        // Most contracts for a liquid stock like AAPL should have positive IV
+        val positiveCount = ivValues.count(_ > 0)
+        assert(
+          positiveCount > ivValues.size / 2,
+          s"Majority of contracts should have positive IV, got $positiveCount/${ivValues.size}"
+        )
       }
     }
   }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/ScreenerSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/ScreenerSpec.scala
@@ -1,0 +1,153 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.*
+
+import scala.concurrent.duration.*
+
+class ScreenerSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  // --- Predefined screen tests ---
+
+  test("predefined DayGainers returns equity results") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.screener.screenPredefined(PredefinedScreen.DayGainers).map { result =>
+        assert(result.nonEmpty, "Day gainers should return results")
+        assert(result.total > 0, "Total should be positive")
+        result.quotes.foreach { q =>
+          assert(q.symbol.nonEmpty, "Each quote should have a symbol")
+        }
+      }
+    }
+  }
+
+  test("predefined MostActives returns results with volume data") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.screener.screenPredefined(PredefinedScreen.MostActives).map { result =>
+        assert(result.nonEmpty, "Most actives should return results")
+        // Most active stocks should have volume data
+        val withVolume = result.quotes.filter(_.regularMarketVolume.isDefined)
+        assert(withVolume.nonEmpty, "Some quotes should have volume data")
+      }
+    }
+  }
+
+  test("predefined screen respects count parameter") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.screener.screenPredefined(PredefinedScreen.DayGainers, count = 5).map { result =>
+        assert(result.quotes.size <= 5, s"Should have at most 5 quotes, got ${result.quotes.size}")
+      }
+    }
+  }
+
+  test("predefined TopMutualFunds returns fund results") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.screener.screenPredefined(PredefinedScreen.TopMutualFunds).map { result =>
+        assert(result.nonEmpty, "Top mutual funds should return results")
+      }
+    }
+  }
+
+  // --- Custom equity screen tests ---
+
+  test("custom equity screen with simple filter returns results") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val query = EquityQuery.and(
+        EquityQuery.eq("region", "us"),
+        EquityQuery.gte("intradaymarketcap", 2000000000L)
+      )
+      client.screener.screenEquities(query).map { result =>
+        assert(result.nonEmpty, "Large-cap US equities should return results")
+        assert(result.total > 0, "Total should be positive")
+      }
+    }
+  }
+
+  test("custom equity screen returns quotes with expected structure") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val query = EquityQuery.and(
+        EquityQuery.gt("percentchange", 3),
+        EquityQuery.eq("region", "us"),
+        EquityQuery.gte("intradaymarketcap", 2000000000L),
+        EquityQuery.gte("intradayprice", 5),
+        EquityQuery.gt("dayvolume", 15000)
+      )
+      val screenerConfig = ScreenerConfig(sortField = "percentchange", sortOrder = SortOrder.Desc, count = 5)
+      client.screener.screenEquities(query, screenerConfig).map { result =>
+        result.quotes.foreach { q =>
+          assert(q.symbol.nonEmpty, "Symbol should not be empty")
+          assert(q.displayName.nonEmpty, "Display name should not be empty")
+        }
+      }
+    }
+  }
+
+  test("custom equity screen respects count config") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val query = EquityQuery.and(
+        EquityQuery.eq("region", "us"),
+        EquityQuery.gte("intradaymarketcap", 2000000000L)
+      )
+      val screenerConfig = ScreenerConfig(count = 3)
+      client.screener.screenEquities(query, screenerConfig).map { result =>
+        assert(result.quotes.size <= 3, s"Should have at most 3 quotes, got ${result.quotes.size}")
+      }
+    }
+  }
+
+  test("custom equity screen with between filter returns results") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val query = EquityQuery.and(
+        EquityQuery.between("peratio.lasttwelvemonths", 0, 20),
+        EquityQuery.isIn("exchange", Seq(ScreenerValue("NMS"), ScreenerValue("NYQ")))
+      )
+      client.screener.screenEquities(query, ScreenerConfig(count = 5)).map { result =>
+        assert(result.nonEmpty, "Low-PE exchange-filtered screen should return results")
+      }
+    }
+  }
+
+  // --- Custom fund screen tests ---
+
+  test("custom fund screen returns results") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val query = FundQuery.and(
+        FundQuery.eq("exchange", "NAS"),
+        FundQuery.gt("intradayprice", 15)
+      )
+      client.screener.screenFunds(query, ScreenerConfig(count = 5)).map { result =>
+        assert(result.nonEmpty, "Fund screen should return results")
+      }
+    }
+  }
+
+  // --- Convenience method tests ---
+
+  test("extracts symbols and tickers from live results") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.screener.screenPredefined(PredefinedScreen.MostActives, count = 3).map { result =>
+        assert(result.symbols.nonEmpty, "symbols should not be empty")
+        assert(result.tickers.nonEmpty, "tickers should not be empty")
+        assertEquals(result.symbols.size, result.tickers.size)
+      }
+    }
+  }
+
+  test("detects more results when total exceeds page size") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.screener.screenPredefined(PredefinedScreen.MostActives, count = 1).map { result =>
+        if (result.total > 1) {
+          assert(result.hasMore, s"total=${result.total} > size=1, should have more")
+        }
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/DividendEventSpec.scala
@@ -8,7 +8,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 class DividendEventSpec extends FunSuite {
 
-  test("converts raw timestamp to ZonedDateTime") {
+  test("parses epoch timestamp into date") {
     val raw = DividendEventRaw(amount = 0.24, date = 1704067200L)
     val event = DividendEvent.fromRaw("1704067200", raw)
 

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/ScreenerQuerySpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/ScreenerQuerySpec.scala
@@ -1,0 +1,182 @@
+package org.coinductive.yfinance4s.unit
+
+import io.circe.syntax.*
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+class ScreenerQuerySpec extends FunSuite {
+
+  // --- ScreenerValue tests ---
+
+  test("encodes string values as JSON strings") {
+    val v = ScreenerValue("us")
+    assertEquals(v.toJson.asString, Some("us"))
+  }
+
+  test("encodes whole numbers without decimal points") {
+    val v = ScreenerValue(3)
+    assertEquals(v.toJson.asNumber.flatMap(_.toLong), Some(3L))
+  }
+
+  test("encodes fractional numbers with decimal points") {
+    val v = ScreenerValue(3.5)
+    assertEquals(v.toJson.asNumber.map(_.toDouble), Some(3.5))
+  }
+
+  test("encodes large numbers without precision loss") {
+    val v = ScreenerValue(2000000000L)
+    assertEquals(v.toJson.asNumber.flatMap(_.toLong), Some(2000000000L))
+  }
+
+  // --- EquityQuery builder tests ---
+
+  test("eq creates equality filter for string value") {
+    val q = EquityQuery.eq("region", "us")
+    assert(q.isInstanceOf[ScreenerQuery.Eq])
+    val node = q.asInstanceOf[ScreenerQuery.Eq]
+    assertEquals(node.field, "region")
+    assertEquals(node.value, ScreenerValue("us"))
+  }
+
+  test("eq creates equality filter for numeric value") {
+    val q = EquityQuery.eq("score", 42.5)
+    val node = q.asInstanceOf[ScreenerQuery.Eq]
+    assertEquals(node.value, ScreenerValue(42.5))
+  }
+
+  test("gt creates greater-than filter") {
+    val q = EquityQuery.gt("percentchange", 3.0)
+    assert(q.isInstanceOf[ScreenerQuery.Gt])
+    val gt = q.asInstanceOf[ScreenerQuery.Gt]
+    assertEquals(gt.field, "percentchange")
+    assertEquals(gt.value, 3.0)
+  }
+
+  test("gt accepts Int values") {
+    val q = EquityQuery.gt("dayvolume", 15000)
+    assertEquals(q.asInstanceOf[ScreenerQuery.Gt].value, 15000.0)
+  }
+
+  test("between creates range filter") {
+    val q = EquityQuery.between("peratio.lasttwelvemonths", 0.0, 20.0)
+    val btwn = q.asInstanceOf[ScreenerQuery.Between]
+    assertEquals(btwn.low, 0.0)
+    assertEquals(btwn.high, 20.0)
+  }
+
+  test("isIn creates set membership filter") {
+    val q = EquityQuery.isIn("exchange", Seq(ScreenerValue("NMS"), ScreenerValue("NYQ")))
+    val isIn = q.asInstanceOf[ScreenerQuery.IsIn]
+    assertEquals(isIn.values.size, 2)
+  }
+
+  test("and combines multiple filters") {
+    val q = EquityQuery.and(EquityQuery.gt("x", 1), EquityQuery.lt("y", 2))
+    assert(q.isInstanceOf[ScreenerQuery.And])
+    assertEquals(q.asInstanceOf[ScreenerQuery.And].operands.size, 2)
+  }
+
+  test("or creates alternative filters") {
+    val q = EquityQuery.or(EquityQuery.eq("a", "x"), EquityQuery.eq("b", "y"))
+    assert(q.isInstanceOf[ScreenerQuery.Or])
+  }
+
+  // --- FundQuery builder tests ---
+
+  test("FundQuery produces same query types as EquityQuery") {
+    val q = FundQuery.eq("categoryname", "Large Growth")
+    assert(q.isInstanceOf[ScreenerQuery.Eq])
+    assertEquals(q.asInstanceOf[ScreenerQuery.Eq].field, "categoryname")
+  }
+
+  // --- Validation tests ---
+
+  test("rejects AND with fewer than 2 operands") {
+    intercept[IllegalArgumentException] {
+      ScreenerQuery.And(List(ScreenerQuery.Gt("x", 1)))
+    }
+  }
+
+  test("rejects OR with fewer than 2 operands") {
+    intercept[IllegalArgumentException] {
+      ScreenerQuery.Or(List(ScreenerQuery.Gt("x", 1)))
+    }
+  }
+
+  test("rejects IS-IN with no values") {
+    intercept[IllegalArgumentException] {
+      ScreenerQuery.IsIn("x", List.empty)
+    }
+  }
+
+  // --- JSON encoding tests ---
+
+  test("equality filter encodes as EQ operator with field and value") {
+    val q: ScreenerQuery = ScreenerQuery.Eq("region", ScreenerValue("us"))
+    val json = q.asJson
+    assertEquals(json.hcursor.downField("operator").as[String], Right("EQ"))
+    val operands = json.hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(operands.size, 2)
+    assertEquals(operands(0).asString, Some("region"))
+    assertEquals(operands(1).asString, Some("us"))
+  }
+
+  test("greater-than filter encodes whole numbers without decimals") {
+    val q: ScreenerQuery = ScreenerQuery.Gt("percentchange", 3.0)
+    val json = q.asJson
+    assertEquals(json.hcursor.downField("operator").as[String], Right("GT"))
+    val operands = json.hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(operands(1).asNumber.flatMap(_.toLong), Some(3L))
+  }
+
+  test("between filter encodes field with low and high bounds") {
+    val q: ScreenerQuery = ScreenerQuery.Between("pe", 0.0, 20.0)
+    val json = q.asJson
+    assertEquals(json.hcursor.downField("operator").as[String], Right("BTWN"))
+    val operands = json.hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(operands.size, 3)
+    assertEquals(operands(0).asString, Some("pe"))
+  }
+
+  test("set membership expands to OR of equality checks") {
+    val q: ScreenerQuery = ScreenerQuery.IsIn("exchange", List(ScreenerValue("NMS"), ScreenerValue("NYQ")))
+    val json = q.asJson
+    assertEquals(json.hcursor.downField("operator").as[String], Right("OR"))
+    val operands = json.hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(operands.size, 2)
+    // Each sub-operand is an EQ query
+    assertEquals(operands(0).hcursor.downField("operator").as[String], Right("EQ"))
+    val eqOps = operands(0).hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(eqOps(0).asString, Some("exchange"))
+    assertEquals(eqOps(1).asString, Some("NMS"))
+  }
+
+  test("AND encodes nested filters recursively") {
+    val q: ScreenerQuery = ScreenerQuery.And(
+      List(
+        ScreenerQuery.Gt("percentchange", 3.0),
+        ScreenerQuery.Eq("region", ScreenerValue("us"))
+      )
+    )
+    val json = q.asJson
+    assertEquals(json.hcursor.downField("operator").as[String], Right("AND"))
+    val operands = json.hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(operands.size, 2)
+    assertEquals(operands(0).hcursor.downField("operator").as[String], Right("GT"))
+    assertEquals(operands(1).hcursor.downField("operator").as[String], Right("EQ"))
+  }
+
+  test("day_gainers-equivalent query encodes all 5 filters") {
+    val q: ScreenerQuery = EquityQuery.and(
+      EquityQuery.gt("percentchange", 3),
+      EquityQuery.eq("region", "us"),
+      EquityQuery.gte("intradaymarketcap", 2000000000L),
+      EquityQuery.gte("intradayprice", 5),
+      EquityQuery.gt("dayvolume", 15000)
+    )
+    val json = q.asJson
+    assertEquals(json.hcursor.downField("operator").as[String], Right("AND"))
+    val operands = json.hcursor.downField("operands").as[List[io.circe.Json]].toOption.get
+    assertEquals(operands.size, 5)
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/ScreenerResultSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/ScreenerResultSpec.scala
@@ -1,0 +1,267 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+class ScreenerResultSpec extends FunSuite {
+
+  // --- ScreenerQuote tests ---
+
+  private val appleQuote = ScreenerQuote(
+    symbol = "AAPL",
+    shortName = Some("Apple Inc."),
+    longName = Some("Apple Inc."),
+    quoteType = Some("EQUITY"),
+    exchange = Some("NMS"),
+    exchangeDisplay = Some("NASDAQ"),
+    sector = Some("Technology"),
+    industry = Some("Consumer Electronics"),
+    regularMarketPrice = Some(227.48),
+    regularMarketChange = Some(3.12),
+    regularMarketChangePercent = Some(1.39),
+    regularMarketVolume = Some(54321000L),
+    marketCap = Some(3450000000000L),
+    trailingPE = Some(37.5),
+    forwardPE = Some(32.1),
+    priceToBook = Some(52.3),
+    fiftyTwoWeekHigh = Some(260.1),
+    fiftyTwoWeekLow = Some(164.08),
+    dividendYield = Some(0.0044),
+    epsTrailingTwelveMonths = Some(6.07),
+    averageDailyVolume3Month = Some(48500000L)
+  )
+
+  private val msftQuote = appleQuote.copy(
+    symbol = "MSFT",
+    shortName = Some("Microsoft Corporation"),
+    longName = Some("Microsoft Corporation"),
+    marketCap = Some(3200000000000L),
+    sector = Some("Technology")
+  )
+
+  private val fundQuote = appleQuote.copy(
+    symbol = "VFINX",
+    shortName = Some("Vanguard 500 Index Fund"),
+    longName = None,
+    quoteType = Some("MUTUALFUND"),
+    sector = None,
+    industry = None,
+    marketCap = None
+  )
+
+  test("identifies EQUITY quote type correctly") {
+    assert(appleQuote.isEquity)
+    assert(!appleQuote.isMutualFund)
+    assert(!appleQuote.isETF)
+  }
+
+  test("identifies MUTUALFUND quote type correctly") {
+    assert(fundQuote.isMutualFund)
+    assert(!fundQuote.isEquity)
+  }
+
+  test("identifies ETF quote type correctly") {
+    val etf = appleQuote.copy(quoteType = Some("ETF"))
+    assert(etf.isETF)
+    assert(!etf.isEquity)
+  }
+
+  test("all type checks return false when quoteType is None") {
+    val noType = appleQuote.copy(quoteType = None)
+    assert(!noType.isEquity)
+    assert(!noType.isMutualFund)
+    assert(!noType.isETF)
+  }
+
+  test("prefers longName for display") {
+    assertEquals(appleQuote.displayName, "Apple Inc.")
+  }
+
+  test("falls back to shortName when longName is absent") {
+    assertEquals(fundQuote.displayName, "Vanguard 500 Index Fund")
+  }
+
+  test("falls back to symbol when both names are absent") {
+    val noNames = appleQuote.copy(longName = None, shortName = None)
+    assertEquals(noNames.displayName, "AAPL")
+  }
+
+  test("converts symbol to Ticker") {
+    assertEquals(appleQuote.toTicker, Ticker("AAPL"))
+  }
+
+  test("sorts quotes by market cap descending") {
+    val smallCap = appleQuote.copy(symbol = "SMALL", marketCap = Some(1000000L))
+    val quotes = List(smallCap, appleQuote, msftQuote)
+    val sorted = quotes.sorted
+    assertEquals(sorted.map(_.symbol), List("AAPL", "MSFT", "SMALL"))
+  }
+
+  test("quotes without marketCap sort last") {
+    val noCap = appleQuote.copy(symbol = "NOCAP", marketCap = None)
+    val quotes = List(noCap, appleQuote)
+    val sorted = quotes.sorted
+    assertEquals(sorted.map(_.symbol), List("AAPL", "NOCAP"))
+  }
+
+  test("52-week high distance is negative when price is below high") {
+    // price=227.48, high=260.1 => (227.48 - 260.1) / 260.1 * 100 ≈ -12.54%
+    val dist = appleQuote.distanceFrom52WeekHigh
+    assert(dist.isDefined)
+    assert(dist.get < 0, "Should be negative (below 52-week high)")
+    assertEqualsDouble(dist.get, -12.5413, 0.01)
+  }
+
+  test("52-week low distance is positive when price is above low") {
+    // price=227.48, low=164.08 => (227.48 - 164.08) / 164.08 * 100 ≈ 38.64%
+    val dist = appleQuote.distanceFrom52WeekLow
+    assert(dist.isDefined)
+    assert(dist.get > 0, "Should be positive (above 52-week low)")
+    assertEqualsDouble(dist.get, 38.6402, 0.01)
+  }
+
+  test("distance metrics return None when price is missing") {
+    val noPrice = appleQuote.copy(regularMarketPrice = None)
+    assertEquals(noPrice.distanceFrom52WeekHigh, None)
+    assertEquals(noPrice.distanceFrom52WeekLow, None)
+  }
+
+  test("distance metrics return None when 52-week data is missing") {
+    val noHigh = appleQuote.copy(fiftyTwoWeekHigh = None)
+    assertEquals(noHigh.distanceFrom52WeekHigh, None)
+  }
+
+  // --- ScreenerResult tests ---
+
+  private val result = ScreenerResult(
+    quotes = List(appleQuote, msftQuote, fundQuote),
+    total = 150
+  )
+
+  test("is non-empty when quotes exist") {
+    assert(result.nonEmpty)
+  }
+
+  test("is empty when no quotes exist") {
+    assert(ScreenerResult.empty.isEmpty)
+  }
+
+  test("reports correct size") {
+    assertEquals(result.size, 3)
+  }
+
+  test("detects more results available") {
+    assert(result.hasMore, "total=150 > size=3, should have more")
+    assert(!ScreenerResult(List(appleQuote), 1).hasMore)
+  }
+
+  test("extracts all ticker symbols") {
+    assertEquals(result.symbols, List("AAPL", "MSFT", "VFINX"))
+  }
+
+  test("extracts all Ticker values") {
+    assertEquals(result.tickers, List(Ticker("AAPL"), Ticker("MSFT"), Ticker("VFINX")))
+  }
+
+  test("filters equities from mixed results") {
+    val equities = result.equities
+    assertEquals(equities.size, 2)
+    assertEquals(equities.map(_.symbol), List("AAPL", "MSFT"))
+  }
+
+  test("filters funds from mixed results") {
+    val funds = result.funds
+    assertEquals(funds.size, 1)
+    assertEquals(funds.head.symbol, "VFINX")
+  }
+
+  test("returns largest by market cap") {
+    val largest = result.largestByMarketCap
+    assert(largest.isDefined)
+    assertEquals(largest.get.symbol, "AAPL")
+  }
+
+  test("filters by sector") {
+    val tech = result.bySector("Technology")
+    assertEquals(tech.size, 2)
+  }
+
+  test("returns distinct sectors") {
+    assertEquals(result.sectors, List("Technology"))
+  }
+
+  test("empty result has zero counts and empty lists") {
+    val empty = ScreenerResult.empty
+    assert(empty.isEmpty)
+    assertEquals(empty.total, 0)
+    assertEquals(empty.size, 0)
+    assert(!empty.hasMore)
+    assertEquals(empty.symbols, List.empty[String])
+    assertEquals(empty.equities, List.empty[ScreenerQuote])
+    assertEquals(empty.largestByMarketCap, None)
+    assertEquals(empty.sectors, List.empty[String])
+  }
+
+  // --- ScreenerConfig tests ---
+
+  test("default config has expected values") {
+    val config = ScreenerConfig.Default
+    assertEquals(config.sortField, "ticker")
+    assertEquals(config.sortOrder, SortOrder.Desc)
+    assertEquals(config.offset, 0)
+    assertEquals(config.count, 25)
+  }
+
+  test("rejects count above max") {
+    intercept[IllegalArgumentException] {
+      ScreenerConfig(count = 251)
+    }
+  }
+
+  test("rejects count below 1") {
+    intercept[IllegalArgumentException] {
+      ScreenerConfig(count = 0)
+    }
+  }
+
+  test("rejects negative offset") {
+    intercept[IllegalArgumentException] {
+      ScreenerConfig(offset = -1)
+    }
+  }
+
+  test("accepts count at max boundary") {
+    val config = ScreenerConfig(count = 250)
+    assertEquals(config.count, 250)
+  }
+
+  // --- SortOrder tests ---
+
+  test("ascending sort maps to ASC") {
+    assertEquals(SortOrder.Asc.apiValue, "ASC")
+  }
+
+  test("descending sort maps to DESC") {
+    assertEquals(SortOrder.Desc.apiValue, "DESC")
+  }
+
+  // --- PredefinedScreen tests ---
+
+  test("all predefined screens have unique IDs") {
+    val ids = PredefinedScreen.values.map(_.screenId)
+    assertEquals(ids.size, ids.distinct.size)
+  }
+
+  test("looks up predefined screen by ID") {
+    assertEquals(PredefinedScreen.fromScreenId("day_gainers"), Some(PredefinedScreen.DayGainers))
+  }
+
+  test("returns None for unknown screen ID") {
+    assertEquals(PredefinedScreen.fromScreenId("nonexistent"), None)
+  }
+
+  test("equity screens and fund screens partition all values") {
+    val all = (PredefinedScreen.equityScreens ++ PredefinedScreen.fundScreens).toSet
+    assertEquals(all, PredefinedScreen.values.toSet)
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SplitEventSpec.scala
@@ -8,7 +8,7 @@ import java.time.{ZoneOffset, ZonedDateTime}
 
 class SplitEventSpec extends FunSuite {
 
-  test("converts raw timestamp correctly") {
+  test("parses epoch timestamp into date") {
     val raw = SplitEventRaw(
       date = 1598832000L,
       numerator = 4,

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
@@ -80,6 +80,11 @@ class TickersSpec extends FunSuite {
     val holders: Holders[Id] = stubHolders
     val financials: Financials[Id] = stubFinancials
     val analysts: Analysts[Id] = stubAnalysts
+    val screener: Screener[Id] = new Screener[Id] {
+      def screenEquities(query: ScreenerQuery, config: ScreenerConfig): ScreenerResult = ???
+      def screenFunds(query: ScreenerQuery, config: ScreenerConfig): ScreenerResult = ???
+      def screenPredefined(screen: PredefinedScreen, count: Int): ScreenerResult = ???
+    }
     def search(query: String, maxResults: Int, newsCount: Int, enableFuzzyQuery: Boolean): SearchResult = ???
   }
 


### PR DESCRIPTION
Implementing Stock Screener. Adding support for screening equities and mutual funds via Yahoo Finance's screener API, including both custom filter queries (POST) and predefined screens (GET).