### PR TITLE
Feat: adding Calendars algebra for earnings calendar data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Effectful Yahoo Finance client in the Scala programming language.
 - **Sector Data**: Sector overview, top ETFs, mutual funds, industries, and top companies for all 11 GICS sectors
 - **Industry Data**: Per-industry overview, top companies, top performers (YTD return, implied upside), and top growth companies
 - **Market Data**: Region-level market summary (headline indices), trading status with open/close times, and trending tickers
+- **Earnings Calendar**: Market-wide upcoming earnings ranked by market cap, and per-ticker historical/upcoming earnings timelines
 - **Search**: Ticker/company/news search with fuzzy matching
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
@@ -64,6 +65,7 @@ YFinanceClient.resource[IO](config).use { client =>
 | [Sector Data](docs/sectors.md) | Sector overview, industries, top ETFs/funds |
 | [Industry Data](docs/industries.md) | Industry overview, top companies, performers, growth |
 | [Market Data](docs/markets.md) | Region summary, market status, trending tickers |
+| [Earnings Calendar](docs/calendars.md) | Market-wide and per-ticker earnings events |
 | [Search & ISIN](docs/search.md) | Ticker search and ISIN lookup |
 | [Screener](docs/screener.md) | Custom and predefined stock/fund screens |
 | [Batch Operations](docs/batch-operations.md) | Multi-ticker parallel fetches |

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/Calendars.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/Calendars.scala
@@ -1,0 +1,305 @@
+package org.coinductive.yfinance4s
+
+import cats.MonadThrow
+import cats.syntax.all.*
+import io.circe.Json
+import io.circe.syntax.*
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.models.internal.*
+
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
+import scala.util.Try
+
+/** Algebra for Yahoo Finance calendar-style queries.
+  *
+  * Phase 6.1 exposes earnings queries; subsequent phases will add IPO (6.2), economic-event (6.3), and splits (6.4)
+  * calendar methods.
+  */
+trait Calendars[F[_]] {
+
+  /** Upcoming and recent earnings events across all tickers in a date range, ordered by market capitalization
+    * descending by default (server-side via `config.sort`).
+    *
+    * @param start
+    *   Inclusive lower bound for the earnings event date. Defaults to `LocalDate.now()` in the system default zone;
+    *   pass `LocalDate.now(ZoneOffset.UTC)` for zone-independent queries.
+    * @param end
+    *   Inclusive upper bound for the earnings event date. Defaults to one week after `start`.
+    * @param config
+    *   Pagination, limit, sort, and market-cap threshold. See [[CalendarConfig]].
+    */
+  def getEarningsCalendar(
+      start: LocalDate = LocalDate.now(),
+      end: LocalDate = LocalDate.now().plusDays(Calendars.DefaultEarningsCalendarDays),
+      config: CalendarConfig = CalendarConfig.Default
+  ): F[List[EarningsEvent]]
+
+  /** Historical and upcoming earnings events for a specific ticker, ordered by date descending (most recent first).
+    *
+    * @param ticker
+    *   Ticker to query. Expected in Yahoo's canonical uppercase form (e.g., `"AAPL"`); Yahoo rejects lowercase.
+    * @param limit
+    *   Number of events to return. Yahoo caps at 100; defaults to 12.
+    * @param offset
+    *   Skip the first `offset` events.
+    */
+  def getEarningsDates(
+      ticker: Ticker,
+      limit: Int = Calendars.DefaultEarningsDatesLimit,
+      offset: Int = 0
+  ): F[List[EarningsDate]]
+}
+
+private[yfinance4s] object Calendars {
+
+  val DefaultEarningsCalendarDays: Int = 7
+  val DefaultEarningsDatesLimit: Int = 12
+  val MaxLimit: Int = 100
+
+  private val DateFmt: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+
+  private val SpEarningsEntityType: String = "sp_earnings"
+  private val EarningsEntityType: String = "earnings"
+
+  private val MarketWideContext: String = "earnings calendar"
+  private val PerTickerContext: String = "earnings dates"
+
+  private val UsRegion: String = "us"
+
+  private object Field {
+    val Ticker: String = "ticker"
+    val CompanyShortName: String = "companyshortname"
+    val IntradayMarketCap: String = "intradaymarketcap"
+    val EventName: String = "eventname"
+    val StartDateTime: String = "startdatetime"
+    val StartDateTimeType: String = "startdatetimetype"
+    val EpsEstimate: String = "epsestimate"
+    val EpsActual: String = "epsactual"
+    val EpsSurprisePct: String = "epssurprisepct"
+    val EventType: String = "eventtype"
+    val Region: String = "region"
+    val TimeZoneShortName: String = "timeZoneShortName"
+  }
+
+  private object Operator {
+    val Eq: String = "EQ"
+    val Gte: String = "GTE"
+    val Lte: String = "LTE"
+    val And: String = "AND"
+    val Or: String = "OR"
+  }
+
+  private object EventTypeCode {
+    val EarningsAnnouncementDate: String = "EAD"
+    val EarningsReleaseAnnouncement: String = "ERA"
+  }
+
+  private val MarketWideFields: List[String] = List(
+    Field.Ticker,
+    Field.CompanyShortName,
+    Field.IntradayMarketCap,
+    Field.EventName,
+    Field.StartDateTime,
+    Field.StartDateTimeType,
+    Field.EpsEstimate,
+    Field.EpsActual,
+    Field.EpsSurprisePct
+  )
+
+  private val PerTickerFields: List[String] = List(
+    Field.StartDateTime,
+    Field.TimeZoneShortName,
+    Field.EpsEstimate,
+    Field.EpsActual,
+    Field.EpsSurprisePct,
+    Field.EventType
+  )
+
+  def apply[F[_]: MonadThrow](gateway: YFinanceGateway[F], auth: YFinanceAuth[F]): Calendars[F] =
+    new CalendarsImpl(gateway, auth)
+
+  // --- Pure helpers (no F) exposed for unit testing ----------------------
+
+  private[yfinance4s] def buildMarketWideBody(start: LocalDate, end: LocalDate, config: CalendarConfig): String = {
+    val eventTypeOr: Json = operand(
+      Operator.Or,
+      List(
+        eqOperand(Field.EventType, EventTypeCode.EarningsAnnouncementDate),
+        eqOperand(Field.EventType, EventTypeCode.EarningsReleaseAnnouncement)
+      )
+    )
+    val baseOperands: List[Json] = List(
+      eqOperand(Field.Region, UsRegion),
+      eventTypeOr,
+      operand(Operator.Gte, List(Json.fromString(Field.StartDateTime), Json.fromString(start.format(DateFmt)))),
+      operand(Operator.Lte, List(Json.fromString(Field.StartDateTime), Json.fromString(end.format(DateFmt))))
+    )
+    val operands: List[Json] = config.marketCap.fold(baseOperands) { mc =>
+      baseOperands :+ operand(Operator.Gte, List(Json.fromString(Field.IntradayMarketCap), numericJson(mc)))
+    }
+    val query = operand(Operator.And, operands)
+    buildBody(SpEarningsEntityType, MarketWideFields, config.limit, config.offset, config.sort, query)
+  }
+
+  private[yfinance4s] def buildPerTickerBody(ticker: Ticker, limit: Int, offset: Int): String = {
+    val query = eqOperand(Field.Ticker, ticker.value)
+    buildBody(EarningsEntityType, PerTickerFields, limit, offset, CalendarSort.ByDateDesc, query)
+  }
+
+  private def buildBody(
+      entityIdType: String,
+      includeFields: List[String],
+      size: Int,
+      offset: Int,
+      sort: CalendarSort,
+      query: Json
+  ): String = {
+    val json = Json.obj(
+      "sortType" -> Json.fromString(sort.order.apiValue),
+      "entityIdType" -> Json.fromString(entityIdType),
+      "sortField" -> Json.fromString(sort.field),
+      "includeFields" -> includeFields.asJson,
+      "size" -> Json.fromInt(math.min(size, MaxLimit)),
+      "offset" -> Json.fromInt(offset),
+      "query" -> query
+    )
+    json.noSpaces
+  }
+
+  private def operand(op: String, args: List[Json]): Json =
+    Json.obj("operator" -> Json.fromString(op), "operands" -> Json.arr(args *))
+
+  private def eqOperand(field: String, value: String): Json =
+    operand(Operator.Eq, List(Json.fromString(field), Json.fromString(value)))
+
+  private def numericJson(value: Double): Json =
+    if (value == math.floor(value) && !value.isInfinite) Json.fromLong(value.toLong)
+    else Json.fromDoubleOrNull(value)
+
+  /** Accepts Yahoo's loose ISO-8601 (with or without offset) and assumes UTC when the offset is missing. Yahoo's
+    * documented format is `YYYY-MM-DDTHH:mm:ss` without a trailing 'Z'.
+    */
+  private def parseZonedDateTime(s: String): Option[ZonedDateTime] =
+    Try(ZonedDateTime.parse(s)).toOption
+      .orElse(Try(java.time.LocalDateTime.parse(s).atZone(ZoneOffset.UTC)).toOption)
+
+  // --- F-polymorphic impl ------------------------------------------------
+
+  private final class CalendarsImpl[F[_]](
+      gateway: YFinanceGateway[F],
+      auth: YFinanceAuth[F]
+  )(implicit F: MonadThrow[F])
+      extends Calendars[F] {
+
+    def getEarningsCalendar(
+        start: LocalDate,
+        end: LocalDate,
+        config: CalendarConfig
+    ): F[List[EarningsEvent]] =
+      auth.getCredentials.flatMap { creds =>
+        val body = buildMarketWideBody(start, end, config)
+        gateway.postVisualization(body, creds).flatMap(raiseOnError).flatMap(mapMarketWide)
+      }
+
+    def getEarningsDates(ticker: Ticker, limit: Int, offset: Int): F[List[EarningsDate]] =
+      auth.getCredentials.flatMap { creds =>
+        val body = buildPerTickerBody(ticker, limit, offset)
+        gateway.postVisualization(body, creds).flatMap(raiseOnError).flatMap(mapPerTicker)
+      }
+
+    // --- Error escalation -------------------------------------------------
+
+    private def raiseOnError(r: YFinanceCalendarResult): F[YFinanceCalendarResult] =
+      r.error.fold(F.pure(r))(err => F.raiseError(err.toException))
+
+    // --- Row mapping ------------------------------------------------------
+    //
+    // Structural fields (API-guaranteed) raise loudly when absent or malformed.
+    // Soft fields (best-effort) fall through to Option when the value is null or the column is missing.
+
+    private def mapMarketWide(raw: YFinanceCalendarResult): F[List[EarningsEvent]] =
+      raw.rows.traverse(mapMarketWideRow(raw.columnIndex)).map(_.sorted(EarningsEvent.byDateAsc))
+
+    private def mapMarketWideRow(idx: Map[String, Int])(row: CalendarRow): F[EarningsEvent] =
+      for {
+        symbolStr <- requireString(row, idx, Field.Ticker, MarketWideContext)
+        startStr <- requireString(row, idx, Field.StartDateTime, MarketWideContext)
+        start <- parseZdt(startStr, Field.StartDateTime, MarketWideContext)
+        timingRaw <- requireString(row, idx, Field.StartDateTimeType, MarketWideContext)
+        timing <- requireEnum(
+          EarningsTiming.withValueOpt(timingRaw),
+          timingRaw,
+          Field.StartDateTimeType,
+          MarketWideContext
+        )
+      } yield EarningsEvent(
+        symbol = Ticker(symbolStr),
+        companyName = optString(row, idx, Field.CompanyShortName),
+        marketCap = optLong(row, idx, Field.IntradayMarketCap),
+        eventName = optString(row, idx, Field.EventName),
+        startDateTime = start,
+        timing = timing,
+        epsEstimate = optDouble(row, idx, Field.EpsEstimate),
+        epsActual = optDouble(row, idx, Field.EpsActual),
+        surprisePercent = optDouble(row, idx, Field.EpsSurprisePct)
+      )
+
+    private def mapPerTicker(raw: YFinanceCalendarResult): F[List[EarningsDate]] =
+      raw.rows.traverse(mapPerTickerRow(raw.columnIndex)).map(_.sorted(EarningsDate.byDateDesc))
+
+    private def mapPerTickerRow(idx: Map[String, Int])(row: CalendarRow): F[EarningsDate] =
+      for {
+        startStr <- requireString(row, idx, Field.StartDateTime, PerTickerContext)
+        start <- parseZdt(startStr, Field.StartDateTime, PerTickerContext)
+        eventTypeRaw <- requireString(row, idx, Field.EventType, PerTickerContext)
+        eventType <- requireEnum(
+          EarningsEventType.withValueOpt(eventTypeRaw),
+          eventTypeRaw,
+          Field.EventType,
+          PerTickerContext
+        )
+      } yield EarningsDate(
+        date = start,
+        eventType = eventType,
+        epsEstimate = optDouble(row, idx, Field.EpsEstimate),
+        epsActual = optDouble(row, idx, Field.EpsActual),
+        surprisePercent = optDouble(row, idx, Field.EpsSurprisePct),
+        timezoneShort = optString(row, idx, Field.TimeZoneShortName)
+      )
+
+    // --- Field accessors --------------------------------------------------
+
+    private def requireString(
+        row: CalendarRow,
+        idx: Map[String, Int],
+        field: String,
+        context: String
+    ): F[String] =
+      idx.get(field).flatMap(row.stringAt) match {
+        case Some(v) => F.pure(v)
+        case None    => F.raiseError(new Exception(s"Missing required field '$field' in $context response row"))
+      }
+
+    private def parseZdt(s: String, field: String, context: String): F[ZonedDateTime] =
+      parseZonedDateTime(s) match {
+        case Some(v) => F.pure(v)
+        case None    => F.raiseError(new Exception(s"Unparseable '$field' in $context response row: '$s'"))
+      }
+
+    private def requireEnum[A](lookup: Option[A], raw: String, field: String, context: String): F[A] =
+      lookup match {
+        case Some(v) => F.pure(v)
+        case None    => F.raiseError(new Exception(s"Unknown '$field' value in $context response row: '$raw'"))
+      }
+
+    private def optString(row: CalendarRow, idx: Map[String, Int], field: String): Option[String] =
+      idx.get(field).flatMap(row.stringAt)
+
+    private def optLong(row: CalendarRow, idx: Map[String, Int], field: String): Option[Long] =
+      idx.get(field).flatMap(row.longAt)
+
+    private def optDouble(row: CalendarRow, idx: Map[String, Int], field: String): Option[Double] =
+      idx.get(field).flatMap(row.doubleAt)
+  }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -49,6 +49,9 @@ trait YFinanceClient[F[_]] {
   /** Market data (region summary, status, trending tickers). */
   def markets: Markets[F]
 
+  /** Calendar data (earnings events; IPO / economic / splits in future phases). */
+  def calendars: Calendars[F]
+
   /** Searches Yahoo Finance for tickers, companies, and news.
     *
     * @param query
@@ -202,6 +205,7 @@ object YFinanceClient {
     val sectors: Sectors[F] = Sectors(gateway, auth)
     val industries: Industries[F] = Industries(gateway, auth)
     val markets: Markets[F] = Markets(gateway, auth)
+    val calendars: Calendars[F] = Calendars(gateway, auth)
 
     def search(
         query: String,

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -49,6 +49,8 @@ sealed trait YFinanceGateway[F[_]] {
       count: Int,
       credentials: YFinanceCredentials
   ): F[YFinanceTrendingResult]
+
+  def postVisualization(body: String, credentials: YFinanceCredentials): F[YFinanceCalendarResult]
 }
 
 private object YFinanceGateway {
@@ -100,6 +102,13 @@ private object YFinanceGateway {
     private val MarketSummaryEndpoint = uri"https://query1.finance.yahoo.com/v6/finance/quote/marketSummary"
     private val MarketTimeEndpoint = uri"https://query1.finance.yahoo.com/v6/finance/markettime"
     private val TrendingEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/trending/"
+
+    private val VisualizationEndpoint = uri"https://query1.finance.yahoo.com/v1/finance/visualization"
+
+    private val VisualizationQueryParams = Map(
+      "lang" -> "en-US",
+      "region" -> "US"
+    )
 
     private val MarketSummaryFields = List(
       "shortName",
@@ -377,6 +386,18 @@ private object YFinanceGateway {
         .header("Cookie", credentials.cookies.mkString("; "))
 
       sendRequest(req, parseAs[YFinanceTrendingResult]("trending"))
+    }
+
+    def postVisualization(body: String, credentials: YFinanceCredentials): F[YFinanceCalendarResult] = {
+      val params = VisualizationQueryParams ++ Map("crumb" -> credentials.crumb)
+      val req = basicRequest
+        .post(VisualizationEndpoint.withParams(params))
+        .body(body)
+        .contentType("application/json")
+        .headers(YFinanceAuth.apiHeaders *)
+        .header("Cookie", credentials.cookies.mkString("; "))
+
+      sendRequest(req, parseAs[YFinanceCalendarResult]("calendar"))
     }
 
   }

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/CalendarConfig.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/CalendarConfig.scala
@@ -1,0 +1,35 @@
+package org.coinductive.yfinance4s.models
+
+/** Configuration for a custom earnings calendar query. Shape mirrors [[ScreenerConfig]] for familiarity.
+  *
+  * @param limit
+  *   Maximum events to return (1..100, Yahoo-capped).
+  * @param offset
+  *   Skip the first N events (for pagination).
+  * @param marketCap
+  *   If set, filter to events whose company has at least this USD market cap.
+  * @param sort
+  *   Server-side sort field/order. Default is market cap descending.
+  */
+final case class CalendarConfig(
+    limit: Int = CalendarConfig.DefaultLimit,
+    offset: Int = 0,
+    marketCap: Option[Double] = None,
+    sort: CalendarSort = CalendarSort.Default
+)
+
+object CalendarConfig {
+  val DefaultLimit: Int = 25
+  val MaxLimit: Int = 100
+
+  val Default: CalendarConfig = CalendarConfig()
+}
+
+/** Server-side sort rule for calendar queries. Reuses [[SortOrder]] from the screener module. */
+final case class CalendarSort(field: String, order: SortOrder)
+
+object CalendarSort {
+  val Default: CalendarSort = CalendarSort("intradaymarketcap", SortOrder.Desc)
+  val ByDateAsc: CalendarSort = CalendarSort("startdatetime", SortOrder.Asc)
+  val ByDateDesc: CalendarSort = CalendarSort("startdatetime", SortOrder.Desc)
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsDate.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsDate.scala
@@ -1,0 +1,69 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.{LocalDate, ZonedDateTime}
+
+/** A single earnings event for a specific ticker, returned by
+  * [[org.coinductive.yfinance4s.Calendars.getEarningsDates]].
+  *
+  * Yahoo's per-ticker earnings feed carries event-type metadata (earnings call vs. report vs. stockholders meeting) but
+  * omits the market-cap and company-name metadata available in the market-wide feed.
+  *
+  * @param date
+  *   Scheduled or historical date/time of the event. Always present; decode fails if Yahoo omits it.
+  * @param eventType
+  *   What kind of event this is: call, report, or meeting.
+  * @param epsEstimate
+  *   Consensus EPS estimate ahead of the event.
+  * @param epsActual
+  *   Reported EPS (empty for future events).
+  * @param surprisePercent
+  *   Earnings surprise as a signed percentage.
+  * @param timezoneShort
+  *   Human-readable timezone abbreviation Yahoo returned (e.g., "EDT"). Not normalized; consult `date`'s
+  *   `ZonedDateTime` for the authoritative offset.
+  */
+final case class EarningsDate(
+    date: ZonedDateTime,
+    eventType: EarningsEventType,
+    epsEstimate: Option[Double],
+    epsActual: Option[Double],
+    surprisePercent: Option[Double],
+    timezoneShort: Option[String]
+) {
+
+  /** The event's local date. */
+  def localDate: LocalDate = date.toLocalDate
+
+  /** True if this is an earnings call event. */
+  def isCall: Boolean = eventType == EarningsEventType.EarningsCall
+
+  /** True if this is an earnings report event. */
+  def isReport: Boolean = eventType == EarningsEventType.EarningsReport
+
+  /** True if this is a stockholders meeting event. */
+  def isMeeting: Boolean = eventType == EarningsEventType.StockholdersMeeting
+
+  /** True when the event is scheduled strictly after `reference`. */
+  def isFuture(reference: ZonedDateTime): Boolean =
+    date.isAfter(reference)
+
+  /** True when the event is scheduled strictly before `reference`. */
+  def isPast(reference: ZonedDateTime): Boolean =
+    date.isBefore(reference)
+
+  /** Beat the consensus: `surprisePercent > 0`. */
+  def isBeat: Option[Boolean] = surprisePercent.map(_ > 0)
+
+  /** Missed the consensus: `surprisePercent < 0`. */
+  def isMiss: Option[Boolean] = surprisePercent.map(_ < 0)
+}
+
+object EarningsDate {
+
+  /** Orders dates ascending (earliest first). */
+  implicit val byDateAsc: Ordering[EarningsDate] =
+    Ordering.by[EarningsDate, ZonedDateTime](_.date)
+
+  /** Orders dates descending (most recent first) - matches upstream default sort. */
+  val byDateDesc: Ordering[EarningsDate] = byDateAsc.reverse
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsEvent.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsEvent.scala
@@ -1,0 +1,80 @@
+package org.coinductive.yfinance4s.models
+
+import java.time.{LocalDate, ZonedDateTime}
+
+/** A scheduled earnings event from Yahoo Finance's market-wide calendar feed.
+  *
+  * Returned by [[org.coinductive.yfinance4s.Calendars.getEarningsCalendar]]. Unlike [[EarningsDate]], this carries
+  * company and market-cap metadata plus a scheduling-timing modifier. Unlike [[EarningsHistory]] (which comes from the
+  * analyst-trend API and uses quarter labels), this has an explicit `ZonedDateTime` and covers future events.
+  *
+  * @param symbol
+  *   Ticker symbol of the reporting company.
+  * @param companyName
+  *   Human-readable short name (e.g., "Apple Inc"), if Yahoo supplies it.
+  * @param marketCap
+  *   Intraday market cap in USD, if available.
+  * @param eventName
+  *   Yahoo's display name for the event (e.g., "Apple Inc Q4 2025 Earnings Call").
+  * @param startDateTime
+  *   Scheduled date and time of the event. Always present; decode fails if Yahoo omits it.
+  * @param timing
+  *   When during the trading day the release is scheduled.
+  * @param epsEstimate
+  *   Consensus EPS estimate ahead of the release.
+  * @param epsActual
+  *   Reported EPS (empty for future events).
+  * @param surprisePercent
+  *   Earnings surprise as a signed percentage.
+  */
+final case class EarningsEvent(
+    symbol: Ticker,
+    companyName: Option[String],
+    marketCap: Option[Long],
+    eventName: Option[String],
+    startDateTime: ZonedDateTime,
+    timing: EarningsTiming,
+    epsEstimate: Option[Double],
+    epsActual: Option[Double],
+    surprisePercent: Option[Double]
+) {
+
+  /** Local date portion of the scheduled event. */
+  def date: LocalDate = startDateTime.toLocalDate
+
+  /** True when the event is scheduled strictly after `reference`. */
+  def isFuture(reference: ZonedDateTime): Boolean =
+    startDateTime.isAfter(reference)
+
+  /** True when the event is scheduled strictly before `reference`. */
+  def isPast(reference: ZonedDateTime): Boolean =
+    startDateTime.isBefore(reference)
+
+  /** Beat the consensus: `surprisePercent > 0`. */
+  def isBeat: Option[Boolean] = surprisePercent.map(_ > 0)
+
+  /** Missed the consensus: `surprisePercent < 0`. */
+  def isMiss: Option[Boolean] = surprisePercent.map(_ < 0)
+
+  /** Release scheduled before the US regular session opens. */
+  def isBeforeMarketOpen: Boolean =
+    timing == EarningsTiming.BeforeMarketOpen
+
+  /** Release scheduled after the US regular session closes. */
+  def isAfterMarketClose: Boolean =
+    timing == EarningsTiming.AfterMarketClose
+}
+
+object EarningsEvent {
+
+  /** Orders events by scheduled date/time ascending (earliest first). */
+  implicit val byDateAsc: Ordering[EarningsEvent] =
+    Ordering.by[EarningsEvent, ZonedDateTime](_.startDateTime)
+
+  /** Orders events by scheduled date/time descending (latest first). */
+  val byDateDesc: Ordering[EarningsEvent] = byDateAsc.reverse
+
+  /** Orders events by market cap descending (largest first); entries with no market cap sort last. */
+  val byMarketCapDesc: Ordering[EarningsEvent] =
+    Ordering.by[EarningsEvent, Long](_.marketCap.getOrElse(Long.MinValue)).reverse
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsEventType.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsEventType.scala
@@ -1,0 +1,16 @@
+package org.coinductive.yfinance4s.models
+
+import enumeratum.values.{StringEnum, StringEnumEntry}
+
+/** Event kind in a per-ticker earnings feed. Maps Yahoo's numeric string codes (empirically `"1"`, `"2"`, `"11"`) to
+  * typed domain values.
+  */
+sealed abstract class EarningsEventType(val value: String) extends StringEnumEntry
+
+object EarningsEventType extends StringEnum[EarningsEventType] {
+  case object EarningsCall extends EarningsEventType("1")
+  case object EarningsReport extends EarningsEventType("2")
+  case object StockholdersMeeting extends EarningsEventType("11")
+
+  val values: IndexedSeq[EarningsEventType] = findValues
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsTiming.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/EarningsTiming.scala
@@ -1,0 +1,17 @@
+package org.coinductive.yfinance4s.models
+
+import enumeratum.values.{StringEnum, StringEnumEntry}
+
+/** Scheduled timing modifier for an earnings event (the `startdatetimetype` field on Yahoo's visualization response).
+  * Maps Yahoo's plain-text values to typed domain values.
+  */
+sealed abstract class EarningsTiming(val value: String) extends StringEnumEntry
+
+object EarningsTiming extends StringEnum[EarningsTiming] {
+  case object BeforeMarketOpen extends EarningsTiming("BMO")
+  case object AfterMarketClose extends EarningsTiming("AMC")
+  case object TimeNotSupplied extends EarningsTiming("TNS")
+  case object TimeAsSpecified extends EarningsTiming("TAS")
+
+  val values: IndexedSeq[EarningsTiming] = findValues
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceCalendarResult.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/internal/YFinanceCalendarResult.scala
@@ -1,0 +1,78 @@
+package org.coinductive.yfinance4s.models.internal
+
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{Decoder, Json}
+
+/** Root response from `POST /v1/finance/visualization`. Both market-wide and per-ticker earnings queries return this
+  * shape.
+  *
+  * Rows are positional JSON arrays aligned with the `columns` list by index. Lookup happens in the algebra via
+  * [[columnIndex]] keyed off each column's stable `id`, never the (potentially duplicated) `label`.
+  */
+private[yfinance4s] final case class YFinanceCalendarResult(
+    columns: List[CalendarColumn],
+    rows: List[CalendarRow],
+    error: Option[CalendarError]
+) {
+
+  /** Zero-based column index keyed by Yahoo's stable `id` (not `label`). */
+  def columnIndex: Map[String, Int] =
+    columns.zipWithIndex.map { case (c, i) => c.id -> i }.toMap
+}
+
+private[yfinance4s] object YFinanceCalendarResult {
+
+  implicit val decoder: Decoder[YFinanceCalendarResult] = Decoder.instance { c =>
+    val finance = c.downField("finance")
+    finance.downField("error").as[Option[CalendarError]].flatMap {
+      case err @ Some(_) =>
+        Right(YFinanceCalendarResult(columns = Nil, rows = Nil, error = err))
+
+      case None =>
+        val doc = finance.downField("result").downArray.downField("documents").downArray
+        for {
+          columns <- doc.downField("columns").as[Option[List[CalendarColumn]]].map(_.getOrElse(Nil))
+          rows <- doc.downField("rows").as[Option[List[CalendarRow]]].map(_.getOrElse(Nil))
+        } yield YFinanceCalendarResult(columns = columns, rows = rows, error = None)
+    }
+  }
+}
+
+private[yfinance4s] final case class CalendarColumn(
+    id: String,
+    label: String,
+    `type`: String
+)
+
+private[yfinance4s] object CalendarColumn {
+  implicit val decoder: Decoder[CalendarColumn] = deriveDecoder
+}
+
+/** Raw row as a positional array of JSON values. Lookup is by column index computed from
+  * [[YFinanceCalendarResult.columnIndex]].
+  */
+private[yfinance4s] final case class CalendarRow(values: List[Json]) {
+
+  def stringAt(idx: Int): Option[String] =
+    values.lift(idx).flatMap(_.asString)
+
+  def longAt(idx: Int): Option[Long] =
+    values.lift(idx).flatMap(j => j.asNumber.flatMap(_.toLong))
+
+  def doubleAt(idx: Int): Option[Double] =
+    values.lift(idx).flatMap(j => j.asNumber.map(_.toDouble))
+}
+
+private[yfinance4s] object CalendarRow {
+  implicit val decoder: Decoder[CalendarRow] =
+    Decoder[List[Json]].map(CalendarRow(_))
+}
+
+private[yfinance4s] final case class CalendarError(code: String, description: String) {
+  def toException: Throwable =
+    new Exception(s"Yahoo calendar query failed: $code - $description")
+}
+
+private[yfinance4s] object CalendarError {
+  implicit val decoder: Decoder[CalendarError] = deriveDecoder
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/EarningsCalendarSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/EarningsCalendarSpec.scala
@@ -1,0 +1,136 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.models.*
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+
+import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
+import scala.concurrent.duration.*
+
+class EarningsCalendarSpec extends CatsEffectSuite {
+
+  private val config: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  private val today: LocalDate = LocalDate.now(ZoneOffset.UTC)
+
+  // --- getEarningsCalendar ---
+
+  test("returns a non-empty earnings calendar over a 30-day window") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars
+        .getEarningsCalendar(start = today, end = today.plusDays(30))
+        .map { events =>
+          assert(events.nonEmpty, "earnings calendar should return results over a 30-day window")
+          events.foreach { e =>
+            assert(e.symbol.value.nonEmpty, s"symbol should be non-empty: $e")
+          }
+        }
+    }
+  }
+
+  test("orders returned events by scheduled date ascending") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars
+        .getEarningsCalendar(start = today, end = today.plusDays(14), config = CalendarConfig(limit = 20))
+        .map { events =>
+          val starts = events.map(_.startDateTime)
+          assertEquals(starts, starts.sorted, "events should be ordered by startDateTime ascending")
+        }
+    }
+  }
+
+  test("respects the configured limit") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars
+        .getEarningsCalendar(start = today, end = today.plusDays(30), config = CalendarConfig(limit = 5))
+        .map { events =>
+          assert(events.size <= 5, s"expected at most 5 events, got ${events.size}")
+        }
+    }
+  }
+
+  test("market-cap filter excludes companies below the threshold") {
+    YFinanceClient.resource[IO](config).use { client =>
+      val threshold = 100_000_000_000d
+      client.calendars
+        .getEarningsCalendar(
+          start = today,
+          end = today.plusDays(60),
+          config = CalendarConfig(limit = 25, marketCap = Some(threshold))
+        )
+        .map { events =>
+          events.foreach { e =>
+            e.marketCap.foreach { mc =>
+              assert(mc >= threshold.toLong, s"event ${e.symbol.value} market cap $mc below threshold $threshold")
+            }
+          }
+        }
+    }
+  }
+
+  // --- getEarningsDates ---
+
+  test("returns a non-empty earnings timeline for Apple") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars.getEarningsDates(Ticker("AAPL"), limit = 8).map { dates =>
+        assert(dates.nonEmpty, "Apple should have at least 8 visible earnings events")
+        dates.foreach { d =>
+          assert(d.date.getYear >= 2000, s"suspicious date: ${d.date}")
+        }
+      }
+    }
+  }
+
+  test("orders Apple's earnings by date descending") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars.getEarningsDates(Ticker("AAPL"), limit = 8).map { dates =>
+        val stamps = dates.map(_.date)
+        assertEquals(stamps, stamps.sorted(Ordering[ZonedDateTime].reverse))
+      }
+    }
+  }
+
+  test("includes at least one historical earnings report with a reported EPS for Apple") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars.getEarningsDates(Ticker("AAPL"), limit = 12).map { dates =>
+        val withActual = dates.filter(_.epsActual.isDefined)
+        assert(withActual.nonEmpty, s"expected at least one historical report with an actual, got $dates")
+      }
+    }
+  }
+
+  test("respects the limit parameter for per-ticker queries") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars.getEarningsDates(Ticker("AAPL"), limit = 5).map { dates =>
+        assert(dates.size <= 5, s"expected at most 5 dates, got ${dates.size}")
+      }
+    }
+  }
+
+  test("returns an empty list for a ticker that doesn't exist") {
+    YFinanceClient.resource[IO](config).use { client =>
+      client.calendars.getEarningsDates(Ticker("_DEFINITELY_NOT_A_TICKER_"), limit = 5).map { dates =>
+        assert(dates.isEmpty, s"expected no events for a non-existent ticker, got ${dates.size}")
+      }
+    }
+  }
+
+  test("offset skips the first page of Apple's earnings events") {
+    YFinanceClient.resource[IO](config).use { client =>
+      for {
+        page0 <- client.calendars.getEarningsDates(Ticker("AAPL"), limit = 5, offset = 0)
+        page1 <- client.calendars.getEarningsDates(Ticker("AAPL"), limit = 5, offset = 5)
+      } yield {
+        if (page0.size == 5 && page1.nonEmpty) {
+          val overlap = page0.map(_.date).toSet intersect page1.map(_.date).toSet
+          assert(overlap.isEmpty, s"page 0 and page 1 should be disjoint, overlap: $overlap")
+        }
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CalendarsBodySpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/CalendarsBodySpec.scala
@@ -1,0 +1,148 @@
+package org.coinductive.yfinance4s.unit
+
+import io.circe.Json
+import io.circe.parser.parse
+import munit.FunSuite
+import org.coinductive.yfinance4s.Calendars
+import org.coinductive.yfinance4s.models.*
+
+import java.time.LocalDate
+
+class CalendarsBodySpec extends FunSuite {
+
+  private val start: LocalDate = LocalDate.of(2026, 1, 1)
+  private val end: LocalDate = LocalDate.of(2026, 1, 7)
+
+  private def parseJson(raw: String): Json =
+    parse(raw).getOrElse(fail(s"body is not valid JSON: $raw"))
+
+  private def stringField(json: Json, field: String): String =
+    json.hcursor.downField(field).as[String].getOrElse(fail(s"missing $field"))
+
+  private def intField(json: Json, field: String): Int =
+    json.hcursor.downField(field).as[Int].getOrElse(fail(s"missing $field"))
+
+  private def flattenOperands(query: Json): List[Json] = {
+    def loop(j: Json): List[Json] =
+      j.hcursor.downField("operands").as[List[Json]] match {
+        case Right(ops) => j :: ops.flatMap(loop)
+        case Left(_)    => List(j)
+      }
+    loop(query)
+  }
+
+  private def findOperand(query: Json, operator: String, field: String): Option[Json] =
+    flattenOperands(query).find { op =>
+      val isOp = op.hcursor.downField("operator").as[String].exists(_ == operator)
+      val hasField = op.hcursor.downField("operands").downArray.as[String].exists(_ == field)
+      isOp && hasField
+    }
+
+  // --- Market-wide body ---
+
+  test("market-wide body uses the sp_earnings entity type and market-cap sort") {
+    val body = parseJson(Calendars.buildMarketWideBody(start, end, CalendarConfig.Default))
+    assertEquals(stringField(body, "entityIdType"), "sp_earnings")
+    assertEquals(stringField(body, "sortField"), "intradaymarketcap")
+    assertEquals(stringField(body, "sortType"), "DESC")
+  }
+
+  test("market-wide body includes the requested date bounds as startdatetime operands") {
+    val body = parseJson(Calendars.buildMarketWideBody(start, end, CalendarConfig.Default))
+    val query = body.hcursor.downField("query").as[Json].getOrElse(fail("missing query"))
+
+    val gte = findOperand(query, "GTE", "startdatetime")
+      .getOrElse(fail(s"no GTE startdatetime operand in ${query.noSpaces}"))
+    val lte = findOperand(query, "LTE", "startdatetime")
+      .getOrElse(fail(s"no LTE startdatetime operand in ${query.noSpaces}"))
+
+    assertEquals(gte.hcursor.downField("operands").downN(1).as[String].toOption, Some("2026-01-01"))
+    assertEquals(lte.hcursor.downField("operands").downN(1).as[String].toOption, Some("2026-01-07"))
+  }
+
+  test("market-wide body restricts eventtype to EAD and ERA via an OR branch") {
+    val body = parseJson(Calendars.buildMarketWideBody(start, end, CalendarConfig.Default))
+    val query = body.hcursor.downField("query").as[Json].getOrElse(fail("missing query"))
+    val ops = flattenOperands(query)
+
+    val orBranch = ops
+      .find { op =>
+        val isOr = op.hcursor.downField("operator").as[String].exists(_ == "OR")
+        isOr && op.hcursor
+          .downField("operands")
+          .downArray
+          .downField("operands")
+          .downN(0)
+          .as[String]
+          .toOption
+          .contains("eventtype")
+      }
+      .getOrElse(fail(s"no OR eventtype branch in ${query.noSpaces}"))
+
+    val eventTypeValues = orBranch.hcursor.downField("operands").as[List[Json]].getOrElse(Nil).flatMap { inner =>
+      inner.hcursor.downField("operands").downN(1).as[String].toOption
+    }
+    assertEquals(eventTypeValues.toSet, Set("EAD", "ERA"))
+  }
+
+  test("market-wide body omits the intradaymarketcap operand when no market cap is configured") {
+    val body = parseJson(Calendars.buildMarketWideBody(start, end, CalendarConfig.Default))
+    val query = body.hcursor.downField("query").as[Json].getOrElse(fail("missing query"))
+    assert(findOperand(query, "GTE", "intradaymarketcap").isEmpty)
+  }
+
+  test("market-wide body appends an intradaymarketcap GTE operand when the config requests it") {
+    val config = CalendarConfig(marketCap = Some(10_000_000_000d))
+    val body = parseJson(Calendars.buildMarketWideBody(start, end, config))
+    val query = body.hcursor.downField("query").as[Json].getOrElse(fail("missing query"))
+
+    val op = findOperand(query, "GTE", "intradaymarketcap")
+      .getOrElse(fail(s"no GTE intradaymarketcap in ${query.noSpaces}"))
+    assertEquals(op.hcursor.downField("operands").downN(1).as[Long].toOption, Some(10_000_000_000L))
+  }
+
+  test("market-wide body caps size at the Yahoo maximum when the config requests more") {
+    val body = parseJson(
+      Calendars.buildMarketWideBody(start, end, CalendarConfig.Default.copy(limit = CalendarConfig.MaxLimit))
+    )
+    assertEquals(intField(body, "size"), Calendars.MaxLimit)
+  }
+
+  test("market-wide body respects the configured offset") {
+    val body = parseJson(Calendars.buildMarketWideBody(start, end, CalendarConfig.Default.copy(offset = 25)))
+    assertEquals(intField(body, "offset"), 25)
+  }
+
+  // --- Per-ticker body ---
+
+  test("per-ticker body uses the earnings entity type and startdatetime descending sort") {
+    val body = parseJson(Calendars.buildPerTickerBody(Ticker("AAPL"), limit = 20, offset = 0))
+    assertEquals(stringField(body, "entityIdType"), "earnings")
+    assertEquals(stringField(body, "sortField"), "startdatetime")
+    assertEquals(stringField(body, "sortType"), "DESC")
+  }
+
+  test("per-ticker body sends an EQ ticker operand carrying the exact ticker value") {
+    val body = parseJson(Calendars.buildPerTickerBody(Ticker("AAPL"), limit = 12, offset = 0))
+    val query = body.hcursor.downField("query").as[Json].getOrElse(fail("missing query"))
+    assertEquals(query.hcursor.downField("operator").as[String].toOption, Some("EQ"))
+    assertEquals(query.hcursor.downField("operands").downN(0).as[String].toOption, Some("ticker"))
+    assertEquals(query.hcursor.downField("operands").downN(1).as[String].toOption, Some("AAPL"))
+  }
+
+  test("per-ticker body includes eventtype in includeFields but market-wide body does not") {
+    val perTicker = parseJson(Calendars.buildPerTickerBody(Ticker("AAPL"), limit = 12, offset = 0))
+    val marketWide = parseJson(Calendars.buildMarketWideBody(start, end, CalendarConfig.Default))
+
+    val perTickerFields = perTicker.hcursor.downField("includeFields").as[List[String]].getOrElse(Nil)
+    val marketWideFields = marketWide.hcursor.downField("includeFields").as[List[String]].getOrElse(Nil)
+
+    assert(perTickerFields.contains("eventtype"), s"per-ticker missing eventtype: $perTickerFields")
+    assert(!marketWideFields.contains("eventtype"), s"market-wide should not request eventtype: $marketWideFields")
+  }
+
+  test("per-ticker body caps size at the Yahoo maximum when caller requests more") {
+    val body = parseJson(Calendars.buildPerTickerBody(Ticker("AAPL"), limit = 500, offset = 0))
+    assertEquals(intField(body, "size"), Calendars.MaxLimit)
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/EarningsDateSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/EarningsDateSpec.scala
@@ -1,0 +1,84 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+import java.time.{ZoneOffset, ZonedDateTime}
+
+class EarningsDateSpec extends FunSuite {
+
+  private val reference: ZonedDateTime = ZonedDateTime.of(2025, 10, 30, 12, 0, 0, 0, ZoneOffset.UTC)
+
+  private def date(
+      d: ZonedDateTime = reference,
+      eventType: EarningsEventType = EarningsEventType.EarningsReport,
+      surprisePercent: Option[Double] = None
+  ): EarningsDate =
+    EarningsDate(
+      date = d,
+      eventType = eventType,
+      epsEstimate = None,
+      epsActual = None,
+      surprisePercent = surprisePercent,
+      timezoneShort = Some("EDT")
+    )
+
+  // --- Event-type classification ---
+
+  test("an earnings call event is recognized only as a call") {
+    val d = date(eventType = EarningsEventType.EarningsCall)
+    assert(d.isCall)
+    assert(!d.isReport)
+    assert(!d.isMeeting)
+  }
+
+  test("an earnings report event is recognized only as a report") {
+    val d = date(eventType = EarningsEventType.EarningsReport)
+    assert(d.isReport)
+    assert(!d.isCall)
+    assert(!d.isMeeting)
+  }
+
+  test("a stockholders meeting event is recognized only as a meeting") {
+    val d = date(eventType = EarningsEventType.StockholdersMeeting)
+    assert(d.isMeeting)
+    assert(!d.isCall)
+    assert(!d.isReport)
+  }
+
+  // --- Scheduling classification ---
+
+  test("classifies a date after the reference as future and not past") {
+    val d = date(d = reference.plusHours(1))
+    assert(d.isFuture(reference))
+    assert(!d.isPast(reference))
+  }
+
+  test("treats a date exactly at the reference as neither future nor past") {
+    val d = date(d = reference)
+    assert(!d.isFuture(reference))
+    assert(!d.isPast(reference))
+  }
+
+  // --- Surprise classification ---
+
+  test("recognizes signed surprises as beat / miss") {
+    assertEquals(date(surprisePercent = Some(2.5)).isBeat, Some(true))
+    assertEquals(date(surprisePercent = Some(-1.5)).isMiss, Some(true))
+  }
+
+  test("treats zero surprise as neither beat nor miss") {
+    assertEquals(date(surprisePercent = Some(0.0)).isBeat, Some(false))
+    assertEquals(date(surprisePercent = Some(0.0)).isMiss, Some(false))
+  }
+
+  // --- Ordering ---
+
+  test("sorts dates descending (most recent first) under the default-sort ordering") {
+    val a = date(d = reference.minusDays(1))
+    val b = date(d = reference.plusDays(1))
+    val c = date(d = reference)
+    val sorted = List(a, b, c).sorted(EarningsDate.byDateDesc)
+    assertEquals(sorted.map(_.date), List(b.date, c.date, a.date))
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/EarningsEventSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/EarningsEventSpec.scala
@@ -1,0 +1,108 @@
+package org.coinductive.yfinance4s.unit
+
+import munit.FunSuite
+import org.coinductive.yfinance4s.models.*
+
+import java.time.{ZoneOffset, ZonedDateTime}
+
+class EarningsEventSpec extends FunSuite {
+
+  private val reference: ZonedDateTime = ZonedDateTime.of(2025, 10, 30, 12, 0, 0, 0, ZoneOffset.UTC)
+
+  private def event(
+      symbol: String = "AAPL",
+      startDateTime: ZonedDateTime = reference,
+      timing: EarningsTiming = EarningsTiming.AfterMarketClose,
+      marketCap: Option[Long] = Some(3_500_000_000_000L),
+      surprisePercent: Option[Double] = None
+  ): EarningsEvent =
+    EarningsEvent(
+      symbol = Ticker(symbol),
+      companyName = Some("Apple Inc"),
+      marketCap = marketCap,
+      eventName = Some("Apple Inc Q4 2025 Earnings Call"),
+      startDateTime = startDateTime,
+      timing = timing,
+      epsEstimate = None,
+      epsActual = None,
+      surprisePercent = surprisePercent
+    )
+
+  // --- Scheduling classification ---
+
+  test("classifies an event after the reference as future") {
+    val e = event(startDateTime = reference.plusHours(1))
+    assert(e.isFuture(reference))
+    assert(!e.isPast(reference))
+  }
+
+  test("classifies an event before the reference as past") {
+    val e = event(startDateTime = reference.minusHours(1))
+    assert(e.isPast(reference))
+    assert(!e.isFuture(reference))
+  }
+
+  test("treats an event exactly at the reference as neither future nor past") {
+    val e = event(startDateTime = reference)
+    assert(!e.isFuture(reference))
+    assert(!e.isPast(reference))
+  }
+
+  // --- Timing classification ---
+
+  test("identifies a BMO release as before market open and not after close") {
+    val e = event(timing = EarningsTiming.BeforeMarketOpen)
+    assert(e.isBeforeMarketOpen)
+    assert(!e.isAfterMarketClose)
+  }
+
+  test("identifies an AMC release as after market close and not before open") {
+    val e = event(timing = EarningsTiming.AfterMarketClose)
+    assert(e.isAfterMarketClose)
+    assert(!e.isBeforeMarketOpen)
+  }
+
+  test("treats an unsupplied timing as neither before open nor after close") {
+    val e = event(timing = EarningsTiming.TimeNotSupplied)
+    assert(!e.isBeforeMarketOpen)
+    assert(!e.isAfterMarketClose)
+  }
+
+  // --- Surprise classification ---
+
+  test("recognizes a positive surprise as a beat") {
+    val e = event(surprisePercent = Some(2.5))
+    assertEquals(e.isBeat, Some(true))
+    assertEquals(e.isMiss, Some(false))
+  }
+
+  test("recognizes a negative surprise as a miss") {
+    val e = event(surprisePercent = Some(-1.5))
+    assertEquals(e.isMiss, Some(true))
+    assertEquals(e.isBeat, Some(false))
+  }
+
+  test("treats a zero surprise as neither beat nor miss") {
+    val e = event(surprisePercent = Some(0.0))
+    assertEquals(e.isBeat, Some(false))
+    assertEquals(e.isMiss, Some(false))
+  }
+
+  // --- Orderings ---
+
+  test("sorts events by scheduled time ascending") {
+    val a = event(symbol = "A", startDateTime = reference.plusDays(2))
+    val b = event(symbol = "B", startDateTime = reference.plusDays(1))
+    val c = event(symbol = "C", startDateTime = reference)
+    val sorted = List(a, b, c).sorted(EarningsEvent.byDateAsc)
+    assertEquals(sorted.map(_.symbol.value), List("C", "B", "A"))
+  }
+
+  test("sorts events by market cap descending with missing caps last") {
+    val a = event(symbol = "A", marketCap = None)
+    val b = event(symbol = "B", marketCap = Some(500_000_000_000L))
+    val c = event(symbol = "C", marketCap = Some(3_000_000_000_000L))
+    val sorted = List(a, b, c).sorted(EarningsEvent.byMarketCapDesc)
+    assertEquals(sorted.map(_.symbol.value), List("C", "B", "A"))
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/TickersSpec.scala
@@ -108,6 +108,10 @@ class TickersSpec extends FunSuite {
       def getTrending(region: MarketRegion, count: Int): List[TrendingTicker] = ???
       def getMarketSnapshot(region: MarketRegion): MarketSnapshot = ???
     }
+    val calendars: Calendars[Id] = new Calendars[Id] {
+      def getEarningsCalendar(start: LocalDate, end: LocalDate, config: CalendarConfig): List[EarningsEvent] = ???
+      def getEarningsDates(ticker: Ticker, limit: Int, offset: Int): List[EarningsDate] = ???
+    }
     def search(query: String, maxResults: Int, newsCount: Int, enableFuzzyQuery: Boolean): SearchResult = ???
     def lookupByISIN(isin: String): Option[Ticker] = ???
     def lookupAllByISIN(isin: String): List[QuoteSearchResult] = ???

--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -1,0 +1,101 @@
+# Earnings Calendar
+
+The `calendars` module exposes Yahoo Finance's calendar-style queries, currently covering earnings events. Two query shapes are supported: a market-wide window (rank upcoming earnings across all tickers by market cap, date range, and threshold) and a per-ticker timeline (historical and upcoming earnings for one symbol).
+
+## Market-Wide Earnings Calendar
+
+Returns `EarningsEvent`s within a date range, ordered by scheduled date ascending. Yahoo's upstream default ranks by market cap descending; results are re-sorted client-side so the earliest events appear first.
+
+```scala
+import java.time.{LocalDate, ZoneOffset}
+import org.coinductive.yfinance4s.models.*
+
+clientResource.use { client =>
+  val today = LocalDate.now(ZoneOffset.UTC)
+  client.calendars.getEarningsCalendar(start = today, end = today.plusDays(7)).map { events =>
+    events.foreach { e =>
+      val cap = e.marketCap.map(mc => f"$$${mc / 1_000_000_000d}%.1fB").getOrElse("N/A")
+      val eps = e.epsEstimate.map(x => f"$x%.2f").getOrElse("-")
+      println(f"${e.symbol.value}%-8s ${e.date} ${e.timing.value}%-3s  est=$eps  cap=$cap")
+    }
+  }
+}
+```
+
+Defaults: `start = LocalDate.now()`, `end = start + 7 days`. For zone-independent queries pass `LocalDate.now(ZoneOffset.UTC)` explicitly.
+
+### Calendar Config
+
+`CalendarConfig` tunes pagination, size, sort, and the optional market-cap threshold:
+
+```scala
+val config = CalendarConfig(
+  limit = 50,                          // 1..100, Yahoo-capped
+  offset = 0,                          // pagination
+  marketCap = Some(10_000_000_000d),   // only companies with >= $10B market cap
+  sort = CalendarSort.ByDateAsc        // or CalendarSort.Default / ByDateDesc
+)
+
+clientResource.use { client =>
+  client.calendars.getEarningsCalendar(
+    start = LocalDate.now(ZoneOffset.UTC),
+    end = LocalDate.now(ZoneOffset.UTC).plusDays(30),
+    config = config
+  )
+}
+```
+
+Default config: `limit = 25`, `offset = 0`, no market-cap filter, sort by market cap descending.
+
+### Event Helpers
+
+`EarningsEvent` carries company metadata plus a `timing` modifier (`BeforeMarketOpen`, `AfterMarketClose`, `TimeNotSupplied`, `TimeAsSpecified`) and EPS fields where available:
+
+```scala
+events.foreach { e =>
+  if (e.isBeforeMarketOpen) println(s"${e.symbol.value} reports pre-market")
+  if (e.isAfterMarketClose) println(s"${e.symbol.value} reports post-close")
+  e.isBeat.foreach(beat => println(s"${e.symbol.value} ${if (beat) "beat" else "missed"} consensus"))
+}
+```
+
+Alternative orderings are available on the companion object:
+
+```scala
+val byMarketCap = events.sorted(EarningsEvent.byMarketCapDesc)
+val byDateDesc  = events.sorted(EarningsEvent.byDateDesc)
+```
+
+## Per-Ticker Earnings Timeline
+
+Returns a ticker's recent and upcoming earnings events as `EarningsDate`s, ordered by date descending (most recent first). Unlike the market-wide feed, per-ticker events include an explicit `eventType` (`EarningsCall`, `EarningsReport`, `StockholdersMeeting`).
+
+```scala
+clientResource.use { client =>
+  client.calendars.getEarningsDates(Ticker("AAPL"), limit = 12).map { dates =>
+    dates.foreach { d =>
+      val est = d.epsEstimate.map(x => f"$x%.2f").getOrElse("-")
+      val act = d.epsActual.map(x => f"$x%.2f").getOrElse("-")
+      val srp = d.surprisePercent.map(x => f"$x%+.1f%%").getOrElse("-")
+      println(f"${d.localDate} ${d.eventType}%-20s  est=$est  act=$act  surprise=$srp")
+    }
+  }
+}
+```
+
+Defaults: `limit = 12`, `offset = 0`. Yahoo caps the limit at 100; use `offset` for pagination.
+
+Tickers must be in Yahoo's canonical uppercase form (e.g., `"AAPL"`). Lowercase symbols are rejected upstream and return an empty list.
+
+### Filtering by Event Type
+
+```scala
+clientResource.use { client =>
+  client.calendars.getEarningsDates(Ticker("MSFT"), limit = 20).map { dates =>
+    val reports = dates.filter(_.isReport)
+    val calls = dates.filter(_.isCall)
+    val pastBeats = dates.filter(d => d.isPast(ZonedDateTime.now()) && d.isBeat.contains(true))
+    println(s"Reports: ${reports.size}, Calls: ${calls.size}, Past beats: ${pastBeats.size}")
+  }
+}
+```

--- a/docs/directory.conf
+++ b/docs/directory.conf
@@ -10,6 +10,7 @@ laika.navigationOrder = [
   sectors.md
   industries.md
   markets.md
+  calendars.md
   search.md
   screener.md
   batch-operations.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,6 +14,7 @@ YFinance4s is an effectful Yahoo Finance client for Scala, built on Cats Effect 
 - **Sector Data**: Sector overview, top ETFs, mutual funds, industries, and top companies for all 11 GICS sectors
 - **Industry Data**: Per-industry overview, top companies, top performers (YTD return, implied upside), and top growth companies
 - **Market Data**: Region-level market summary (headline indices), trading status with open/close times, and trending tickers
+- **Earnings Calendar**: Market-wide upcoming earnings ranked by market cap, and per-ticker historical/upcoming earnings timelines
 - **Search**: Ticker/company/news search with fuzzy matching
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
@@ -75,6 +76,7 @@ client.analysts    // price targets, recommendations, estimates
 client.sectors     // sector overview, industries, top ETFs/funds
 client.industries  // industry overview, top performers, top growth companies
 client.markets     // region summary, market status, trending tickers
+client.calendars   // earnings calendar and per-ticker earnings timelines
 client.screener    // custom and predefined stock/fund screens
 client.search(q)   // ticker and news search
 ```


### PR DESCRIPTION
Adds a new Calendars[F] algebra exposing two query methods over Yahoo's visualization endpoint:

- getEarningsCalendar(start, end, config): market-wide upcoming earnings ranked by market cap, filterable by date range and market-cap threshold.
- getEarningsDates(ticker, limit, offset): per-ticker historical and upcoming earnings events ordered by date descending.