### PR TITLE
Feat: adding Industry Data algebra

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Effectful Yahoo Finance client in the Scala programming language.
 - **Financial Statements**: Income statements, balance sheets, and cash flow statements (annual, quarterly, trailing)
 - **Analyst Data**: Price targets, recommendations, earnings estimates, upgrade/downgrade history, growth comparisons
 - **Sector Data**: Sector overview, top ETFs, mutual funds, industries, and top companies for all 11 GICS sectors
+- **Industry Data**: Per-industry overview, top companies, top performers (YTD return, implied upside), and top growth companies
 - **Search**: Ticker/company/news search with fuzzy matching
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
@@ -60,6 +61,7 @@ YFinanceClient.resource[IO](config).use { client =>
 | [Financial Statements](docs/financials.md) | Income statements, balance sheets, cash flows |
 | [Analyst Data](docs/analysts.md) | Price targets, recommendations, estimates |
 | [Sector Data](docs/sectors.md) | Sector overview, industries, top ETFs/funds |
+| [Industry Data](docs/industries.md) | Industry overview, top companies, performers, growth |
 | [Search & ISIN](docs/search.md) | Ticker search and ISIN lookup |
 | [Screener](docs/screener.md) | Custom and predefined stock/fund screens |
 | [Batch Operations](docs/batch-operations.md) | Multi-ticker parallel fetches |

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Industries.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Industries.scala
@@ -1,0 +1,151 @@
+package org.coinductive.yfinance4s
+
+import cats.Monad
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
+
+/** Algebra for industry data (overview, top companies, top performers, top growth). */
+trait Industries[F[_]] {
+
+  /** Comprehensive industry data. Raises in F if the key is unknown. */
+  def getIndustryData(industryKey: IndustryKey): F[IndustryData]
+
+  /** Just the industry overview (companies count, market cap, market weight, etc.). */
+  def getIndustryOverview(industryKey: IndustryKey): F[Option[IndustryOverview]]
+
+  /** The parent sector (key + name) of the industry. */
+  def getSectorInfo(industryKey: IndustryKey): F[IndustrySectorInfo]
+
+  /** Top companies within this industry, ordered by market weight. */
+  def getTopCompanies(industryKey: IndustryKey): F[List[TopCompany]]
+
+  /** Top performing companies in this industry, sorted by YTD return descending. */
+  def getTopPerformingCompanies(industryKey: IndustryKey): F[List[TopPerformingCompany]]
+
+  /** Top growth companies in this industry, sorted by growth estimate descending. */
+  def getTopGrowthCompanies(industryKey: IndustryKey): F[List[TopGrowthCompany]]
+
+  /** Research reports for this industry. */
+  def getResearchReports(industryKey: IndustryKey): F[List[ResearchReport]]
+}
+
+private[yfinance4s] object Industries {
+
+  def apply[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Industries[F] =
+    new IndustriesImpl(gateway, auth)
+
+  private final class IndustriesImpl[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F])
+      extends Industries[F] {
+
+    def getIndustryData(industryKey: IndustryKey): F[IndustryData] =
+      fetchIndustryData(industryKey)(mapToIndustryData(industryKey, _))
+
+    def getIndustryOverview(industryKey: IndustryKey): F[Option[IndustryOverview]] =
+      fetchIndustryData(industryKey)(extractOverview)
+
+    def getSectorInfo(industryKey: IndustryKey): F[IndustrySectorInfo] =
+      fetchIndustryData(industryKey)(extractSectorInfo)
+
+    def getTopCompanies(industryKey: IndustryKey): F[List[TopCompany]] =
+      fetchIndustryData(industryKey)(extractTopCompanies)
+
+    def getTopPerformingCompanies(industryKey: IndustryKey): F[List[TopPerformingCompany]] =
+      fetchIndustryData(industryKey)(extractTopPerformingCompanies)
+
+    def getTopGrowthCompanies(industryKey: IndustryKey): F[List[TopGrowthCompany]] =
+      fetchIndustryData(industryKey)(extractTopGrowthCompanies)
+
+    def getResearchReports(industryKey: IndustryKey): F[List[ResearchReport]] =
+      fetchIndustryData(industryKey)(extractResearchReports)
+
+    // --- Private helpers ---
+
+    private def fetchIndustryData[A](industryKey: IndustryKey)(
+        extract: YFinanceIndustryResult => A
+    ): F[A] =
+      auth.getCredentials.flatMap { credentials =>
+        gateway.getIndustryData(industryKey, credentials).map(extract)
+      }
+
+    private def mapToIndustryData(industryKey: IndustryKey, result: YFinanceIndustryResult): IndustryData =
+      IndustryData(
+        key = industryKey,
+        name = result.name,
+        sectorKey = result.sectorKey,
+        sectorName = result.sectorName,
+        symbol = result.symbol,
+        overview = extractOverview(result),
+        topCompanies = extractTopCompanies(result),
+        topPerformingCompanies = extractTopPerformingCompanies(result),
+        topGrowthCompanies = extractTopGrowthCompanies(result),
+        researchReports = extractResearchReports(result)
+      )
+
+    private def extractOverview(result: YFinanceIndustryResult): Option[IndustryOverview] =
+      result.overview.map(mapOverview)
+
+    private def extractSectorInfo(result: YFinanceIndustryResult): IndustrySectorInfo =
+      IndustrySectorInfo(result.sectorKey, result.sectorName)
+
+    private def extractTopCompanies(result: YFinanceIndustryResult): List[TopCompany] =
+      result.topCompanies.getOrElse(List.empty).flatMap(mapTopCompany)
+
+    private def extractTopPerformingCompanies(result: YFinanceIndustryResult): List[TopPerformingCompany] =
+      result.topPerformingCompanies.getOrElse(List.empty).map(mapTopPerformingCompany).sorted
+
+    private def extractTopGrowthCompanies(result: YFinanceIndustryResult): List[TopGrowthCompany] =
+      result.topGrowthCompanies.getOrElse(List.empty).map(mapTopGrowthCompany).sorted
+
+    private def extractResearchReports(result: YFinanceIndustryResult): List[ResearchReport] =
+      result.researchReports.getOrElse(List.empty).map(mapResearchReport)
+
+    // --- Mapping helpers ---
+
+    // industriesCount from raw overview is intentionally dropped; not meaningful for a leaf industry.
+    private def mapOverview(raw: SectorOverviewRaw): IndustryOverview =
+      IndustryOverview(
+        companiesCount = raw.companiesCount,
+        marketCap = raw.marketCap.map(_.raw),
+        messageBoardId = raw.messageBoardId,
+        description = raw.description,
+        marketWeight = raw.marketWeight.map(_.raw),
+        employeeCount = raw.employeeCount.map(_.raw)
+      )
+
+    private def mapTopCompany(raw: TopCompanyRaw): Option[TopCompany] =
+      raw.symbol.map { sym =>
+        TopCompany(
+          symbol = sym,
+          name = raw.name,
+          rating = raw.rating,
+          marketWeight = raw.marketWeight.map(_.raw)
+        )
+      }
+
+    private def mapTopPerformingCompany(raw: TopPerformingCompanyRaw): TopPerformingCompany =
+      TopPerformingCompany(
+        symbol = raw.symbol,
+        name = raw.name,
+        ytdReturn = raw.ytdReturn.map(_.raw),
+        lastPrice = raw.lastPrice.map(_.raw),
+        targetPrice = raw.targetPrice.map(_.raw)
+      )
+
+    private def mapTopGrowthCompany(raw: TopGrowthCompanyRaw): TopGrowthCompany =
+      TopGrowthCompany(
+        symbol = raw.symbol,
+        name = raw.name,
+        ytdReturn = raw.ytdReturn.map(_.raw),
+        growthEstimate = raw.growthEstimate.map(_.raw)
+      )
+
+    private def mapResearchReport(raw: ResearchReportRaw): ResearchReport =
+      ResearchReport(
+        reportTitle = raw.reportTitle,
+        provider = raw.provider,
+        reportDate = raw.reportDate
+      )
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -43,6 +43,9 @@ trait YFinanceClient[F[_]] {
   /** Sector data (overview, top ETFs/funds, industries). */
   def sectors: Sectors[F]
 
+  /** Industry data (overview, top companies, top performers, top growth). */
+  def industries: Industries[F]
+
   /** Searches Yahoo Finance for tickers, companies, and news.
     *
     * @param query
@@ -194,6 +197,7 @@ object YFinanceClient {
     val analysts: Analysts[F] = Analysts(gateway, auth)
     val screener: Screener[F] = Screener(gateway, auth)
     val sectors: Sectors[F] = Sectors(gateway, auth)
+    val industries: Industries[F] = Industries(gateway, auth)
 
     def search(
         query: String,

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -38,6 +38,8 @@ sealed trait YFinanceGateway[F[_]] {
   def screenPredefined(screenId: String, count: Int): F[YFinanceScreenerResult]
 
   def getSectorData(sectorKey: SectorKey, credentials: YFinanceCredentials): F[YFinanceSectorResult]
+
+  def getIndustryData(industryKey: IndustryKey, credentials: YFinanceCredentials): F[YFinanceIndustryResult]
 }
 
 private object YFinanceGateway {
@@ -84,6 +86,7 @@ private object YFinanceGateway {
     private val DefaultNewsQueryId = "news_cie_vespa"
 
     private val SectorsEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/sectors/"
+    private val IndustriesEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/industries/"
 
     private val DomainQueryParams = Map(
       "formatted" -> "true",
@@ -337,6 +340,25 @@ private object YFinanceGateway {
       decode[YFinanceSectorResult](content)
         .fold(
           e => F.raiseError(new Exception(s"Failed to parse sector response: ${e.getMessage}")),
+          F.pure
+        )
+
+    def getIndustryData(industryKey: IndustryKey, credentials: YFinanceCredentials): F[YFinanceIndustryResult] = {
+      val req = basicRequest
+        .get(
+          IndustriesEndpoint
+            .addPath(industryKey.show)
+            .withParams(DomainQueryParams ++ Map("crumb" -> credentials.crumb))
+        )
+        .headers(YFinanceAuth.apiHeaders *)
+        .header("Cookie", credentials.cookies.mkString("; "))
+      sendRequest(req, parseIndustryContent)
+    }
+
+    private def parseIndustryContent(content: String): F[YFinanceIndustryResult] =
+      decode[YFinanceIndustryResult](content)
+        .fold(
+          e => F.raiseError(new Exception(s"Failed to parse industry response: ${e.getMessage}")),
           F.pure
         )
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/IndustryData.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/IndustryData.scala
@@ -1,0 +1,138 @@
+package org.coinductive.yfinance4s.models
+
+// --- Overview ---
+
+final case class IndustryOverview(
+    companiesCount: Option[Int] = None,
+    marketCap: Option[Long] = None,
+    messageBoardId: Option[String] = None,
+    description: Option[String] = None,
+    marketWeight: Option[Double] = None,
+    employeeCount: Option[Long] = None
+) {
+
+  /** Market weight as a percentage (0-100). */
+  def marketWeightPercent: Option[Double] = marketWeight.map(_ * 100)
+}
+
+object IndustryOverview {
+  val empty: IndustryOverview = IndustryOverview()
+}
+
+// --- Parent sector info ---
+
+final case class IndustrySectorInfo(sectorKey: String, sectorName: String) {
+  def toSectorKey: SectorKey = SectorKey(sectorKey)
+}
+
+// --- Top performing companies ---
+
+final case class TopPerformingCompany(
+    symbol: String,
+    name: Option[String],
+    ytdReturn: Option[Double],
+    lastPrice: Option[Double],
+    targetPrice: Option[Double]
+) {
+  def toTicker: Ticker = Ticker(symbol)
+
+  /** YTD return as a percentage (0-100). */
+  def ytdReturnPercent: Option[Double] = ytdReturn.map(_ * 100)
+
+  /** Implied upside from last price to analyst target, as a fraction. None when last price is missing, zero, or
+    * negative, or when target price is missing.
+    */
+  def impliedUpside: Option[Double] =
+    for {
+      last <- lastPrice if last > 0
+      target <- targetPrice
+    } yield (target - last) / last
+
+  /** Implied upside as a percentage (0-100). */
+  def impliedUpsidePercent: Option[Double] = impliedUpside.map(_ * 100)
+}
+
+object TopPerformingCompany {
+  implicit val ordering: Ordering[TopPerformingCompany] =
+    Ordering.by[TopPerformingCompany, Option[Double]](_.ytdReturn)(Ordering[Option[Double]].reverse)
+}
+
+// --- Top growth companies ---
+
+final case class TopGrowthCompany(
+    symbol: String,
+    name: Option[String],
+    ytdReturn: Option[Double],
+    growthEstimate: Option[Double]
+) {
+  def toTicker: Ticker = Ticker(symbol)
+
+  /** YTD return as a percentage (0-100). */
+  def ytdReturnPercent: Option[Double] = ytdReturn.map(_ * 100)
+
+  /** Growth estimate as a percentage (0-100). */
+  def growthEstimatePercent: Option[Double] = growthEstimate.map(_ * 100)
+}
+
+object TopGrowthCompany {
+  implicit val ordering: Ordering[TopGrowthCompany] =
+    Ordering.by[TopGrowthCompany, Option[Double]](_.growthEstimate)(Ordering[Option[Double]].reverse)
+}
+
+// --- Top-level aggregate ---
+
+final case class IndustryData(
+    key: IndustryKey,
+    name: String,
+    sectorKey: String,
+    sectorName: String,
+    symbol: Option[String] = None,
+    overview: Option[IndustryOverview] = None,
+    topCompanies: List[TopCompany] = List.empty,
+    topPerformingCompanies: List[TopPerformingCompany] = List.empty,
+    topGrowthCompanies: List[TopGrowthCompany] = List.empty,
+    researchReports: List[ResearchReport] = List.empty
+) {
+
+  def nonEmpty: Boolean =
+    overview.isDefined ||
+      topCompanies.nonEmpty ||
+      topPerformingCompanies.nonEmpty ||
+      topGrowthCompanies.nonEmpty
+
+  def isEmpty: Boolean = !nonEmpty
+
+  /** The parent sector of this industry. */
+  def sectorInfo: IndustrySectorInfo = IndustrySectorInfo(sectorKey, sectorName)
+
+  /** Total market weight of the industry (fraction), if available. */
+  def totalMarketWeight: Option[Double] = overview.flatMap(_.marketWeight)
+
+  /** Total market weight as a percentage (0-100). */
+  def totalMarketWeightPercent: Option[Double] = totalMarketWeight.map(_ * 100)
+
+  /** Total number of companies in the industry, if available. */
+  def totalCompanies: Option[Int] = overview.flatMap(_.companiesCount)
+
+  /** Total market capitalization of the industry, if available. */
+  def totalMarketCap: Option[Long] = overview.flatMap(_.marketCap)
+
+  /** Industry description text, if available. */
+  def description: Option[String] = overview.flatMap(_.description)
+
+  /** Top N companies by market weight (descending). */
+  def topCompaniesByWeight(n: Int): List[TopCompany] =
+    topCompanies.sortBy(_.marketWeight)(Ordering[Option[Double]].reverse).take(n)
+
+  /** Top N performers by YTD return (descending). */
+  def topPerformersByYtd(n: Int): List[TopPerformingCompany] =
+    topPerformingCompanies.sorted.take(n)
+
+  /** Top N growth companies by growth estimate (descending). */
+  def topGrowthByEstimate(n: Int): List[TopGrowthCompany] =
+    topGrowthCompanies.sorted.take(n)
+
+  /** Finds a top-company entry by symbol. */
+  def findTopCompany(symbol: String): Option[TopCompany] =
+    topCompanies.find(_.symbol == symbol)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/IndustryKey.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/IndustryKey.scala
@@ -1,0 +1,14 @@
+package org.coinductive.yfinance4s.models
+
+import cats.Show
+
+/** A Yahoo Finance industry key (e.g., `IndustryKey("semiconductors")`).
+  *
+  * Yahoo exposes ~150+ industry keys across 11 sectors; discover them dynamically via [[Sectors#getIndustries]], which
+  * returns [[SectorIndustry]] entries whose `.key` values can be wrapped in `IndustryKey`.
+  */
+final case class IndustryKey(value: String) extends AnyVal
+
+object IndustryKey {
+  implicit val show: Show[IndustryKey] = Show.show(_.value)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceIndustryResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceIndustryResult.scala
@@ -1,0 +1,56 @@
+package org.coinductive.yfinance4s.models.internal
+
+import io.circe.Decoder
+import io.circe.generic.semiauto.deriveDecoder
+import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult.Value
+
+/** Yahoo Finance `/v1/finance/industries/{key}` payload.
+  *
+  * Matches the inner object of Yahoo's `{"data": {…}}` envelope directly; the companion decoder navigates the `data`
+  * field before applying the derived field-based decoder.
+  */
+private[yfinance4s] final case class YFinanceIndustryResult(
+    name: String,
+    symbol: Option[String],
+    sectorKey: String,
+    sectorName: String,
+    overview: Option[SectorOverviewRaw],
+    topCompanies: Option[List[TopCompanyRaw]],
+    topPerformingCompanies: Option[List[TopPerformingCompanyRaw]],
+    topGrowthCompanies: Option[List[TopGrowthCompanyRaw]],
+    researchReports: Option[List[ResearchReportRaw]]
+)
+
+private[yfinance4s] object YFinanceIndustryResult {
+  implicit val decoder: Decoder[YFinanceIndustryResult] = {
+    val inner: Decoder[YFinanceIndustryResult] = deriveDecoder
+    inner.prepare(_.downField("data"))
+  }
+}
+
+// --- Top performing companies ---
+
+private[yfinance4s] final case class TopPerformingCompanyRaw(
+    symbol: String,
+    name: Option[String],
+    ytdReturn: Option[Value[Double]],
+    lastPrice: Option[Value[Double]],
+    targetPrice: Option[Value[Double]]
+)
+
+private[yfinance4s] object TopPerformingCompanyRaw {
+  implicit val decoder: Decoder[TopPerformingCompanyRaw] = deriveDecoder
+}
+
+// --- Top growth companies ---
+
+private[yfinance4s] final case class TopGrowthCompanyRaw(
+    symbol: String,
+    name: Option[String],
+    ytdReturn: Option[Value[Double]],
+    growthEstimate: Option[Value[Double]]
+)
+
+private[yfinance4s] object TopGrowthCompanyRaw {
+  implicit val decoder: Decoder[TopGrowthCompanyRaw] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/IndustryDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/IndustryDataSpec.scala
@@ -1,0 +1,163 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.{IndustryKey, SectorKey}
+
+import scala.concurrent.duration.*
+
+class IndustryDataSpec extends CatsEffectSuite {
+
+  val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  // --- getIndustryData ---
+
+  test("returns comprehensive industry data for semiconductors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getIndustryData(IndustryKey("semiconductors")).map { data =>
+        assert(data.name.nonEmpty, "Industry name should not be empty")
+        assert(data.nonEmpty, "Industry data should be non-empty")
+        assertEquals(data.sectorKey, "technology")
+      }
+    }
+  }
+
+  // --- getIndustryOverview ---
+
+  test("returns industry overview with positive metrics for semiconductors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getIndustryOverview(IndustryKey("semiconductors")).map { result =>
+        assert(result.isDefined, "Overview should be defined for semiconductors")
+        val overview = result.get
+
+        overview.companiesCount.foreach { count =>
+          assert(count > 0, s"Companies count should be positive: $count")
+        }
+        overview.marketCap.foreach { cap =>
+          assert(cap > 0, s"Market cap should be positive: $cap")
+        }
+        overview.marketWeight.foreach { weight =>
+          assert(weight > 0 && weight < 1, s"Market weight should be between 0 and 1: $weight")
+        }
+        overview.employeeCount.foreach { count =>
+          assert(count > 0, s"Employee count should be positive: $count")
+        }
+      }
+    }
+  }
+
+  // --- getSectorInfo ---
+
+  test("returns sector info pointing to technology for semiconductors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getSectorInfo(IndustryKey("semiconductors")).map { info =>
+        assertEquals(info.sectorKey, "technology")
+        assertEquals(info.toSectorKey, SectorKey.Technology)
+      }
+    }
+  }
+
+  // --- getTopCompanies ---
+
+  test("returns non-empty top companies for semiconductors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getTopCompanies(IndustryKey("semiconductors")).map { companies =>
+        assert(companies.nonEmpty, "Semiconductors industry should have top companies")
+        companies.foreach { company =>
+          assert(company.symbol.nonEmpty, "Company symbol should not be empty")
+        }
+      }
+    }
+  }
+
+  // --- getTopPerformingCompanies ---
+
+  test("returns non-empty top performing companies for semiconductors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getTopPerformingCompanies(IndustryKey("semiconductors")).map { performers =>
+        assert(performers.nonEmpty, "Semiconductors industry should have top performers")
+        performers.foreach { p =>
+          assert(p.symbol.nonEmpty, "Performer symbol should not be empty")
+        }
+      }
+    }
+  }
+
+  test("top performing companies are sorted by ytd return descending") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getTopPerformingCompanies(IndustryKey("semiconductors")).map { performers =>
+        assertEquals(performers, performers.sorted)
+      }
+    }
+  }
+
+  // --- getTopGrowthCompanies ---
+
+  test("returns non-empty top growth companies for semiconductors") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getTopGrowthCompanies(IndustryKey("semiconductors")).map { growers =>
+        assert(growers.nonEmpty, "Semiconductors industry should have top growth companies")
+        growers.foreach { g =>
+          assert(g.symbol.nonEmpty, "Grower symbol should not be empty")
+        }
+      }
+    }
+  }
+
+  test("top growth companies are sorted by growth estimate descending") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getTopGrowthCompanies(IndustryKey("semiconductors")).map { growers =>
+        assertEquals(growers, growers.sorted)
+      }
+    }
+  }
+
+  // --- Cross-sector coverage ---
+
+  test("returns industry data for software-infrastructure (technology sector)") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getIndustryData(IndustryKey("software-infrastructure")).map { data =>
+        assertEquals(data.sectorKey, "technology")
+        assert(data.nonEmpty)
+      }
+    }
+  }
+
+  test("returns industry data for biotechnology (healthcare sector)") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getIndustryData(IndustryKey("biotechnology")).map { data =>
+        assertEquals(data.sectorKey, "healthcare")
+        assert(data.nonEmpty)
+      }
+    }
+  }
+
+  test("returns industry data for banks-diversified (financial-services sector)") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.industries.getIndustryData(IndustryKey("banks-diversified")).map { data =>
+        assertEquals(data.sectorKey, "financial-services")
+        assert(data.nonEmpty)
+      }
+    }
+  }
+
+  // --- End-to-end discovery flow ---
+
+  test("discovers industry key via sector listing and fetches it") {
+    YFinanceClient.resource[IO](config).use { client =>
+      for {
+        industries <- client.sectors.getIndustries(SectorKey.Technology)
+        _ = assert(industries.nonEmpty, "Technology sector should have industries")
+        firstIndustry = industries.head
+        data <- client.industries.getIndustryData(IndustryKey(firstIndustry.key))
+        _ = assertEquals(data.name, firstIndustry.name)
+        _ = assertEquals(data.sectorKey, "technology")
+      } yield ()
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/AnalystDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/AnalystDataSpec.scala
@@ -615,15 +615,9 @@ class AnalystDataSpec extends FunSuite {
     assertEquals(data.earningsBeatRate, None)
   }
 
-  test("empty instance returns defaults for all accessors") {
+  test("derived accessors yield empty results on empty history") {
     val data = AnalystData.empty
-    assertEquals(data.currentRecommendation, None)
-    assertEquals(data.currentQuarterEarningsEstimate, None)
-    assertEquals(data.currentQuarterRevenueEstimate, None)
-    assertEquals(data.currentYearEarningsEstimate, None)
-    assertEquals(data.consecutiveBeats, 0)
     assertEquals(data.recentUpgrades().size, 0)
     assertEquals(data.recentDowngrades().size, 0)
-    assertEquals(data.earningsBeatRate, None)
   }
 }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IndustryDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/IndustryDataSpec.scala
@@ -1,0 +1,282 @@
+package org.coinductive.yfinance4s.unit
+
+import cats.syntax.show.*
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+class IndustryDataSpec extends FunSuite {
+
+  // --- IndustryOverview ---
+
+  private val overview = IndustryOverview(
+    companiesCount = Some(75),
+    marketCap = Some(5000000000000L),
+    messageBoardId = Some("finmb_xyz"),
+    description = Some("The semiconductors industry..."),
+    marketWeight = Some(0.089),
+    employeeCount = Some(1200000L)
+  )
+
+  test("calculates industry market weight as percentage") {
+    val percent = overview.marketWeightPercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 8.9) < 0.001)
+  }
+
+  test("returns no market weight percent when absent") {
+    assertEquals(IndustryOverview.empty.marketWeightPercent, None)
+  }
+
+  // --- IndustrySectorInfo ---
+
+  test("converts sector info to SectorKey") {
+    val info = IndustrySectorInfo(sectorKey = "technology", sectorName = "Technology")
+    assertEquals(info.toSectorKey, SectorKey("technology"))
+  }
+
+  // --- TopPerformingCompany ---
+
+  private val performer = TopPerformingCompany(
+    symbol = "NVDA",
+    name = Some("NVIDIA Corporation"),
+    ytdReturn = Some(0.42),
+    lastPrice = Some(100.0),
+    targetPrice = Some(120.0)
+  )
+
+  test("converts performer symbol to ticker") {
+    assertEquals(performer.toTicker, Ticker("NVDA"))
+  }
+
+  test("calculates performer ytd return percent") {
+    val percent = performer.ytdReturnPercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 42.0) < 0.001)
+  }
+
+  test("computes implied upside from last and target prices") {
+    val upside = performer.impliedUpside
+    assert(upside.isDefined)
+    assert(Math.abs(upside.get - 0.20) < 0.001)
+  }
+
+  test("computes implied upside as percentage") {
+    val percent = performer.impliedUpsidePercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 20.0) < 0.001)
+  }
+
+  test("returns no implied upside when last price is zero") {
+    val p = performer.copy(lastPrice = Some(0.0))
+    assertEquals(p.impliedUpside, None)
+  }
+
+  test("returns no implied upside when last price is negative") {
+    val p = performer.copy(lastPrice = Some(-10.0))
+    assertEquals(p.impliedUpside, None)
+  }
+
+  test("returns no implied upside when last price is missing") {
+    val p = performer.copy(lastPrice = None)
+    assertEquals(p.impliedUpside, None)
+  }
+
+  test("returns no implied upside when target price is missing") {
+    val p = performer.copy(targetPrice = None)
+    assertEquals(p.impliedUpside, None)
+  }
+
+  test("sorts performers by ytd return descending") {
+    val list = List(
+      performer.copy(symbol = "A", ytdReturn = Some(0.10)),
+      performer.copy(symbol = "B", ytdReturn = Some(0.30)),
+      performer.copy(symbol = "C", ytdReturn = Some(0.20))
+    )
+    assertEquals(list.sorted.map(_.symbol), List("B", "C", "A"))
+  }
+
+  test("sorts performers with None ytd return last") {
+    val list = List(
+      performer.copy(symbol = "A", ytdReturn = None),
+      performer.copy(symbol = "B", ytdReturn = Some(0.30)),
+      performer.copy(symbol = "C", ytdReturn = Some(0.10))
+    )
+    assertEquals(list.sorted.map(_.symbol), List("B", "C", "A"))
+  }
+
+  // --- TopGrowthCompany ---
+
+  private val grower = TopGrowthCompany(
+    symbol = "NVDA",
+    name = Some("NVIDIA Corporation"),
+    ytdReturn = Some(0.42),
+    growthEstimate = Some(0.28)
+  )
+
+  test("converts grower symbol to ticker") {
+    assertEquals(grower.toTicker, Ticker("NVDA"))
+  }
+
+  test("calculates grower ytd return percent") {
+    val percent = grower.ytdReturnPercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 42.0) < 0.001)
+  }
+
+  test("calculates growth estimate percent") {
+    val percent = grower.growthEstimatePercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 28.0) < 0.001)
+  }
+
+  test("sorts growers by growth estimate descending") {
+    val list = List(
+      grower.copy(symbol = "A", growthEstimate = Some(0.10)),
+      grower.copy(symbol = "B", growthEstimate = Some(0.30)),
+      grower.copy(symbol = "C", growthEstimate = Some(0.20))
+    )
+    assertEquals(list.sorted.map(_.symbol), List("B", "C", "A"))
+  }
+
+  test("sorts growers with None growth estimate last") {
+    val list = List(
+      grower.copy(symbol = "A", growthEstimate = None),
+      grower.copy(symbol = "B", growthEstimate = Some(0.30)),
+      grower.copy(symbol = "C", growthEstimate = Some(0.10))
+    )
+    assertEquals(list.sorted.map(_.symbol), List("B", "C", "A"))
+  }
+
+  // --- IndustryData ---
+
+  private val topCompany = TopCompany(
+    symbol = "NVDA",
+    name = Some("NVIDIA Corporation"),
+    rating = Some("Buy"),
+    marketWeight = Some(0.35)
+  )
+
+  private val data = IndustryData(
+    key = IndustryKey("semiconductors"),
+    name = "Semiconductors",
+    sectorKey = "technology",
+    sectorName = "Technology",
+    symbol = Some("^GSPC-SEMI"),
+    overview = Some(overview),
+    topCompanies = List(
+      topCompany,
+      topCompany.copy(symbol = "AMD", name = Some("AMD"), marketWeight = Some(0.20)),
+      topCompany.copy(symbol = "INTC", name = Some("Intel"), marketWeight = Some(0.15))
+    ),
+    topPerformingCompanies = List(
+      performer.copy(symbol = "A", ytdReturn = Some(0.10)),
+      performer.copy(symbol = "B", ytdReturn = Some(0.30)),
+      performer.copy(symbol = "C", ytdReturn = Some(0.20))
+    ),
+    topGrowthCompanies = List(
+      grower.copy(symbol = "X", growthEstimate = Some(0.10)),
+      grower.copy(symbol = "Y", growthEstimate = Some(0.30)),
+      grower.copy(symbol = "Z", growthEstimate = Some(0.20))
+    )
+  )
+
+  private val minimal = IndustryData(
+    key = IndustryKey("test"),
+    name = "Test",
+    sectorKey = "technology",
+    sectorName = "Technology"
+  )
+
+  test("is non-empty when overview is present") {
+    assert(data.nonEmpty)
+  }
+
+  test("is non-empty when only top companies are present") {
+    val d = minimal.copy(topCompanies = List(topCompany))
+    assert(d.nonEmpty)
+  }
+
+  test("is non-empty when only top performing companies are present") {
+    val d = minimal.copy(topPerformingCompanies = List(performer))
+    assert(d.nonEmpty)
+  }
+
+  test("is non-empty when only top growth companies are present") {
+    val d = minimal.copy(topGrowthCompanies = List(grower))
+    assert(d.nonEmpty)
+  }
+
+  test("is empty when all collections empty and overview absent") {
+    assert(minimal.isEmpty)
+  }
+
+  test("derives sector info from required fields") {
+    assertEquals(data.sectorInfo, IndustrySectorInfo("technology", "Technology"))
+  }
+
+  test("sector info round-trips to SectorKey") {
+    assertEquals(data.sectorInfo.toSectorKey, SectorKey("technology"))
+  }
+
+  test("returns total market weight from overview") {
+    assertEquals(data.totalMarketWeight, Some(0.089))
+  }
+
+  test("returns total market weight as percentage") {
+    val percent = data.totalMarketWeightPercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 8.9) < 0.001)
+  }
+
+  test("returns total companies from overview") {
+    assertEquals(data.totalCompanies, Some(75))
+  }
+
+  test("returns total market cap from overview") {
+    assertEquals(data.totalMarketCap, Some(5000000000000L))
+  }
+
+  test("returns description from overview") {
+    assertEquals(data.description, Some("The semiconductors industry..."))
+  }
+
+  test("returns no description when overview is absent") {
+    assertEquals(minimal.description, None)
+  }
+
+  test("returns top N companies by market weight descending") {
+    val top2 = data.topCompaniesByWeight(2)
+    assertEquals(top2.map(_.symbol), List("NVDA", "AMD"))
+  }
+
+  test("returns all companies when N exceeds count") {
+    val allTop = data.topCompaniesByWeight(10)
+    assertEquals(allTop.size, 3)
+  }
+
+  test("returns top N performers by ytd return descending") {
+    val top2 = data.topPerformersByYtd(2)
+    assertEquals(top2.map(_.symbol), List("B", "C"))
+  }
+
+  test("returns top N growth companies by growth estimate descending") {
+    val top2 = data.topGrowthByEstimate(2)
+    assertEquals(top2.map(_.symbol), List("Y", "Z"))
+  }
+
+  test("finds top company by symbol") {
+    val found = data.findTopCompany("AMD")
+    assert(found.isDefined)
+    assertEquals(found.get.name, Some("AMD"))
+  }
+
+  test("returns None for unknown top company symbol") {
+    assertEquals(data.findTopCompany("GOOGL"), None)
+  }
+
+  // --- IndustryKey ---
+
+  test("displays industry key as its string value") {
+    assertEquals(IndustryKey("software-infrastructure").show, "software-infrastructure")
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InsiderTransactionSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/InsiderTransactionSpec.scala
@@ -116,9 +116,4 @@ class InsiderTransactionSpec extends FunSuite {
     assertEquals(OwnershipType.fromString("i"), OwnershipType.Indirect)
     assertEquals(OwnershipType.fromString("unknown"), OwnershipType.Direct) // Default
   }
-
-  test("represents ownership type as string") {
-    assertEquals(OwnershipType.Direct.value, "D")
-    assertEquals(OwnershipType.Indirect.value, "I")
-  }
 }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/ScreenerResultSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/ScreenerResultSpec.scala
@@ -190,12 +190,8 @@ class ScreenerResultSpec extends FunSuite {
     assertEquals(result.sectors, List("Technology"))
   }
 
-  test("empty result has zero counts and empty lists") {
+  test("derived accessors yield empty results on empty input") {
     val empty = ScreenerResult.empty
-    assert(empty.isEmpty)
-    assertEquals(empty.total, 0)
-    assertEquals(empty.size, 0)
-    assert(!empty.hasMore)
     assertEquals(empty.symbols, List.empty[String])
     assertEquals(empty.equities, List.empty[ScreenerQuote])
     assertEquals(empty.largestByMarketCap, None)
@@ -203,14 +199,6 @@ class ScreenerResultSpec extends FunSuite {
   }
 
   // --- ScreenerConfig tests ---
-
-  test("default config has expected values") {
-    val config = ScreenerConfig.Default
-    assertEquals(config.sortField, "ticker")
-    assertEquals(config.sortOrder, SortOrder.Desc)
-    assertEquals(config.offset, 0)
-    assertEquals(config.count, 25)
-  }
 
   test("rejects count above max") {
     intercept[IllegalArgumentException] {

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SearchResultSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SearchResultSpec.scala
@@ -225,13 +225,8 @@ class SearchResultSpec extends FunSuite {
     assertEquals(searchResult.tickers, List(Ticker("AAPL"), Ticker("SPY"), Ticker("BTC-USD")))
   }
 
-  test("empty result has zero counts and empty lists") {
+  test("derived accessors yield empty results on empty input") {
     val empty = SearchResult.empty
-    assert(empty.isEmpty)
-    assert(empty.quotes.isEmpty)
-    assert(empty.news.isEmpty)
-    assert(empty.lists.isEmpty)
-    assertEquals(empty.totalResults, 0)
     assertEquals(empty.equities, List.empty[QuoteSearchResult])
     assertEquals(empty.etfs, List.empty[QuoteSearchResult])
     assertEquals(empty.topQuote, None)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SectorDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/SectorDataSpec.scala
@@ -193,19 +193,6 @@ class SectorDataSpec extends FunSuite {
 
   // --- SectorKey tests ---
 
-  test("predefined sector keys have correct values") {
-    assertEquals(SectorKey.Technology.value, "technology")
-    assertEquals(SectorKey.Healthcare.value, "healthcare")
-    assertEquals(SectorKey.FinancialServices.value, "financial-services")
-    assertEquals(SectorKey.RealEstate.value, "real-estate")
-    assertEquals(SectorKey.ConsumerCyclical.value, "consumer-cyclical")
-    assertEquals(SectorKey.BasicMaterials.value, "basic-materials")
-  }
-
-  test("all contains exactly 11 GICS sectors") {
-    assertEquals(SectorKey.all.size, 11)
-  }
-
   test("all sector keys are unique") {
     assertEquals(SectorKey.all.map(_.value).distinct.size, 11)
   }
@@ -217,14 +204,8 @@ class SectorDataSpec extends FunSuite {
 
   // --- defaults ---
 
-  test("has empty defaults when constructed with only key and name") {
+  test("derived lookups yield empty results on minimal construction") {
     val data = SectorData(key = SectorKey.Technology, name = "Technology")
-    assertEquals(data.industryCount, 0)
-    assertEquals(data.totalMarketWeight, None)
-    assertEquals(data.totalMarketWeightPercent, None)
-    assertEquals(data.totalCompanies, None)
-    assertEquals(data.totalMarketCap, None)
-    assertEquals(data.description, None)
     assert(data.industriesByWeight.isEmpty)
     assertEquals(data.findIndustry("any"), None)
     assert(data.topCompaniesByWeight(5).isEmpty)

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
@@ -93,6 +93,15 @@ class TickersSpec extends FunSuite {
       def getIndustries(sectorKey: SectorKey): List[SectorIndustry] = ???
       def getTopCompanies(sectorKey: SectorKey): List[TopCompany] = ???
     }
+    val industries: Industries[Id] = new Industries[Id] {
+      def getIndustryData(industryKey: IndustryKey): IndustryData = ???
+      def getIndustryOverview(industryKey: IndustryKey): Option[IndustryOverview] = ???
+      def getSectorInfo(industryKey: IndustryKey): IndustrySectorInfo = ???
+      def getTopCompanies(industryKey: IndustryKey): List[TopCompany] = ???
+      def getTopPerformingCompanies(industryKey: IndustryKey): List[TopPerformingCompany] = ???
+      def getTopGrowthCompanies(industryKey: IndustryKey): List[TopGrowthCompany] = ???
+      def getResearchReports(industryKey: IndustryKey): List[ResearchReport] = ???
+    }
     def search(query: String, maxResults: Int, newsCount: Int, enableFuzzyQuery: Boolean): SearchResult = ???
     def lookupByISIN(isin: String): Option[Ticker] = ???
     def lookupAllByISIN(isin: String): List[QuoteSearchResult] = ???

--- a/docs/directory.conf
+++ b/docs/directory.conf
@@ -8,6 +8,7 @@ laika.navigationOrder = [
   financials.md
   analysts.md
   sectors.md
+  industries.md
   search.md
   screener.md
   batch-operations.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ YFinance4s is an effectful Yahoo Finance client for Scala, built on Cats Effect 
 - **Financial Statements**: Income statements, balance sheets, and cash flow statements (annual, quarterly, trailing)
 - **Analyst Data**: Price targets, recommendations, earnings estimates, upgrade/downgrade history, growth comparisons
 - **Sector Data**: Sector overview, top ETFs, mutual funds, industries, and top companies for all 11 GICS sectors
+- **Industry Data**: Per-industry overview, top companies, top performers (YTD return, implied upside), and top growth companies
 - **Search**: Ticker/company/news search with fuzzy matching
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
@@ -71,6 +72,7 @@ client.holders     // institutional, mutual fund, and insider data
 client.financials  // income statements, balance sheets, cash flows
 client.analysts    // price targets, recommendations, estimates
 client.sectors     // sector overview, industries, top ETFs/funds
+client.industries  // industry overview, top performers, top growth companies
 client.screener    // custom and predefined stock/fund screens
 client.search(q)   // ticker and news search
 ```

--- a/docs/industries.md
+++ b/docs/industries.md
@@ -1,0 +1,88 @@
+# Industry Data
+
+The `industries` module exposes Yahoo Finance's industry-level data: overview statistics, parent sector lookup, top companies, top performers, top growth companies, and research reports. Industries are the leaf nodes beneath [sectors](./sectors.md) in Yahoo's taxonomy.
+
+## Industry Overview
+
+```scala
+clientResource.use { client =>
+  client.industries.getIndustryData(IndustryKey("semiconductors")).map { data =>
+    println(s"${data.name} (parent sector: ${data.sectorName})")
+    data.overview.foreach { o =>
+      println(s"Companies: ${o.companiesCount.getOrElse("N/A")}")
+      println(s"Market Cap: ${o.marketCap.getOrElse("N/A")}")
+      println(f"Market Weight: ${o.marketWeightPercent.getOrElse(0.0)}%.1f%%")
+    }
+  }
+}
+```
+
+## Top Companies
+
+```scala
+clientResource.use { client =>
+  client.industries.getTopCompanies(IndustryKey("semiconductors")).map { companies =>
+    companies.foreach { c =>
+      println(s"${c.symbol}: ${c.name.getOrElse("N/A")} (${c.rating.getOrElse("N/A")})")
+    }
+  }
+}
+```
+
+## Top Performing Companies
+
+Top performing companies are sorted by YTD return descending, with helpers for computing implied upside from analyst target prices.
+
+```scala
+clientResource.use { client =>
+  client.industries.getTopPerformingCompanies(IndustryKey("semiconductors")).map { performers =>
+    performers.foreach { p =>
+      val ytd = p.ytdReturnPercent.map(y => f"$y%.1f%%").getOrElse("N/A")
+      val upside = p.impliedUpsidePercent.map(u => f"$u%.1f%%").getOrElse("N/A")
+      println(s"${p.symbol}: YTD $ytd, implied upside $upside")
+    }
+  }
+}
+```
+
+## Top Growth Companies
+
+```scala
+clientResource.use { client =>
+  client.industries.getTopGrowthCompanies(IndustryKey("biotechnology")).map { growers =>
+    growers.foreach { g =>
+      val growth = g.growthEstimatePercent.map(x => f"$x%.1f%%").getOrElse("N/A")
+      println(s"${g.symbol}: growth estimate $growth")
+    }
+  }
+}
+```
+
+## Parent Sector Lookup
+
+Every industry belongs to a sector. `getSectorInfo` returns the parent sector's key and name, and `toSectorKey` round-trips to a `SectorKey`:
+
+```scala
+clientResource.use { client =>
+  client.industries.getSectorInfo(IndustryKey("semiconductors")).map { info =>
+    println(s"${info.sectorName} (${info.sectorKey})")
+    val parent: SectorKey = info.toSectorKey
+  }
+}
+```
+
+## Discovering Industry Keys
+
+Yahoo Finance exposes ~150+ industry keys across 11 sectors. Rather than hardcoding them, discover keys dynamically via `sectors.getIndustries`:
+
+```scala
+clientResource.use { client =>
+  for {
+    industries <- client.sectors.getIndustries(SectorKey.Technology)
+    _ = industries.foreach(i => println(s"${i.key}: ${i.name}"))
+    data <- client.industries.getIndustryData(IndustryKey(industries.head.key))
+  } yield data
+}
+```
+
+Any string can be wrapped in `IndustryKey`. If Yahoo doesn't recognise the key, the HTTP request raises in `F`.

--- a/docs/sectors.md
+++ b/docs/sectors.md
@@ -34,6 +34,8 @@ clientResource.use { client =>
 }
 ```
 
+For per-industry data (overview, top performers, top growth companies), use the `industries` algebra - see [industries.md](./industries.md).
+
 ## Top Companies
 
 ```scala


### PR DESCRIPTION
- `Industries[F]` algebra: `getIndustryData`, `getIndustryOverview`, `getSectorInfo`, `getTopCompanies`, `getTopPerformingCompanies`, `getTopGrowthCompanies`, `getResearchReports`.
- New domain types: `IndustryKey` (bare newtype), `IndustryData`, `IndustryOverview`, `IndustrySectorInfo`, `TopPerformingCompany` (with YTD return and implied-upside helpers), `TopGrowthCompany`. Reuses `TopCompany`, `ResearchReport`, `SectorOverviewRaw`, `TopCompanyRaw` and `ResearchReportRaw` from the Sectors module.