### PR TITLE
Feat: adding Markets algebra for region-level market data

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Effectful Yahoo Finance client in the Scala programming language.
 - **Analyst Data**: Price targets, recommendations, earnings estimates, upgrade/downgrade history, growth comparisons
 - **Sector Data**: Sector overview, top ETFs, mutual funds, industries, and top companies for all 11 GICS sectors
 - **Industry Data**: Per-industry overview, top companies, top performers (YTD return, implied upside), and top growth companies
+- **Market Data**: Region-level market summary (headline indices), trading status with open/close times, and trending tickers
 - **Search**: Ticker/company/news search with fuzzy matching
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
@@ -62,6 +63,7 @@ YFinanceClient.resource[IO](config).use { client =>
 | [Analyst Data](docs/analysts.md) | Price targets, recommendations, estimates |
 | [Sector Data](docs/sectors.md) | Sector overview, industries, top ETFs/funds |
 | [Industry Data](docs/industries.md) | Industry overview, top companies, performers, growth |
+| [Market Data](docs/markets.md) | Region summary, market status, trending tickers |
 | [Search & ISIN](docs/search.md) | Ticker search and ISIN lookup |
 | [Screener](docs/screener.md) | Custom and predefined stock/fund screens |
 | [Batch Operations](docs/batch-operations.md) | Multi-ticker parallel fetches |

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/HTTPBase.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/HTTPBase.scala
@@ -3,6 +3,8 @@ package org.coinductive.yfinance4s
 import cats.effect.Sync
 import cats.syntax.either.*
 import cats.syntax.flatMap.*
+import io.circe.Decoder
+import io.circe.parser.decode
 import retry.{RetryPolicy, Sleep, retryingOnAllErrors}
 import sttp.client3.{Identity, RequestT, Response, SttpBackend}
 
@@ -22,6 +24,15 @@ trait HTTPBase[F[_]] {
       request.send(sttpBackend)
     }.flatMap(parseResponse[A](_, parseContent))
   }
+
+  /** Decodes a JSON payload and lifts decode failures into the effect. `label` is a human-readable name used in the
+    * error message (e.g., `"chart"`, `"market summary"`).
+    */
+  protected def parseAs[A: Decoder](label: String)(content: String): F[A] =
+    decode[A](content).fold(
+      e => F.raiseError(new Exception(s"Failed to parse $label response: ${e.getMessage}")),
+      F.pure
+    )
 
   private def parseResponse[A](
       response: Response[Either[String, String]],

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Markets.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Markets.scala
@@ -1,0 +1,103 @@
+package org.coinductive.yfinance4s
+
+import cats.Monad
+import cats.syntax.flatMap.*
+import cats.syntax.functor.*
+import org.coinductive.yfinance4s.Mapping.*
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
+
+/** Algebra for market-level data: region summaries, trading status, trending tickers. */
+trait Markets[F[_]] {
+
+  /** Headline indices and instruments for the given region (e.g., US → S&P 500, Dow, Nasdaq, VIX). */
+  def getSummary(region: MarketRegion): F[MarketSummary]
+
+  /** Trading status for the region: open/closed, session hours, timezone. */
+  def getStatus(region: MarketRegion): F[MarketStatus]
+
+  /** Most-searched tickers in the region. Yahoo caps the count server-side; the returned list may be shorter than
+    * requested.
+    */
+  def getTrending(region: MarketRegion, count: Int = Markets.DefaultTrendingCount): F[List[TrendingTicker]]
+
+  /** Convenience aggregate: fires all three queries sequentially and bundles the results. */
+  def getMarketSnapshot(region: MarketRegion): F[MarketSnapshot]
+}
+
+private[yfinance4s] object Markets {
+
+  val DefaultTrendingCount: Int = 10
+
+  def apply[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Markets[F] =
+    new MarketsImpl(gateway, auth)
+
+  private final class MarketsImpl[F[_]: Monad](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]) extends Markets[F] {
+
+    def getSummary(region: MarketRegion): F[MarketSummary] =
+      auth.getCredentials.flatMap { creds =>
+        gateway.getMarketSummary(region, creds).map(mapMarketSummary(region, _))
+      }
+
+    def getStatus(region: MarketRegion): F[MarketStatus] =
+      auth.getCredentials.flatMap { creds =>
+        gateway.getMarketStatus(region, creds).map(mapMarketStatus(region, _))
+      }
+
+    def getTrending(region: MarketRegion, count: Int): F[List[TrendingTicker]] =
+      auth.getCredentials.flatMap { creds =>
+        gateway.getMarketTrending(region, count, creds).map(_.quotes.map(q => TrendingTicker(q.symbol)))
+      }
+
+    def getMarketSnapshot(region: MarketRegion): F[MarketSnapshot] =
+      for {
+        summary <- getSummary(region)
+        status <- getStatus(region)
+        trending <- getTrending(region)
+      } yield MarketSnapshot(region, summary, status, trending)
+
+    // --- Mapping helpers ---
+
+    private def mapMarketSummary(region: MarketRegion, result: YFinanceMarketSummaryResult): MarketSummary =
+      MarketSummary(
+        region = region,
+        quotes = result.result.map(mapMarketQuote)
+      )
+
+    private def mapMarketQuote(raw: MarketQuoteRaw): MarketIndexQuote =
+      MarketIndexQuote(
+        symbol = raw.symbol,
+        shortName = raw.shortName,
+        fullExchangeName = raw.fullExchangeName,
+        exchange = raw.exchange,
+        currency = raw.currency,
+        marketState = raw.marketState,
+        exchangeTimezoneName = raw.exchangeTimezoneName,
+        regularMarketPrice = raw.regularMarketPrice.map(_.raw),
+        regularMarketChange = raw.regularMarketChange.map(_.raw),
+        regularMarketChangePercent = raw.regularMarketChangePercent.map(_.raw),
+        regularMarketTime = raw.regularMarketTime.map(v => epochToZonedDateTime(v.raw)),
+        previousClose = raw.previousClose.map(_.raw)
+      )
+
+    private def mapMarketStatus(region: MarketRegion, result: YFinanceMarketStatusResult): MarketStatus = {
+      val raw = result.marketTime
+      MarketStatus(
+        region = region,
+        status = raw.status,
+        open = raw.open,
+        close = raw.close,
+        timezone = mapTimezone(raw.timezone),
+        message = raw.message,
+        yfitMarketState = raw.yfitMarketState
+      )
+    }
+
+    private def mapTimezone(raw: TimezoneRaw): MarketTimezone =
+      MarketTimezone(
+        short = raw.short,
+        gmtOffsetMillis = raw.gmtoffset,
+        full = raw.full
+      )
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -46,6 +46,9 @@ trait YFinanceClient[F[_]] {
   /** Industry data (overview, top companies, top performers, top growth). */
   def industries: Industries[F]
 
+  /** Market data (region summary, status, trending tickers). */
+  def markets: Markets[F]
+
   /** Searches Yahoo Finance for tickers, companies, and news.
     *
     * @param query
@@ -198,6 +201,7 @@ object YFinanceClient {
     val screener: Screener[F] = Screener(gateway, auth)
     val sectors: Sectors[F] = Sectors(gateway, auth)
     val industries: Industries[F] = Industries(gateway, auth)
+    val markets: Markets[F] = Markets(gateway, auth)
 
     def search(
         query: String,

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -2,7 +2,6 @@ package org.coinductive.yfinance4s
 
 import cats.effect.{Async, Resource, Sync}
 import cats.syntax.show.*
-import io.circe.parser.decode
 import org.coinductive.yfinance4s.models.*
 import org.coinductive.yfinance4s.models.internal.*
 import retry.{RetryPolicies, RetryPolicy, Sleep}
@@ -40,6 +39,16 @@ sealed trait YFinanceGateway[F[_]] {
   def getSectorData(sectorKey: SectorKey, credentials: YFinanceCredentials): F[YFinanceSectorResult]
 
   def getIndustryData(industryKey: IndustryKey, credentials: YFinanceCredentials): F[YFinanceIndustryResult]
+
+  def getMarketSummary(region: MarketRegion, credentials: YFinanceCredentials): F[YFinanceMarketSummaryResult]
+
+  def getMarketStatus(region: MarketRegion, credentials: YFinanceCredentials): F[YFinanceMarketStatusResult]
+
+  def getMarketTrending(
+      region: MarketRegion,
+      count: Int,
+      credentials: YFinanceCredentials
+  ): F[YFinanceTrendingResult]
 }
 
 private object YFinanceGateway {
@@ -88,6 +97,29 @@ private object YFinanceGateway {
     private val SectorsEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/sectors/"
     private val IndustriesEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/industries/"
 
+    private val MarketSummaryEndpoint = uri"https://query1.finance.yahoo.com/v6/finance/quote/marketSummary"
+    private val MarketTimeEndpoint = uri"https://query1.finance.yahoo.com/v6/finance/markettime"
+    private val TrendingEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/trending/"
+
+    private val MarketSummaryFields = List(
+      "shortName",
+      "fullExchangeName",
+      "exchange",
+      "currency",
+      "marketState",
+      "exchangeTimezoneName",
+      "regularMarketPrice",
+      "regularMarketChange",
+      "regularMarketChangePercent",
+      "regularMarketTime",
+      "previousClose"
+    ).mkString(",")
+
+    private val MarketBaseParams = Map(
+      "formatted" -> "true",
+      "lang" -> "en-US"
+    )
+
     private val DomainQueryParams = Map(
       "formatted" -> "true",
       "withReturns" -> "true",
@@ -110,7 +142,7 @@ private object YFinanceGateway {
             .withParams(("interval", interval.show), ("range", range.show), ("events", "div,split"))
         )
 
-      sendRequest(req, parseChartContent)
+      sendRequest(req, parseAs[YFinanceQueryResult]("chart"))
     }
 
     def getChart(
@@ -131,7 +163,7 @@ private object YFinanceGateway {
             )
         )
 
-      sendRequest(req, parseChartContent)
+      sendRequest(req, parseAs[YFinanceQueryResult]("chart"))
     }
 
     def getOptions(ticker: Ticker, credentials: YFinanceCredentials): F[YFinanceOptionsResult] = {
@@ -144,7 +176,7 @@ private object YFinanceGateway {
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
 
-      sendRequest(req, parseOptionsContent)
+      sendRequest(req, parseAs[YFinanceOptionsResult]("options"))
     }
 
     def getOptions(ticker: Ticker, expiration: Long, credentials: YFinanceCredentials): F[YFinanceOptionsResult] = {
@@ -157,7 +189,7 @@ private object YFinanceGateway {
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
 
-      sendRequest(req, parseOptionsContent)
+      sendRequest(req, parseAs[YFinanceOptionsResult]("options"))
     }
 
     def getHolders(ticker: Ticker, credentials: YFinanceCredentials): F[YFinanceHoldersResult] = {
@@ -174,31 +206,7 @@ private object YFinanceGateway {
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
 
-      sendRequest(req, parseHoldersContent)
-    }
-
-    private def parseChartContent(content: String): F[YFinanceQueryResult] = {
-      decode[YFinanceQueryResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse chart response: ${e.getMessage}")),
-          F.pure
-        )
-    }
-
-    private def parseOptionsContent(content: String): F[YFinanceOptionsResult] = {
-      decode[YFinanceOptionsResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse options response: ${e.getMessage}")),
-          F.pure
-        )
-    }
-
-    private def parseHoldersContent(content: String): F[YFinanceHoldersResult] = {
-      decode[YFinanceHoldersResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse holders response: ${e.getMessage}")),
-          F.pure
-        )
+      sendRequest(req, parseAs[YFinanceHoldersResult]("holders"))
     }
 
     def getFinancials(
@@ -228,15 +236,8 @@ private object YFinanceGateway {
           )
       )
 
-      sendRequest(req, parseFinancialsContent)
+      sendRequest(req, parseAs[YFinanceFinancialsResult]("financials"))
     }
-
-    private def parseFinancialsContent(content: String): F[YFinanceFinancialsResult] =
-      decode[YFinanceFinancialsResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse financials response: ${e.getMessage}")),
-          F.pure
-        )
 
     def getAnalystData(ticker: Ticker, credentials: YFinanceCredentials): F[YFinanceAnalystResult] = {
       val req = basicRequest
@@ -252,15 +253,8 @@ private object YFinanceGateway {
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
 
-      sendRequest(req, parseAnalystContent)
+      sendRequest(req, parseAs[YFinanceAnalystResult]("analyst"))
     }
-
-    private def parseAnalystContent(content: String): F[YFinanceAnalystResult] =
-      decode[YFinanceAnalystResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse analyst response: ${e.getMessage}")),
-          F.pure
-        )
 
     def search(
         query: String,
@@ -285,15 +279,8 @@ private object YFinanceGateway {
         )
       )
 
-      sendRequest(req, parseSearchContent)
+      sendRequest(req, parseAs[YFinanceSearchResult]("search"))
     }
-
-    private def parseSearchContent(content: String): F[YFinanceSearchResult] =
-      decode[YFinanceSearchResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse search response: ${e.getMessage}")),
-          F.pure
-        )
 
     def screenCustom(body: String, credentials: YFinanceCredentials): F[YFinanceScreenerResult] = {
       val params = ScreenerQueryParams ++ Map("crumb" -> credentials.crumb)
@@ -304,7 +291,7 @@ private object YFinanceGateway {
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
 
-      sendRequest(req, parseScreenerContent)
+      sendRequest(req, parseAs[YFinanceScreenerResult]("screener"))
     }
 
     def screenPredefined(screenId: String, count: Int): F[YFinanceScreenerResult] = {
@@ -314,15 +301,8 @@ private object YFinanceGateway {
       )
       val req = basicRequest.get(PredefinedScreenerEndpoint.withParams(params))
 
-      sendRequest(req, parseScreenerContent)
+      sendRequest(req, parseAs[YFinanceScreenerResult]("screener"))
     }
-
-    private def parseScreenerContent(content: String): F[YFinanceScreenerResult] =
-      decode[YFinanceScreenerResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse screener response: ${e.getMessage}")),
-          F.pure
-        )
 
     def getSectorData(sectorKey: SectorKey, credentials: YFinanceCredentials): F[YFinanceSectorResult] = {
       val req = basicRequest
@@ -333,15 +313,8 @@ private object YFinanceGateway {
         )
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
-      sendRequest(req, parseSectorContent)
+      sendRequest(req, parseAs[YFinanceSectorResult]("sector"))
     }
-
-    private def parseSectorContent(content: String): F[YFinanceSectorResult] =
-      decode[YFinanceSectorResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse sector response: ${e.getMessage}")),
-          F.pure
-        )
 
     def getIndustryData(industryKey: IndustryKey, credentials: YFinanceCredentials): F[YFinanceIndustryResult] = {
       val req = basicRequest
@@ -352,15 +325,59 @@ private object YFinanceGateway {
         )
         .headers(YFinanceAuth.apiHeaders *)
         .header("Cookie", credentials.cookies.mkString("; "))
-      sendRequest(req, parseIndustryContent)
+      sendRequest(req, parseAs[YFinanceIndustryResult]("industry"))
     }
 
-    private def parseIndustryContent(content: String): F[YFinanceIndustryResult] =
-      decode[YFinanceIndustryResult](content)
-        .fold(
-          e => F.raiseError(new Exception(s"Failed to parse industry response: ${e.getMessage}")),
-          F.pure
-        )
+    def getMarketSummary(
+        region: MarketRegion,
+        credentials: YFinanceCredentials
+    ): F[YFinanceMarketSummaryResult] = {
+      val params = MarketBaseParams ++ Map(
+        "fields" -> MarketSummaryFields,
+        "market" -> region.show,
+        "crumb" -> credentials.crumb
+      )
+      val req = basicRequest
+        .get(MarketSummaryEndpoint.withParams(params))
+        .headers(YFinanceAuth.apiHeaders *)
+        .header("Cookie", credentials.cookies.mkString("; "))
+
+      sendRequest(req, parseAs[YFinanceMarketSummaryResult]("market summary"))
+    }
+
+    def getMarketStatus(
+        region: MarketRegion,
+        credentials: YFinanceCredentials
+    ): F[YFinanceMarketStatusResult] = {
+      val params = MarketBaseParams ++ Map(
+        "key" -> "finance",
+        "market" -> region.show,
+        "crumb" -> credentials.crumb
+      )
+      val req = basicRequest
+        .get(MarketTimeEndpoint.withParams(params))
+        .headers(YFinanceAuth.apiHeaders *)
+        .header("Cookie", credentials.cookies.mkString("; "))
+
+      sendRequest(req, parseAs[YFinanceMarketStatusResult]("market status"))
+    }
+
+    def getMarketTrending(
+        region: MarketRegion,
+        count: Int,
+        credentials: YFinanceCredentials
+    ): F[YFinanceTrendingResult] = {
+      val params = MarketBaseParams ++ Map(
+        "count" -> count.toString,
+        "crumb" -> credentials.crumb
+      )
+      val req = basicRequest
+        .get(TrendingEndpoint.addPath(region.show).withParams(params))
+        .headers(YFinanceAuth.apiHeaders *)
+        .header("Cookie", credentials.cookies.mkString("; "))
+
+      sendRequest(req, parseAs[YFinanceTrendingResult]("trending"))
+    }
 
   }
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceScrapper.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceScrapper.scala
@@ -5,7 +5,6 @@ import cats.syntax.apply.*
 import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import cats.syntax.show.*
-import io.circe.parser.decode
 import org.coinductive.yfinance4s.html.PlatformHtmlParser
 import org.coinductive.yfinance4s.models.Ticker
 import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult
@@ -70,16 +69,8 @@ private object YFinanceScrapper {
 
       (maybeSummary, maybeFundamentals).traverseN { case (summaryStr, fundamentalsStr) =>
         for {
-          summary <- decode[YFinanceQuoteResult.Summary](summaryStr)
-            .fold(
-              e => F.raiseError(new Exception(s"Illegible quote summary: ${e.getMessage}")),
-              F.pure
-            )
-          fundamentals <- decode[YFinanceQuoteResult.Fundamentals](fundamentalsStr)
-            .fold(
-              e => F.raiseError(new Exception(s"Illegible quote fundamentals: ${e.getMessage}")),
-              F.pure
-            )
+          summary <- parseAs[YFinanceQuoteResult.Summary]("quote summary")(summaryStr)
+          fundamentals <- parseAs[YFinanceQuoteResult.Fundamentals]("quote fundamentals")(fundamentalsStr)
         } yield YFinanceQuoteResult(summary, fundamentals)
       }
     }

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketRegion.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketRegion.scala
@@ -1,0 +1,18 @@
+package org.coinductive.yfinance4s.models
+
+import cats.Show
+
+/** A Yahoo Finance market region (e.g., `MarketRegion("US")`, `MarketRegion("JP")`).
+  *
+  * Yahoo accepts uppercase ISO-3166 alpha-2 codes for ~20 regions. The set isn't standardized - common values include
+  * US, GB, CA, DE, FR, IT, ES, AU, JP, HK, IN, BR, MX. No constants are defined on the companion: a curated subset
+  * would imply "these are blessed, others aren't", which is false - any ISO code Yahoo accepts works identically.
+  * Construct instances directly: `MarketRegion("GB")`.
+  *
+  * Codes are case-sensitive on Yahoo's side (`"us"` is rejected); the newtype does not normalize.
+  */
+final case class MarketRegion(code: String) extends AnyVal
+
+object MarketRegion {
+  implicit val show: Show[MarketRegion] = Show.show(_.code)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketSnapshot.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketSnapshot.scala
@@ -1,0 +1,12 @@
+package org.coinductive.yfinance4s.models
+
+/** Bundled result of the three `Markets` queries for a single region. */
+final case class MarketSnapshot(
+    region: MarketRegion,
+    summary: MarketSummary,
+    status: MarketStatus,
+    trending: List[TrendingTicker]
+) {
+  def isOpen: Boolean = status.isOpen
+  def isClosed: Boolean = status.isClosed
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketStatus.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketStatus.scala
@@ -1,0 +1,49 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.ZonedDateTime
+import scala.concurrent.duration.{Duration, FiniteDuration, MILLISECONDS}
+
+/** Timezone descriptor associated with a [[MarketStatus]]. `short` and `gmtOffsetMillis` are structurally guaranteed by
+  * Yahoo's `/markettime` response; `full` is a human-readable label that Yahoo sometimes omits.
+  */
+final case class MarketTimezone(
+    short: String,
+    gmtOffsetMillis: Long,
+    full: Option[String] = None
+) {
+
+  /** Offset expressed as a `FiniteDuration`. Use `.toSeconds` / `.toHours` for unit conversions. */
+  def gmtOffset: FiniteDuration = Duration(gmtOffsetMillis, MILLISECONDS)
+}
+
+/** Trading status for a [[MarketRegion]]: open/closed, session hours, timezone.
+  *
+  * Fields structurally guaranteed by Yahoo's `/markettime` endpoint (`status`, `open`, `close`, `timezone`) are
+  * required. Auxiliary metadata (`message`, `yfitMarketState`) is optional.
+  */
+final case class MarketStatus(
+    region: MarketRegion,
+    status: String,
+    open: ZonedDateTime,
+    close: ZonedDateTime,
+    timezone: MarketTimezone,
+    message: Option[String] = None,
+    yfitMarketState: Option[String] = None
+) {
+
+  /** True when Yahoo reports the market as `"open"` (case-insensitive). */
+  def isOpen: Boolean = status.equalsIgnoreCase(MarketStatus.OpenState)
+
+  /** True when Yahoo reports a non-regular session state (closed, pre/post-market). */
+  def isClosed: Boolean = MarketStatus.ClosedStates.contains(status.toLowerCase)
+
+  /** Duration of the regular session. `open` and `close` are required, so this is always defined. */
+  def sessionDuration: FiniteDuration =
+    Duration(java.time.Duration.between(open, close).toMillis, MILLISECONDS)
+}
+
+object MarketStatus {
+
+  private val OpenState: String = "open"
+  private val ClosedStates: Set[String] = Set("closed", "pre-market", "post-market", "pre", "post")
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketSummary.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/MarketSummary.scala
@@ -1,0 +1,84 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.ZonedDateTime
+
+/** A single quote in a [[MarketSummary]]. Only `symbol` is structurally guaranteed by Yahoo's
+  * `/v6/finance/quote/marketSummary` response - all other fields depend on the `fields=` request and the instrument's
+  * trading state.
+  */
+final case class MarketIndexQuote(
+    symbol: String,
+    shortName: Option[String] = None,
+    fullExchangeName: Option[String] = None,
+    exchange: Option[String] = None,
+    currency: Option[String] = None,
+    marketState: Option[String] = None,
+    regularMarketPrice: Option[Double] = None,
+    regularMarketChange: Option[Double] = None,
+    regularMarketChangePercent: Option[Double] = None,
+    regularMarketTime: Option[ZonedDateTime] = None,
+    previousClose: Option[Double] = None,
+    exchangeTimezoneName: Option[String] = None
+) {
+
+  def toTicker: Ticker = Ticker(symbol)
+
+  /** Market change as a percentage (e.g., `0.023` → `2.3`). */
+  def regularMarketChangePercentAsPercent: Option[Double] =
+    regularMarketChangePercent.map(_ * 100)
+
+  /** True when Yahoo reports the instrument as actively trading. */
+  def isOpen: Boolean =
+    marketState.exists(s => MarketIndexQuote.OpenStates.contains(s.toUpperCase))
+
+  /** True when Yahoo explicitly reports the instrument as closed. */
+  def isClosed: Boolean =
+    marketState.exists(_.equalsIgnoreCase(MarketIndexQuote.ClosedState))
+}
+
+object MarketIndexQuote {
+
+  private val OpenStates: Set[String] = Set("REGULAR", "PRE", "POST", "PREPRE", "POSTPOST")
+  private val ClosedState: String = "CLOSED"
+
+  /** Sorted by `regularMarketChangePercent` descending; `None` values last. */
+  implicit val byChangePercentDesc: Ordering[MarketIndexQuote] =
+    Ordering
+      .by[MarketIndexQuote, Option[Double]](_.regularMarketChangePercent)(Ordering[Option[Double]].reverse)
+}
+
+/** A region's market-summary snapshot: headline indices and instruments. Ordered as Yahoo returned them. */
+final case class MarketSummary(
+    region: MarketRegion,
+    quotes: List[MarketIndexQuote] = List.empty
+) {
+
+  def nonEmpty: Boolean = quotes.nonEmpty
+  def isEmpty: Boolean = quotes.isEmpty
+
+  /** First quote whose symbol matches exactly (case-sensitive). */
+  def findBySymbol(symbol: String): Option[MarketIndexQuote] =
+    quotes.find(_.symbol == symbol)
+
+  /** First quote whose `exchange` matches (case-insensitive). */
+  def findByExchange(exchange: String): Option[MarketIndexQuote] =
+    quotes.find(_.exchange.exists(_.equalsIgnoreCase(exchange)))
+
+  /** The quote with the highest positive `regularMarketChangePercent`. */
+  def largestGainer: Option[MarketIndexQuote] =
+    quotes
+      .filter(_.regularMarketChangePercent.exists(_ > 0))
+      .sorted(MarketIndexQuote.byChangePercentDesc)
+      .headOption
+
+  /** The quote with the lowest (most-negative) `regularMarketChangePercent`. */
+  def largestLoser: Option[MarketIndexQuote] =
+    quotes
+      .filter(_.regularMarketChangePercent.exists(_ < 0))
+      .sortBy(_.regularMarketChangePercent)(Ordering[Option[Double]])
+      .headOption
+
+  /** Quotes whose absolute change percent meets or exceeds the threshold (fraction, e.g., `0.02` for ±2%). */
+  def movers(threshold: Double): List[MarketIndexQuote] =
+    quotes.filter(_.regularMarketChangePercent.exists(c => math.abs(c) >= threshold))
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/TrendingTicker.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/TrendingTicker.scala
@@ -1,0 +1,10 @@
+package org.coinductive.yfinance4s.models
+
+/** A trending ticker entry returned by Yahoo's `/v1/finance/trending/{region}` endpoint.
+  *
+  * Currently carries only the symbol, but wraps it in a dedicated type so additional fields (rank, score, delta) can be
+  * added without a breaking change.
+  */
+final case class TrendingTicker(symbol: String) {
+  def toTicker: Ticker = Ticker(symbol)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceMarketResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceMarketResult.scala
@@ -1,0 +1,131 @@
+package org.coinductive.yfinance4s.models.internal
+
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{Decoder, DecodingFailure}
+import org.coinductive.yfinance4s.models.internal.MarketDecoders.zonedDateTimeDecoder
+import org.coinductive.yfinance4s.models.internal.YFinanceQuoteResult.Value
+
+import java.time.ZonedDateTime
+import scala.util.Try
+
+private[internal] object MarketDecoders {
+  implicit val zonedDateTimeDecoder: Decoder[ZonedDateTime] =
+    Decoder[String].emap(s => Try(ZonedDateTime.parse(s)).toEither.left.map(_.getMessage))
+}
+
+// --- Market summary ---
+
+private[yfinance4s] final case class YFinanceMarketSummaryResult(result: List[MarketQuoteRaw])
+
+private[yfinance4s] object YFinanceMarketSummaryResult {
+  implicit val decoder: Decoder[YFinanceMarketSummaryResult] = {
+    val inner: Decoder[YFinanceMarketSummaryResult] = deriveDecoder
+    inner.prepare(_.downField("marketSummaryResponse"))
+  }
+}
+
+/** Only `symbol` is structurally guaranteed. Other fields are requested via the `fields=` query param and may be absent
+  * for halted/newly-listed instruments.
+  */
+private[yfinance4s] final case class MarketQuoteRaw(
+    symbol: String,
+    shortName: Option[String],
+    fullExchangeName: Option[String],
+    exchange: Option[String],
+    currency: Option[String],
+    marketState: Option[String],
+    exchangeTimezoneName: Option[String],
+    regularMarketPrice: Option[Value[Double]],
+    regularMarketChange: Option[Value[Double]],
+    regularMarketChangePercent: Option[Value[Double]],
+    regularMarketTime: Option[Value[Long]],
+    previousClose: Option[Value[Double]]
+)
+
+private[yfinance4s] object MarketQuoteRaw {
+  implicit val decoder: Decoder[MarketQuoteRaw] = deriveDecoder
+}
+
+// --- Market status (markettime) ---
+
+private[yfinance4s] final case class YFinanceMarketStatusResult(marketTime: MarketTimeRaw)
+
+private[yfinance4s] object YFinanceMarketStatusResult {
+  implicit val decoder: Decoder[YFinanceMarketStatusResult] =
+    Decoder.instance { c =>
+      c.downField("finance")
+        .downField("marketTimes")
+        .downArray
+        .downField("marketTime")
+        .downArray
+        .as[MarketTimeRaw]
+        .map(YFinanceMarketStatusResult(_))
+    }
+}
+
+/** Core fields (`status`, `open`, `close`, `timezone`) are structurally guaranteed by `/markettime` and therefore
+  * required. Auxiliary metadata fields stay `Option`.
+  */
+private[yfinance4s] final case class MarketTimeRaw(
+    status: String,
+    open: ZonedDateTime,
+    close: ZonedDateTime,
+    timezone: TimezoneRaw,
+    id: Option[String],
+    name: Option[String],
+    message: Option[String],
+    yfitMarketId: Option[String],
+    yfitMarketState: Option[String],
+    time: Option[ZonedDateTime]
+)
+
+private[yfinance4s] object MarketTimeRaw {
+  implicit val decoder: Decoder[MarketTimeRaw] = Decoder.instance { c =>
+    for {
+      status <- c.downField("status").as[String]
+      open <- c.downField("open").as[ZonedDateTime]
+      close <- c.downField("close").as[ZonedDateTime]
+      timezoneArray <- c.downField("timezone").as[List[TimezoneRaw]]
+      timezone <- timezoneArray.headOption.toRight(DecodingFailure("'timezone' array is empty", c.history))
+      id <- c.downField("id").as[Option[String]]
+      name <- c.downField("name").as[Option[String]]
+      message <- c.downField("message").as[Option[String]]
+      yfitMarketId <- c.downField("yfitMarketId").as[Option[String]]
+      yfitMarketState <- c.downField("yfitMarketState").as[Option[String]]
+      time <- c.downField("time").as[Option[ZonedDateTime]]
+    } yield MarketTimeRaw(status, open, close, timezone, id, name, message, yfitMarketId, yfitMarketState, time)
+  }
+}
+
+/** `short` and `gmtoffset` are structurally guaranteed; `full` is optional. */
+private[yfinance4s] final case class TimezoneRaw(
+    short: String,
+    gmtoffset: Long,
+    full: Option[String]
+)
+
+private[yfinance4s] object TimezoneRaw {
+  implicit val decoder: Decoder[TimezoneRaw] = deriveDecoder
+}
+
+// --- Trending ---
+
+private[yfinance4s] final case class YFinanceTrendingResult(quotes: List[TrendingQuoteRaw])
+
+private[yfinance4s] object YFinanceTrendingResult {
+  implicit val decoder: Decoder[YFinanceTrendingResult] =
+    Decoder.instance { c =>
+      c.downField("finance")
+        .downField("result")
+        .downArray
+        .downField("quotes")
+        .as[List[TrendingQuoteRaw]]
+        .map(YFinanceTrendingResult(_))
+    }
+}
+
+private[yfinance4s] final case class TrendingQuoteRaw(symbol: String)
+
+private[yfinance4s] object TrendingQuoteRaw {
+  implicit val decoder: Decoder[TrendingQuoteRaw] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/MarketDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/MarketDataSpec.scala
@@ -1,0 +1,154 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import cats.syntax.all.*
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+
+import scala.concurrent.duration.*
+
+class MarketDataSpec extends CatsEffectSuite {
+
+  private val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  private val US = MarketRegion("US")
+  private val GB = MarketRegion("GB")
+  private val majorRegions = List("US", "GB", "JP", "DE").map(MarketRegion(_))
+
+  // --- getSummary ---
+
+  test("returns a non-empty US market summary with populated symbols") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getSummary(US).map { summary =>
+        assertEquals(summary.region, US)
+        assert(summary.nonEmpty, "US summary should be non-empty")
+        summary.quotes.foreach { q =>
+          assert(q.symbol.nonEmpty, s"symbol should be non-empty: $q")
+        }
+        assert(
+          summary.quotes.exists(_.regularMarketPrice.isDefined),
+          "at least one quote should carry a price"
+        )
+      }
+    }
+  }
+
+  test("includes the S&P 500 in the US market summary") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getSummary(US).map { summary =>
+        assert(
+          summary.findBySymbol("^GSPC").isDefined,
+          s"expected ^GSPC in summary; got ${summary.quotes.map(_.symbol).mkString(",")}"
+        )
+      }
+    }
+  }
+
+  test("returns a non-empty UK market summary") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getSummary(GB).map { summary =>
+        assert(summary.nonEmpty, "UK summary should be non-empty")
+      }
+    }
+  }
+
+  test("returns a summary for at least 3 of the major regions") {
+    YFinanceClient.resource[IO](config).use { client =>
+      majorRegions
+        .traverse(r => client.markets.getSummary(r).attempt)
+        .map { results =>
+          val succeeded = results.count(_.isRight)
+          assert(succeeded >= 3, s"expected ≥3 major regions to succeed; got $succeeded/${majorRegions.size}")
+        }
+    }
+  }
+
+  // --- getStatus ---
+
+  test("returns a US market status with a non-empty status label") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getStatus(US).map { status =>
+        assertEquals(status.region, US)
+        assert(status.status.nonEmpty, "status label should be non-empty")
+      }
+    }
+  }
+
+  test("US market status carries a timezone abbreviation") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getStatus(US).map { status =>
+        assert(
+          status.timezone.short.nonEmpty,
+          s"timezone abbreviation should be non-empty: ${status.timezone}"
+        )
+      }
+    }
+  }
+
+  test("US market status close is after open") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getStatus(US).map { status =>
+        assert(status.close.isAfter(status.open), s"close (${status.close}) should be after open (${status.open})")
+      }
+    }
+  }
+
+  test("US market session duration falls between 1 and 24 hours") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getStatus(US).map { status =>
+        val d = status.sessionDuration
+        assert(d >= 1.hour && d <= 24.hours, s"sessionDuration $d outside [1h, 24h]")
+      }
+    }
+  }
+
+  // --- getTrending ---
+
+  test("returns at most 5 trending US tickers when requested") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getTrending(US, count = 5).map { trending =>
+        assert(trending.nonEmpty, "trending list should not be empty")
+        assert(trending.size <= 5, s"trending list larger than requested: ${trending.size}")
+      }
+    }
+  }
+
+  test("every trending ticker has a non-empty symbol") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getTrending(US).map { trending =>
+        trending.foreach(t => assert(t.symbol.nonEmpty, s"symbol empty: $t"))
+      }
+    }
+  }
+
+  // --- getMarketSnapshot ---
+
+  test("returns a populated snapshot for the US region") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getMarketSnapshot(US).map { snapshot =>
+        assertEquals(snapshot.region, US)
+        assert(snapshot.summary.nonEmpty, "snapshot summary should not be empty")
+        assert(snapshot.trending.nonEmpty, "snapshot trending should not be empty")
+        assert(snapshot.status.status.nonEmpty, "snapshot status.status should not be empty")
+      }
+    }
+  }
+
+  test("largest gainer and largest loser are disjoint when multiple quotes exist") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.markets.getSummary(US).map { summary =>
+        if (summary.quotes.size > 1) {
+          (summary.largestGainer, summary.largestLoser) match {
+            case (Some(g), Some(l)) => assertNotEquals(g.symbol, l.symbol)
+            case _                  => () // at least one side empty; nothing to assert
+          }
+        }
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MarketStatusSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MarketStatusSpec.scala
@@ -1,0 +1,72 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+import java.time.ZonedDateTime
+import scala.concurrent.duration.*
+
+class MarketStatusSpec extends FunSuite {
+
+  // --- MarketTimezone ---
+
+  test("converts a westward millisecond offset to a negative duration") {
+    val tz = MarketTimezone(short = "EDT", gmtOffsetMillis = -14400000L)
+    assertEquals(tz.gmtOffset, -4.hours)
+  }
+
+  test("converts an eastward millisecond offset to a positive duration") {
+    val tz = MarketTimezone(short = "JST", gmtOffsetMillis = 9L * 60 * 60 * 1000)
+    assertEquals(tz.gmtOffset, 9.hours)
+  }
+
+  // --- MarketStatus ---
+
+  private val region = MarketRegion("US")
+  private val tz = MarketTimezone(short = "EDT", gmtOffsetMillis = -14400000L)
+  private val open = ZonedDateTime.parse("2024-06-27T09:30:00-04:00")
+  private val close = ZonedDateTime.parse("2024-06-27T16:00:00-04:00")
+
+  private val openStatus = MarketStatus(region, status = "open", open = open, close = close, timezone = tz)
+
+  test("treats a lowercase 'open' status as an open market") {
+    assert(openStatus.isOpen)
+  }
+
+  test("treats 'open' status case-insensitively when deciding open market") {
+    assert(openStatus.copy(status = "Open").isOpen)
+    assert(openStatus.copy(status = "OPEN").isOpen)
+  }
+
+  test("treats closed and pre/post-market statuses as a non-open market") {
+    assert(!openStatus.copy(status = "closed").isOpen)
+    assert(!openStatus.copy(status = "pre-market").isOpen)
+    assert(!openStatus.copy(status = "post-market").isOpen)
+  }
+
+  test("treats closed, pre-market, post-market, pre, and post statuses as a closed market") {
+    assert(openStatus.copy(status = "closed").isClosed)
+    assert(openStatus.copy(status = "pre-market").isClosed)
+    assert(openStatus.copy(status = "post-market").isClosed)
+    assert(openStatus.copy(status = "pre").isClosed)
+    assert(openStatus.copy(status = "post").isClosed)
+  }
+
+  test("treats status case-insensitively when deciding closed market") {
+    assert(openStatus.copy(status = "CLOSED").isClosed)
+    assert(openStatus.copy(status = "Pre-Market").isClosed)
+  }
+
+  test("treats an open market as not closed") {
+    assert(!openStatus.isClosed)
+  }
+
+  test("computes the session duration between open and close") {
+    assertEquals(openStatus.sessionDuration, 6.hours + 30.minutes)
+  }
+
+  test("reports a zero session duration when open equals close") {
+    val zero = openStatus.copy(close = open)
+    assertEquals(zero.sessionDuration, 0.millis)
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MarketSummarySpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/MarketSummarySpec.scala
@@ -1,0 +1,167 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+class MarketSummarySpec extends FunSuite {
+
+  // --- MarketIndexQuote ---
+
+  private val gspcQuote = MarketIndexQuote(
+    symbol = "^GSPC",
+    shortName = Some("S&P 500"),
+    exchange = Some("SNP"),
+    marketState = Some("REGULAR"),
+    regularMarketPrice = Some(5280.42),
+    regularMarketChange = Some(12.13),
+    regularMarketChangePercent = Some(0.023)
+  )
+
+  test("converts market change percent fraction to human-scale percent") {
+    val percent = gspcQuote.regularMarketChangePercentAsPercent
+    assert(percent.isDefined)
+    assert(Math.abs(percent.get - 2.3) < 0.001)
+  }
+
+  test("returns no change percent when underlying value is absent") {
+    val q = gspcQuote.copy(regularMarketChangePercent = None)
+    assertEquals(q.regularMarketChangePercentAsPercent, None)
+  }
+
+  test("treats a regular-session quote as open") {
+    assert(gspcQuote.copy(marketState = Some("REGULAR")).isOpen)
+  }
+
+  test("treats pre-market and after-hours quotes as open") {
+    assert(gspcQuote.copy(marketState = Some("PRE")).isOpen)
+    assert(gspcQuote.copy(marketState = Some("POST")).isOpen)
+    assert(gspcQuote.copy(marketState = Some("PREPRE")).isOpen)
+    assert(gspcQuote.copy(marketState = Some("POSTPOST")).isOpen)
+  }
+
+  test("treats market state case-insensitively when deciding open status") {
+    assert(gspcQuote.copy(marketState = Some("regular")).isOpen)
+    assert(gspcQuote.copy(marketState = Some("Pre")).isOpen)
+  }
+
+  test("treats a closed quote as not open") {
+    assert(!gspcQuote.copy(marketState = Some("CLOSED")).isOpen)
+  }
+
+  test("treats a quote with missing market state as not open") {
+    assert(!gspcQuote.copy(marketState = None).isOpen)
+  }
+
+  test("treats a closed quote as closed") {
+    assert(gspcQuote.copy(marketState = Some("CLOSED")).isClosed)
+    assert(gspcQuote.copy(marketState = Some("closed")).isClosed)
+  }
+
+  test("treats a regular-session quote as not closed") {
+    assert(!gspcQuote.copy(marketState = Some("REGULAR")).isClosed)
+  }
+
+  test("treats a quote with missing market state as not closed") {
+    assert(!gspcQuote.copy(marketState = None).isClosed)
+  }
+
+  // --- MarketIndexQuote.byChangePercentDesc ordering ---
+
+  test("sorts quotes by change percent descending") {
+    val a = gspcQuote.copy(symbol = "A", regularMarketChangePercent = Some(0.01))
+    val b = gspcQuote.copy(symbol = "B", regularMarketChangePercent = Some(0.05))
+    val c = gspcQuote.copy(symbol = "C", regularMarketChangePercent = Some(-0.02))
+    val sorted = List(a, b, c).sorted(MarketIndexQuote.byChangePercentDesc)
+    assertEquals(sorted.map(_.symbol), List("B", "A", "C"))
+  }
+
+  test("sorts quotes with missing change percent last") {
+    val a = gspcQuote.copy(symbol = "A", regularMarketChangePercent = None)
+    val b = gspcQuote.copy(symbol = "B", regularMarketChangePercent = Some(0.05))
+    val c = gspcQuote.copy(symbol = "C", regularMarketChangePercent = Some(-0.02))
+    val sorted = List(a, b, c).sorted(MarketIndexQuote.byChangePercentDesc)
+    assertEquals(sorted.map(_.symbol), List("B", "C", "A"))
+  }
+
+  // --- MarketSummary ---
+
+  private val region = MarketRegion("US")
+
+  private val quotes = List(
+    MarketIndexQuote(symbol = "^GSPC", exchange = Some("SNP"), regularMarketChangePercent = Some(0.01)),
+    MarketIndexQuote(symbol = "^DJI", exchange = Some("DJI"), regularMarketChangePercent = Some(0.03)),
+    MarketIndexQuote(symbol = "^IXIC", exchange = Some("NAS"), regularMarketChangePercent = Some(-0.02)),
+    MarketIndexQuote(symbol = "^VIX", exchange = Some("CBO"), regularMarketChangePercent = Some(-0.05))
+  )
+
+  private val summary = MarketSummary(region = region, quotes = quotes)
+
+  test("treats a summary with quotes as non-empty") {
+    assert(summary.nonEmpty)
+    assert(!summary.isEmpty)
+  }
+
+  test("treats a summary without quotes as empty") {
+    val empty = MarketSummary(region = region)
+    assert(empty.isEmpty)
+    assert(!empty.nonEmpty)
+  }
+
+  test("finds quote by exact symbol match") {
+    assertEquals(summary.findBySymbol("^DJI").map(_.symbol), Some("^DJI"))
+  }
+
+  test("treats symbol lookup as case-sensitive") {
+    assertEquals(summary.findBySymbol("^dji"), None)
+  }
+
+  test("finds no quote for an unknown symbol") {
+    assertEquals(summary.findBySymbol("NOT-A-SYMBOL"), None)
+  }
+
+  test("finds quote by exchange case-insensitively") {
+    assertEquals(summary.findByExchange("snp").map(_.symbol), Some("^GSPC"))
+    assertEquals(summary.findByExchange("NAS").map(_.symbol), Some("^IXIC"))
+  }
+
+  test("finds no quote for an unknown exchange") {
+    assertEquals(summary.findByExchange("FOO"), None)
+  }
+
+  test("identifies the largest positive mover") {
+    assertEquals(summary.largestGainer.map(_.symbol), Some("^DJI"))
+  }
+
+  test("returns no gainer when all quotes have negative or zero change") {
+    val negOnly = MarketSummary(region, quotes.filter(_.regularMarketChangePercent.exists(_ < 0)))
+    assertEquals(negOnly.largestGainer, None)
+  }
+
+  test("returns no gainer when no quotes have a change percent") {
+    val noChange = MarketSummary(region, List(MarketIndexQuote("^X")))
+    assertEquals(noChange.largestGainer, None)
+  }
+
+  test("identifies the most negative mover") {
+    assertEquals(summary.largestLoser.map(_.symbol), Some("^VIX"))
+  }
+
+  test("returns no loser when all quotes have non-negative change") {
+    val posOnly = MarketSummary(region, quotes.filter(_.regularMarketChangePercent.exists(_ >= 0)))
+    assertEquals(posOnly.largestLoser, None)
+  }
+
+  test("returns movers whose absolute change meets or exceeds the threshold") {
+    val movers3pct = summary.movers(0.03).map(_.symbol).toSet
+    assertEquals(movers3pct, Set("^DJI", "^VIX"))
+  }
+
+  test("returns no movers when threshold exceeds all changes") {
+    assertEquals(summary.movers(0.10), List.empty)
+  }
+
+  test("returns all quotes with a present change at zero threshold") {
+    val all = summary.movers(0.0).map(_.symbol).toSet
+    assertEquals(all, Set("^GSPC", "^DJI", "^IXIC", "^VIX"))
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
@@ -102,6 +102,12 @@ class TickersSpec extends FunSuite {
       def getTopGrowthCompanies(industryKey: IndustryKey): List[TopGrowthCompany] = ???
       def getResearchReports(industryKey: IndustryKey): List[ResearchReport] = ???
     }
+    val markets: Markets[Id] = new Markets[Id] {
+      def getSummary(region: MarketRegion): MarketSummary = ???
+      def getStatus(region: MarketRegion): MarketStatus = ???
+      def getTrending(region: MarketRegion, count: Int): List[TrendingTicker] = ???
+      def getMarketSnapshot(region: MarketRegion): MarketSnapshot = ???
+    }
     def search(query: String, maxResults: Int, newsCount: Int, enableFuzzyQuery: Boolean): SearchResult = ???
     def lookupByISIN(isin: String): Option[Ticker] = ???
     def lookupAllByISIN(isin: String): List[QuoteSearchResult] = ???

--- a/docs/directory.conf
+++ b/docs/directory.conf
@@ -9,6 +9,7 @@ laika.navigationOrder = [
   analysts.md
   sectors.md
   industries.md
+  markets.md
   search.md
   screener.md
   batch-operations.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ YFinance4s is an effectful Yahoo Finance client for Scala, built on Cats Effect 
 - **Analyst Data**: Price targets, recommendations, earnings estimates, upgrade/downgrade history, growth comparisons
 - **Sector Data**: Sector overview, top ETFs, mutual funds, industries, and top companies for all 11 GICS sectors
 - **Industry Data**: Per-industry overview, top companies, top performers (YTD return, implied upside), and top growth companies
+- **Market Data**: Region-level market summary (headline indices), trading status with open/close times, and trending tickers
 - **Search**: Ticker/company/news search with fuzzy matching
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
@@ -73,6 +74,7 @@ client.financials  // income statements, balance sheets, cash flows
 client.analysts    // price targets, recommendations, estimates
 client.sectors     // sector overview, industries, top ETFs/funds
 client.industries  // industry overview, top performers, top growth companies
+client.markets     // region summary, market status, trending tickers
 client.screener    // custom and predefined stock/fund screens
 client.search(q)   // ticker and news search
 ```

--- a/docs/markets.md
+++ b/docs/markets.md
@@ -1,0 +1,105 @@
+# Market Data
+
+The `markets` module exposes Yahoo Finance's region-level market data: headline index summaries, trading status (open/close times, timezone), and trending tickers. It sits alongside [sectors](./sectors.md) and [industries](./industries.md) as one of the domain-level aggregate queries.
+
+## Region Keys
+
+`MarketRegion` is a simple newtype around a Yahoo region code (uppercase ISO-3166 alpha-2). There are no curated constants - any code Yahoo accepts works identically. Common values: `US`, `GB`, `CA`, `DE`, `FR`, `IT`, `ES`, `AU`, `JP`, `HK`, `IN`, `BR`, `MX`.
+
+```scala
+import org.coinductive.yfinance4s.models.*
+
+val US = MarketRegion("US")
+val JP = MarketRegion("JP")
+```
+
+## Market Summary
+
+Returns the region's headline indices and instruments as a list of `MarketIndexQuote`s.
+
+```scala
+clientResource.use { client =>
+  client.markets.getSummary(MarketRegion("US")).map { summary =>
+    summary.quotes.foreach { q =>
+      val pct = q.regularMarketChangePercentAsPercent.getOrElse(0.0)
+      val price = q.regularMarketPrice.getOrElse(0.0)
+      println(f"${q.symbol}%-8s ${q.shortName.getOrElse("")}%-30s $price%.2f ($pct%+.2f%%)")
+    }
+  }
+}
+```
+
+Helpers on `MarketSummary`:
+
+```scala
+summary.findBySymbol("^GSPC")          // Option[MarketIndexQuote] - exact match
+summary.findByExchange("SNP")          // Option[MarketIndexQuote] - case-insensitive
+summary.largestGainer                  // Option[MarketIndexQuote] - highest +%
+summary.largestLoser                   // Option[MarketIndexQuote] - lowest -%
+summary.movers(threshold = 0.02)       // List of quotes with |change| ≥ 2%
+```
+
+## Market Status
+
+Returns trading status for a region. `status`, `open`, `close`, and `timezone` are required (Yahoo guarantees them when the endpoint responds); `message` and `yfitMarketState` are optional.
+
+```scala
+clientResource.use { client =>
+  client.markets.getStatus(MarketRegion("US")).map { status =>
+    println(s"State: ${status.status}")
+    println(s"Open:  ${status.open}")
+    println(s"Close: ${status.close}")
+    println(s"TZ:    ${status.timezone.short} (${status.timezone.gmtOffset})")
+    if (status.isOpen) println("Market is OPEN")
+    else println("Market is CLOSED")
+  }
+}
+```
+
+`status.sessionDuration` returns the length of the regular session as a `FiniteDuration`.
+
+## Trending Tickers
+
+The region's most-searched symbols. Each entry is a bare `TrendingTicker(symbol)`; use `.toTicker` to convert to a `Ticker` for downstream queries.
+
+```scala
+clientResource.use { client =>
+  for {
+    trending <- client.markets.getTrending(MarketRegion("US"), count = 10)
+    _ = trending.foreach(t => println(t.symbol))
+    // Deep-dive on one of them via charts/stocks:
+    stock <- client.charts.getStock(trending.head.toTicker)
+  } yield stock
+}
+```
+
+Yahoo caps the count server-side; the returned list may be shorter than requested.
+
+## Market Snapshot
+
+Convenience aggregate that runs all three queries sequentially for a single region.
+
+```scala
+clientResource.use { client =>
+  client.markets.getMarketSnapshot(MarketRegion("US")).map { snap =>
+    println(s"Market: ${if (snap.isOpen) "OPEN" else "CLOSED"}")
+    println(s"Top mover: ${snap.summary.largestGainer.map(_.symbol).getOrElse("-")}")
+    println(s"Trending:  ${snap.trending.map(_.symbol).mkString(", ")}")
+  }
+}
+```
+
+For parallel execution, call the individual methods via `parTraverseN` yourself.
+
+## Common Symbols by Region
+
+For orientation only - not encoded in the library:
+
+| Region | Indices |
+|---|---|
+| `US` | `^GSPC` (S&P 500), `^DJI` (Dow), `^IXIC` (Nasdaq), `^RUT`, `^VIX` |
+| `GB` | `^FTSE`, `^FTMC`, `^FTAS` |
+| `DE` | `^GDAXI`, `^TECDAX` |
+| `JP` | `^N225`, `^N300` |
+
+For historical OHLCV on any of these symbols, use [`client.charts.getChart(Ticker("^GSPC"), interval, range)`](./charts.md).


### PR DESCRIPTION
Exposing Yahoo's market summary, status, and trending-tickers endpoints through a new `Markets[F]` algebra on `YFinanceClient` with `getSummary`, `getStatus`, `getTrending`, and `getMarketSnapshot`. `MarketRegion` is a bare newtype (matching `IndustryKey`) since Yahoo's region list isn't standardized and curating a subset would falsely imply exclusivity.