### PR TITLE
Adding ISIN lookup for resolving ISINs to Yahoo Finance tickers

### DIFF
--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -1,6 +1,6 @@
 package org.coinductive.yfinance4s
 
-import cats.Monad
+import cats.MonadThrow
 import cats.data.NonEmptyList
 import cats.effect.{Async, Concurrent, Resource}
 import cats.effect.syntax.concurrent.*
@@ -59,6 +59,33 @@ trait YFinanceClient[F[_]] {
       newsCount: Int = YFinanceClient.SearchDefaults.NewsCount,
       enableFuzzyQuery: Boolean = YFinanceClient.SearchDefaults.EnableFuzzyQuery
   ): F[SearchResult]
+
+  /** Looks up a Yahoo Finance ticker by ISIN.
+    *
+    * Validates the ISIN format (12-character alphanumeric with valid Luhn check digit), then queries Yahoo Finance's
+    * search API. Returns the best-matching ticker (highest relevance score), or None if no match is found.
+    *
+    * When a security is listed on multiple exchanges, returns the exchange Yahoo considers the primary listing. Use
+    * [[lookupAllByISIN]] to see all exchange listings.
+    *
+    * @param isin
+    *   A 12-character ISIN string (e.g., "US0378331005" for Apple)
+    * @return
+    *   The best-matching ticker, or None if no match is found. Raises an error in F if the ISIN format is invalid.
+    */
+  def lookupByISIN(isin: String): F[Option[Ticker]]
+
+  /** Looks up all Yahoo Finance tickers matching an ISIN.
+    *
+    * Useful when a security is listed on multiple exchanges (e.g., a European stock trading on both its home exchange
+    * and US ADR). Returns full quote search results so the caller can filter by exchange.
+    *
+    * @param isin
+    *   A 12-character ISIN string
+    * @return
+    *   All matching quote results (may be empty). Raises an error in F if the ISIN format is invalid.
+    */
+  def lookupAllByISIN(isin: String): F[List[QuoteSearchResult]]
 
   // --- Multi-Ticker Downloads (concrete with default implementations) ---
 
@@ -128,6 +155,12 @@ object YFinanceClient {
     val EnableFuzzyQuery = false
   }
 
+  private[yfinance4s] object IsinLookupDefaults {
+    val MaxResults = 8
+    val NewsCount = 0
+    val EnableFuzzyQuery = false
+  }
+
   def resource[F[_]: Async](config: YFinanceClientConfig): Resource[F, YFinanceClient[F]] =
     for {
       gateway <- YFinanceGateway.resource[F](config.connectTimeout, config.readTimeout, config.retries)
@@ -145,7 +178,7 @@ object YFinanceClient {
       }
       .map(_.toMap)
 
-  private final class YFinanceClientImpl[F[_]: Monad](
+  private final class YFinanceClientImpl[F[_]: MonadThrow](
       gateway: YFinanceGateway[F],
       scrapper: YFinanceScrapper[F],
       auth: YFinanceAuth[F]
@@ -165,6 +198,29 @@ object YFinanceClient {
         enableFuzzyQuery: Boolean
     ): F[SearchResult] =
       gateway.search(query, maxResults, newsCount, enableFuzzyQuery).map(mapSearchResult)
+
+    def lookupByISIN(isin: String): F[Option[Ticker]] =
+      lookupAllByISIN(isin).map(_.sorted.headOption.map(_.toTicker))
+
+    def lookupAllByISIN(isin: String): F[List[QuoteSearchResult]] =
+      validateIsin(isin).flatMap { validIsin =>
+        gateway
+          .search(
+            validIsin.value,
+            IsinLookupDefaults.MaxResults,
+            IsinLookupDefaults.NewsCount,
+            IsinLookupDefaults.EnableFuzzyQuery
+          )
+          .map(_.quotes.flatMap(mapSearchQuote))
+      }
+
+    private def validateIsin(isin: String): F[Isin] =
+      Isin
+        .validate(isin)
+        .fold(
+          error => MonadThrow[F].raiseError(new IllegalArgumentException(error)),
+          MonadThrow[F].pure
+        )
 
     // --- Search Mapping Helpers ---
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/Isin.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/Isin.scala
@@ -1,0 +1,83 @@
+package org.coinductive.yfinance4s.models
+
+import cats.Show
+
+/** An International Securities Identification Number (ISO 6166).
+  *
+  * An ISIN is a 12-character alphanumeric code that uniquely identifies a security. The format is: 2-letter country
+  * code + 9 alphanumeric characters + 1 Luhn check digit.
+  *
+  * Use [[Isin.validate]] to parse and validate, or [[Isin.isValid]] for a boolean check.
+  *
+  * @param value
+  *   The 12-character ISIN string (always stored uppercase)
+  */
+final case class Isin(value: String) extends AnyVal
+
+object Isin {
+
+  implicit val show: Show[Isin] = Show.show(_.value)
+
+  private val IsinLength = 12
+  private val IsinPattern = "^[A-Z]{2}[A-Z0-9]{9}[0-9]$".r
+
+  /** Validates and constructs an [[Isin]] from a raw string.
+    *
+    * Checks:
+    *   1. Length is exactly 12 characters
+    *   1. First 2 characters are uppercase letters (country code)
+    *   1. Characters 3-11 are uppercase alphanumeric
+    *   1. Character 12 is a digit (check digit)
+    *   1. Luhn check digit is correct
+    *
+    * @return
+    *   Right(Isin) if valid, Left(error message) if invalid
+    */
+  def validate(value: String): Either[String, Isin] = {
+    val upper = value.trim.toUpperCase
+    if (upper.length != IsinLength)
+      Left(s"ISIN must be $IsinLength characters, got ${upper.length}: '$value'")
+    else if (IsinPattern.findFirstIn(upper).isEmpty)
+      Left(s"ISIN must match pattern XX(alphanumeric x9)(digit): '$value'")
+    else {
+      val expectedCheckDigit = computeCheckDigit(upper.substring(0, IsinLength - 1))
+      val actualCheckDigit = upper.last - '0'
+      if (actualCheckDigit != expectedCheckDigit)
+        Left(s"ISIN check digit mismatch: expected $expectedCheckDigit, got $actualCheckDigit in '$value'")
+      else
+        Right(Isin(upper))
+    }
+  }
+
+  /** Returns true if the value is a syntactically valid ISIN. */
+  def isValid(value: String): Boolean = validate(value).isRight
+
+  /** Computes the Luhn check digit for an 11-character ISIN prefix.
+    *
+    * Converts letters to two-digit numbers (A=10 .. Z=35), concatenates all digits, then applies the standard Luhn
+    * algorithm.
+    */
+  def computeCheckDigit(prefix: String): Int = {
+    val digits = prefix.flatMap(charToDigits)
+    val sum = digits.reverse.zipWithIndex.map { case (d, i) =>
+      val posFromRight = i + 2 // position 1 is the check digit being computed
+      if (posFromRight % 2 == 0) {
+        val doubled = d * 2
+        if (doubled > 9) doubled - 9 else doubled
+      } else d
+    }.sum
+    (10 - (sum % 10)) % 10
+  }
+
+  /** Extracts the 2-character country code from an ISIN. Does not validate the ISIN -- call [[validate]] first if
+    * needed.
+    */
+  def countryCode(isin: String): String = isin.take(2).toUpperCase
+
+  private def charToDigits(c: Char): Seq[Int] =
+    if (c.isDigit) Seq(c - '0')
+    else {
+      val n = c.toUpper - 'A' + 10
+      Seq(n / 10, n % 10)
+    }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/IsinLookupSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/IsinLookupSpec.scala
@@ -1,0 +1,106 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import cats.syntax.traverse.*
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.Ticker
+
+import scala.concurrent.duration.*
+
+class IsinLookupSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  // --- lookupByISIN ---
+
+  test("resolves well-known ISINs to expected tickers") {
+    val isinToTicker = List(
+      "US0378331005" -> Ticker("AAPL"),
+      "US5949181045" -> Ticker("MSFT")
+    )
+    YFinanceClient.resource[IO](config).use { client =>
+      isinToTicker.traverse { case (isin, expected) =>
+        client.lookupByISIN(isin).map { result =>
+          assert(result.isDefined, s"ISIN $isin should resolve")
+          assertEquals(result.get, expected)
+        }
+      }.void
+    }
+  }
+
+  test("resolves international ISINs") {
+    val isinToSubstring = List(
+      "GB0002374006" -> "DGE", // Diageo (UK)
+      "DE0007164600" -> "SAP" // SAP (Germany)
+    )
+    YFinanceClient.resource[IO](config).use { client =>
+      isinToSubstring.traverse { case (isin, substring) =>
+        client.lookupByISIN(isin).map { result =>
+          assert(result.isDefined, s"ISIN $isin should resolve")
+          assert(
+            result.get.value.contains(substring),
+            s"Expected ticker containing '$substring' for $isin, got: ${result.get.value}"
+          )
+        }
+      }.void
+    }
+  }
+
+  test("returns None for valid but nonexistent ISIN") {
+    // US0000000002 has a valid check digit (0) but no real security
+    YFinanceClient.resource[IO](config).use { client =>
+      client.lookupByISIN("US0000000002").map { result =>
+        assert(result.isEmpty, s"Expected None for nonexistent ISIN, got: $result")
+      }
+    }
+  }
+
+  test("raises error for malformed ISIN") {
+    YFinanceClient.resource[IO](config).use { client =>
+      interceptIO[IllegalArgumentException](client.lookupByISIN("INVALID"))
+    }
+  }
+
+  test("raises error for ISIN with wrong check digit") {
+    YFinanceClient.resource[IO](config).use { client =>
+      interceptIO[IllegalArgumentException](client.lookupByISIN("US0378331009"))
+    }
+  }
+
+  test("handles lowercase ISIN input") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.lookupByISIN("us0378331005").map { result =>
+        assert(result.isDefined, "Lowercase Apple ISIN should resolve")
+        assertEquals(result.get, Ticker("AAPL"))
+      }
+    }
+  }
+
+  // --- lookupAllByISIN ---
+
+  test("returns results with quote details for widely-traded ISIN") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.lookupAllByISIN("US0378331005").map { results =>
+        assert(results.nonEmpty, "Apple ISIN should return at least one result")
+        assert(results.exists(_.symbol == "AAPL"), s"AAPL should appear in results: ${results.map(_.symbol)}")
+        val first = results.head
+        assert(first.symbol.nonEmpty, "symbol should not be empty")
+        assert(first.exchangeDisplay.isDefined, "exchangeDisplay should be defined")
+        assert(first.quoteType.isDefined, "quoteType should be defined")
+      }
+    }
+  }
+
+  test("returns empty list for valid but nonexistent ISIN") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.lookupAllByISIN("US0000000002").map { results =>
+        assert(results.isEmpty, s"Expected empty list for nonexistent ISIN, got: ${results.map(_.symbol)}")
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IsinSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IsinSpec.scala
@@ -1,0 +1,130 @@
+package org.coinductive.yfinance4s.unit
+
+import cats.syntax.show.*
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.Isin
+
+class IsinSpec extends FunSuite {
+
+  // --- Validation: valid ISINs ---
+
+  private val validIsins = List(
+    "US0378331005", // Apple
+    "US5949181045", // Microsoft
+    "US67066G1040", // NVIDIA
+    "US88160R1014", // Tesla
+    "GB0002374006", // Diageo
+    "DE0007164600", // SAP
+    "JP3633400001", // Toyota
+    "FR0000120271" // TotalEnergies
+  )
+
+  test("validates a corpus of known-valid ISINs") {
+    validIsins.foreach { isin =>
+      val result = Isin.validate(isin)
+      assert(result.isRight, s"Expected valid: $isin, got: $result")
+      assertEquals(result, Right(Isin(isin)))
+    }
+  }
+
+  // --- Validation: normalisation ---
+
+  test("normalises lowercase input to uppercase") {
+    assertEquals(Isin.validate("us0378331005"), Right(Isin("US0378331005")))
+  }
+
+  test("normalises mixed case input to uppercase") {
+    assertEquals(Isin.validate("Us67066g1040"), Right(Isin("US67066G1040")))
+  }
+
+  test("trims leading and trailing whitespace") {
+    assertEquals(Isin.validate("  US0378331005  "), Right(Isin("US0378331005")))
+  }
+
+  // --- Validation: length errors ---
+
+  test("rejects ISIN that is too short") {
+    val result = Isin.validate("US037833100")
+    assert(result.isLeft)
+    assert(result.left.exists(_.contains("12 characters")), s"Unexpected error: $result")
+  }
+
+  test("rejects ISIN that is too long") {
+    val result = Isin.validate("US03783310055")
+    assert(result.isLeft)
+    assert(result.left.exists(_.contains("12 characters")), s"Unexpected error: $result")
+  }
+
+  test("rejects empty string") {
+    val result = Isin.validate("")
+    assert(result.isLeft)
+    assert(result.left.exists(_.contains("12 characters")), s"Unexpected error: $result")
+  }
+
+  // --- Validation: pattern errors ---
+
+  test("rejects ISIN with special characters") {
+    val result = Isin.validate("US037833100!")
+    assert(result.isLeft)
+    assert(result.left.exists(_.contains("pattern")), s"Unexpected error: $result")
+  }
+
+  test("rejects ISIN with numeric country code") {
+    val result = Isin.validate("123456789012")
+    assert(result.isLeft)
+    assert(result.left.exists(_.contains("pattern")), s"Unexpected error: $result")
+  }
+
+  // --- Validation: check digit errors ---
+
+  test("rejects ISIN with incorrect check digit") {
+    val result = Isin.validate("US0378331009")
+    assert(result.isLeft)
+    assert(result.left.exists(_.contains("check digit")), s"Unexpected error: $result")
+  }
+
+  // --- isValid convenience method ---
+
+  test("isValid returns true for valid ISIN") {
+    assert(Isin.isValid("US0378331005"))
+  }
+
+  test("isValid returns false for invalid ISIN") {
+    assert(!Isin.isValid("INVALID"))
+  }
+
+  // --- Check digit computation ---
+
+  test("computes correct check digits for known ISINs") {
+    val prefixToExpected = List(
+      "US037833100" -> 5, // Apple
+      "US594918104" -> 5, // Microsoft
+      "US67066G104" -> 0, // NVIDIA (boundary: check digit 0)
+      "US88160R101" -> 4, // Tesla
+      "GB000237400" -> 6, // Diageo
+      "DE000716460" -> 0, // SAP
+      "JP363340000" -> 1, // Toyota
+      "FR000012027" -> 1 // TotalEnergies
+    )
+    prefixToExpected.foreach { case (prefix, expected) =>
+      assertEquals(Isin.computeCheckDigit(prefix), expected, s"Failed for prefix: $prefix")
+    }
+  }
+
+  // --- Country code extraction ---
+
+  test("extracts country code") {
+    assertEquals(Isin.countryCode("US0378331005"), "US")
+    assertEquals(Isin.countryCode("GB0002374006"), "GB")
+  }
+
+  test("uppercases country code from lowercase input") {
+    assertEquals(Isin.countryCode("de0007164600"), "DE")
+  }
+
+  // --- Show instance ---
+
+  test("Show instance renders ISIN value") {
+    assertEquals(Isin("US0378331005").show, "US0378331005")
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
@@ -86,6 +86,8 @@ class TickersSpec extends FunSuite {
       def screenPredefined(screen: PredefinedScreen, count: Int): ScreenerResult = ???
     }
     def search(query: String, maxResults: Int, newsCount: Int, enableFuzzyQuery: Boolean): SearchResult = ???
+    def lookupByISIN(isin: String): Option[Ticker] = ???
+    def lookupAllByISIN(isin: String): List[QuoteSearchResult] = ???
   }
 
   // --- Factory Tests ---


### PR DESCRIPTION
`Isin` model with ISO 6166 Luhn check digit validation, `lookupByISIN` returning the best-matching ticker, and `lookupAllByISIN` returning all exchange listings.