### PR TITLE
Feat: adding rate limiting via upperbound

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Effectful Yahoo Finance client in the Scala programming language.
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
 - **Batch Operations**: Parallel multi-ticker fetches with configurable concurrency and error-tolerant modes
+- **Rate Limiting**: Built-in outbound request pacing (interval-based, configurable, on by default) to avoid Yahoo throttling
 - **Purely Functional**: Built on Cats Effect 3 with `Resource`-based lifecycle management
 - **Cross-Platform**: JVM and Scala.js
 - **Scala 2.13 & Scala 3**

--- a/build.sbt
+++ b/build.sbt
@@ -10,8 +10,8 @@ ThisBuild / scalaVersion := Scala2
 
 ThisBuild / testFrameworks += new TestFramework("munit.Framework")
 
-val catsV = "2.9.0"
-val catsEffectV = "3.4.8"
+val catsV = "2.11.0"
+val catsEffectV = "3.6.1"
 val circeV = "0.14.5"
 val sttpV = "3.10.1"
 val catsRetryV = "3.1.3"
@@ -19,6 +19,7 @@ val enumeratumV = "1.7.5"
 val chimneyV = "1.8.2"
 val jsoupV = "1.18.3"
 val munitCatsEffectV = "1.0.7"
+val upperboundV = "0.5.0"
 
 lazy val core = crossProject(JVMPlatform, JSPlatform)
   .crossType(CrossType.Full)
@@ -46,7 +47,9 @@ lazy val core = crossProject(JVMPlatform, JSPlatform)
       "com.github.cb372" %%% "cats-retry" % catsRetryV,
       "com.beachape" %%% "enumeratum" % enumeratumV,
       "io.scalaland" %%% "chimney" % chimneyV,
+      "org.systemfw" %%% "upperbound" % upperboundV,
       "org.typelevel" %%% "munit-cats-effect-3" % munitCatsEffectV % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % catsEffectV % Test,
     )
   )
   .jvmSettings(

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/HTTPBase.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/HTTPBase.scala
@@ -15,13 +15,14 @@ trait HTTPBase[F[_]] {
 
   protected val sttpBackend: SttpBackend[F, Any]
   protected val retryPolicy: RetryPolicy[F]
+  protected val rateLimiter: RateLimiter[F]
 
   protected def sendRequest[A](
       request: RequestT[Identity, Either[String, String], Any],
       parseContent: String => F[A]
   ): F[A] = {
     retryingOnAllErrors(policy = retryPolicy, (_: Throwable, _) => F.unit) {
-      request.send(sttpBackend)
+      rateLimiter.acquire(request.send(sttpBackend))
     }.flatMap(parseResponse[A](_, parseContent))
   }
 

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/RateLimiter.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/RateLimiter.scala
@@ -1,0 +1,45 @@
+package org.coinductive.yfinance4s
+
+import cats.Applicative
+import cats.effect.{Async, Resource}
+import org.coinductive.yfinance4s.models.RateLimitConfig
+import upperbound.Limiter
+
+import scala.concurrent.duration.DurationInt
+
+/** Paces outbound HTTP requests according to a [[RateLimitConfig]].
+  *
+  * A thin internal facade around `upperbound.Limiter` so that the rest of the codebase stays decoupled from the
+  * concrete implementation library.
+  */
+private[yfinance4s] sealed trait RateLimiter[F[_]] {
+
+  /** Wraps `fa` so that it does not start until the limiter issues a permit. */
+  def acquire[A](fa: F[A]): F[A]
+}
+
+private[yfinance4s] object RateLimiter {
+
+  /** Allocates a `RateLimiter` matching the supplied [[RateLimitConfig]]. Returns a no-op for `Disabled` and a
+    * permit-issuing limiter for `Enabled`. The returned `Resource` releases any underlying scheduling resources on
+    * close.
+    */
+  def resource[F[_]: Async](config: RateLimitConfig): Resource[F, RateLimiter[F]] =
+    config match {
+      case RateLimitConfig.Disabled =>
+        Resource.pure[F, RateLimiter[F]](noop[F])
+      case RateLimitConfig.Enabled(maxRequestsPerSecond) =>
+        val minInterval = 1.second / maxRequestsPerSecond.toLong
+        Limiter.start[F](minInterval).map(fromUpperbound[F])
+    }
+
+  /** A `RateLimiter` that never paces. Used for [[RateLimitConfig.Disabled]] and tests. */
+  def noop[F[_]: Applicative]: RateLimiter[F] = new RateLimiter[F] {
+    def acquire[A](fa: F[A]): F[A] = fa
+  }
+
+  private def fromUpperbound[F[_]](limiter: Limiter[F]): RateLimiter[F] =
+    new RateLimiter[F] {
+      def acquire[A](fa: F[A]): F[A] = limiter.submit(fa)
+    }
+}

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceAuth.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceAuth.scala
@@ -82,18 +82,20 @@ private object YFinanceAuth {
   def resource[F[_]: Async](
       connectTimeout: FiniteDuration,
       readTimeout: FiniteDuration,
-      retries: Int
+      retries: Int,
+      rateLimiter: RateLimiter[F]
   ): Resource[F, YFinanceAuth[F]] =
     PlatformSttpBackend.resource[F](connectTimeout, readTimeout).evalMap { backend =>
       val retryPolicy = RetryPolicies.limitRetries[F](retries)
       Ref.of[F, Option[YFinanceCredentials]](None).map { credentialsRef =>
-        new YFinanceAuthImpl[F](backend, retryPolicy, credentialsRef)
+        new YFinanceAuthImpl[F](backend, retryPolicy, rateLimiter, credentialsRef)
       }
     }
 
   private final class YFinanceAuthImpl[F[_]](
       sttpBackend: SttpBackend[F, Any],
       retryPolicy: RetryPolicy[F],
+      rateLimiter: RateLimiter[F],
       credentialsRef: Ref[F, Option[YFinanceCredentials]]
   )(implicit F: Async[F], S: Sleep[F])
       extends YFinanceAuth[F] {
@@ -121,7 +123,7 @@ private object YFinanceAuth {
 
       retry
         .retryingOnAllErrors(policy = retryPolicy, (_: Throwable, _) => F.unit) {
-          request.send(sttpBackend)
+          rateLimiter.acquire(request.send(sttpBackend))
         }
         .map { response =>
           response.headers
@@ -143,7 +145,7 @@ private object YFinanceAuth {
 
       retry
         .retryingOnAllErrors(policy = retryPolicy, (_: Throwable, _) => F.unit) {
-          request.send(sttpBackend)
+          rateLimiter.acquire(request.send(sttpBackend))
         }
         .flatMap { response =>
           response.body match {

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClient.scala
@@ -175,9 +175,10 @@ object YFinanceClient {
 
   def resource[F[_]: Async](config: YFinanceClientConfig): Resource[F, YFinanceClient[F]] =
     for {
-      gateway <- YFinanceGateway.resource[F](config.connectTimeout, config.readTimeout, config.retries)
-      scrapper <- YFinanceScrapper.resource[F](config.connectTimeout, config.readTimeout, config.retries)
-      auth <- YFinanceAuth.resource[F](config.connectTimeout, config.readTimeout, config.retries)
+      rateLimiter <- RateLimiter.resource[F](config.rateLimit)
+      gateway <- YFinanceGateway.resource[F](config.connectTimeout, config.readTimeout, config.retries, rateLimiter)
+      scrapper <- YFinanceScrapper.resource[F](config.connectTimeout, config.readTimeout, config.retries, rateLimiter)
+      auth <- YFinanceAuth.resource[F](config.connectTimeout, config.readTimeout, config.retries, rateLimiter)
     } yield new YFinanceClientImpl(gateway, scrapper, auth)
 
   private def downloadMulti[F[_], A](

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClientConfig.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceClientConfig.scala
@@ -1,5 +1,12 @@
 package org.coinductive.yfinance4s
 
+import org.coinductive.yfinance4s.models.RateLimitConfig
+
 import scala.concurrent.duration.FiniteDuration
 
-final case class YFinanceClientConfig(connectTimeout: FiniteDuration, readTimeout: FiniteDuration, retries: Int)
+final case class YFinanceClientConfig(
+    connectTimeout: FiniteDuration,
+    readTimeout: FiniteDuration,
+    retries: Int,
+    rateLimit: RateLimitConfig = RateLimitConfig.Default
+)

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceGateway.scala
@@ -58,18 +58,24 @@ private object YFinanceGateway {
   def resource[F[_]: Async](
       connectTimeout: FiniteDuration,
       readTimeout: FiniteDuration,
-      retries: Int
+      retries: Int,
+      rateLimiter: RateLimiter[F]
   ): Resource[F, YFinanceGateway[F]] =
-    PlatformSttpBackend.resource[F](connectTimeout, readTimeout).map(apply[F](retries, _))
+    PlatformSttpBackend.resource[F](connectTimeout, readTimeout).map(apply[F](retries, _, rateLimiter))
 
-  def apply[F[_]: Sync: Sleep](retries: Int, sttpBackend: SttpBackend[F, Any]): YFinanceGateway[F] = {
+  def apply[F[_]: Sync: Sleep](
+      retries: Int,
+      sttpBackend: SttpBackend[F, Any],
+      rateLimiter: RateLimiter[F]
+  ): YFinanceGateway[F] = {
     val retryPolicy = RetryPolicies.limitRetries(retries)
-    new YFinanceGatewayImpl[F](sttpBackend, retryPolicy)
+    new YFinanceGatewayImpl[F](sttpBackend, retryPolicy, rateLimiter)
   }
 
   private final class YFinanceGatewayImpl[F[_]](
       protected val sttpBackend: SttpBackend[F, Any],
-      protected val retryPolicy: RetryPolicy[F]
+      protected val retryPolicy: RetryPolicy[F],
+      protected val rateLimiter: RateLimiter[F]
   )(implicit
       protected val F: Sync[F],
       protected val S: Sleep[F]

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceScrapper.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/YFinanceScrapper.scala
@@ -22,18 +22,24 @@ private object YFinanceScrapper {
   def resource[F[_]: Async](
       connectTimeout: FiniteDuration,
       readTimeout: FiniteDuration,
-      retries: Int
+      retries: Int,
+      rateLimiter: RateLimiter[F]
   ): Resource[F, YFinanceScrapper[F]] =
-    PlatformSttpBackend.resource[F](connectTimeout, readTimeout).map(apply[F](retries, _))
+    PlatformSttpBackend.resource[F](connectTimeout, readTimeout).map(apply[F](retries, _, rateLimiter))
 
-  def apply[F[_]: Sync: Sleep](retries: Int, sttpBackend: SttpBackend[F, Any]): YFinanceScrapper[F] = {
+  def apply[F[_]: Sync: Sleep](
+      retries: Int,
+      sttpBackend: SttpBackend[F, Any],
+      rateLimiter: RateLimiter[F]
+  ): YFinanceScrapper[F] = {
     val retryPolicy = RetryPolicies.limitRetries(retries)
-    new YFinanceScrapperImpl[F](sttpBackend, retryPolicy)
+    new YFinanceScrapperImpl[F](sttpBackend, retryPolicy, rateLimiter)
   }
 
   private final class YFinanceScrapperImpl[F[_]](
       protected val sttpBackend: SttpBackend[F, Any],
-      protected val retryPolicy: RetryPolicy[F]
+      protected val retryPolicy: RetryPolicy[F],
+      protected val rateLimiter: RateLimiter[F]
   )(implicit
       protected val F: Sync[F],
       protected val S: Sleep[F]

--- a/core/shared/src/main/scala/org/coinductive/yfinance4s/models/RateLimitConfig.scala
+++ b/core/shared/src/main/scala/org/coinductive/yfinance4s/models/RateLimitConfig.scala
@@ -1,0 +1,31 @@
+package org.coinductive.yfinance4s.models
+
+/** Configures how outbound HTTP requests to Yahoo Finance are paced.
+  *
+  * Yahoo's unofficial API throttles aggressive callers and may return 429 ("Too Many Requests"). Use
+  * [[RateLimitConfig.Enabled]] (the default) to apply a request-pacing limit covering all requests issued by a single
+  * [[org.coinductive.yfinance4s.YFinanceClient]] instance.
+  *
+  * Pacing is interval-based: requests are spaced no closer than `1.second / maxRequestsPerSecond` apart, with no burst
+  * capacity. A long idle period does not earn credit toward subsequent bursts.
+  */
+sealed trait RateLimitConfig
+
+object RateLimitConfig {
+
+  /** Disables rate limiting entirely. Useful for tests and for callers who have their own throttle. */
+  case object Disabled extends RateLimitConfig
+
+  /** Enables interval-based rate limiting.
+    *
+    * @param maxRequestsPerSecond
+    *   Steady-state rate. Internally converted to a minimum interval of `1.second / maxRequestsPerSecond` between
+    *   request starts. Must be positive.
+    */
+  final case class Enabled(maxRequestsPerSecond: Int) extends RateLimitConfig {
+    require(maxRequestsPerSecond > 0, "maxRequestsPerSecond must be positive")
+  }
+
+  /** Conservative default: 2 requests per second. */
+  val Default: RateLimitConfig = Enabled(maxRequestsPerSecond = 2)
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/MarketDataSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/MarketDataSpec.scala
@@ -41,9 +41,12 @@ class MarketDataSpec extends CatsEffectSuite {
   test("includes the S&P 500 in the US market summary") {
     YFinanceClient.resource[IO](config).use { client =>
       client.markets.getSummary(US).map { summary =>
+        // Yahoo serves ^GSPC (cash) during regular hours and ES=F (E-mini S&P 500 futures)
+        // when the cash market is closed; either represents the same underlying index.
+        val present = summary.findBySymbol("^GSPC").orElse(summary.findBySymbol("ES=F"))
         assert(
-          summary.findBySymbol("^GSPC").isDefined,
-          s"expected ^GSPC in summary; got ${summary.quotes.map(_.symbol).mkString(",")}"
+          present.isDefined,
+          s"expected ^GSPC or ES=F in summary; got ${summary.quotes.map(_.symbol).mkString(",")}"
         )
       }
     }

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/RateLimitedClientSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/integration/RateLimitedClientSpec.scala
@@ -1,0 +1,68 @@
+package org.coinductive.yfinance4s.integration
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.{YFinanceClient, YFinanceClientConfig}
+import org.coinductive.yfinance4s.models.*
+
+import scala.concurrent.duration.*
+
+class RateLimitedClientSpec extends CatsEffectSuite {
+
+  override val munitTimeout: Duration = 120.seconds
+
+  private val baseConfig: YFinanceClientConfig = YFinanceClientConfig(
+    connectTimeout = 10.seconds,
+    readTimeout = 30.seconds,
+    retries = 3
+  )
+
+  private val tickers: NonEmptyList[Ticker] =
+    NonEmptyList.of(Ticker("AAPL"), Ticker("MSFT"), Ticker("GOOGL"), Ticker("NVDA"))
+
+  test("respects rate limit when downloading multiple tickers") {
+    val maxRequestsPerSecond = 2
+    val config = baseConfig.copy(rateLimit = RateLimitConfig.Enabled(maxRequestsPerSecond))
+
+    YFinanceClient.resource[IO](config).use { client =>
+      for {
+        start <- IO.monotonic
+        _ <- client.downloadCharts(tickers, Interval.`1Day`, Range.`1Month`, parallelism = tickers.size)
+        end <- IO.monotonic
+        elapsed = end - start
+      } yield {
+        // (n - 1) * minInterval is the lower bound for sequenced starts.
+        val lowerBound = (tickers.size - 1) * (1.second / maxRequestsPerSecond.toLong)
+        assert(
+          elapsed >= lowerBound,
+          s"expected elapsed >= $lowerBound under ${maxRequestsPerSecond} RPS, got $elapsed"
+        )
+      }
+    }
+  }
+
+  test("Disabled config does not introduce extra latency") {
+    val config = baseConfig.copy(rateLimit = RateLimitConfig.Disabled)
+
+    YFinanceClient.resource[IO](config).use { client =>
+      for {
+        start <- IO.monotonic
+        _ <- client.downloadCharts(tickers, Interval.`1Day`, Range.`1Month`, parallelism = tickers.size)
+        end <- IO.monotonic
+        elapsed = end - start
+      } yield {
+        // Sanity check: 4 small chart fetches with no pacing should easily complete in 30s.
+        assert(elapsed < 30.seconds, s"Disabled rate limiting should not throttle, got $elapsed")
+      }
+    }
+  }
+
+  test("default client config produces a working client") {
+    YFinanceClient.resource[IO](baseConfig).use { client =>
+      client.charts.getStock(Ticker("AAPL")).map { result =>
+        assert(result.isDefined, "AAPL stock should be retrievable with default config")
+      }
+    }
+  }
+}

--- a/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/RateLimiterSpec.scala
+++ b/core/shared/src/test/scala/org/coinductive/yfinance4s/unit/RateLimiterSpec.scala
@@ -1,0 +1,40 @@
+package org.coinductive.yfinance4s.unit
+
+import cats.effect.IO
+import cats.effect.testkit.TestControl
+import cats.syntax.all.*
+import munit.CatsEffectSuite
+import org.coinductive.yfinance4s.RateLimiter
+import org.coinductive.yfinance4s.models.RateLimitConfig
+
+import scala.concurrent.duration.*
+
+class RateLimiterSpec extends CatsEffectSuite {
+
+  test("Enabled config paces successive acquires at the configured interval") {
+    val maxRequestsPerSecond = 4
+    val acquires = 5
+    val expectedInterval = 1.second / maxRequestsPerSecond.toLong
+
+    val program = RateLimiter.resource[IO](RateLimitConfig.Enabled(maxRequestsPerSecond)).use { limiter =>
+      (1 to acquires).toList.traverse(_ => limiter.acquire(IO.monotonic))
+    }
+
+    TestControl.executeEmbed(program).map { times =>
+      val deltas = times.sliding(2).collect { case List(a, b) => b - a }.toList
+      deltas.foreach(d => assertEquals(d, expectedInterval))
+    }
+  }
+
+  test("Disabled config never delays an acquire") {
+    val program = RateLimiter.resource[IO](RateLimitConfig.Disabled).use { limiter =>
+      for {
+        start <- IO.monotonic
+        _ <- (1 to 100).toList.traverse_(_ => limiter.acquire(IO.unit))
+        end <- IO.monotonic
+      } yield end - start
+    }
+
+    TestControl.executeEmbed(program).assertEquals(Duration.Zero)
+  }
+}

--- a/docs/batch-operations.md
+++ b/docs/batch-operations.md
@@ -1,5 +1,10 @@
 # Batch Operations
 
+> **Rate limiting and concurrency compose independently.** All multi-ticker operations are paced by the client's
+> rate limiter (configured via `YFinanceClientConfig.rateLimit`, default 2 RPS). The `parallelism` /
+> `withParallelism` knob caps how many fibres are in-flight; the rate limiter caps how often new requests can
+> *start*. Both limits apply. See [Rate Limiting](index.md#rate-limiting) for configuration.
+
 ## Tickers Wrapper
 
 The `Tickers` wrapper provides a fluent API for fetching data across multiple tickers in parallel.

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ YFinance4s is an effectful Yahoo Finance client for Scala, built on Cats Effect 
 - **Stock Screener**: Custom and predefined equity/fund screens
 - **ISIN Lookup**: Resolve ISINs to Yahoo Finance tickers with ISO 6166 validation
 - **Batch Operations**: Parallel multi-ticker fetches with configurable concurrency and error-tolerant modes
+- **Rate Limiting**: Built-in outbound request pacing (interval-based, configurable, on by default) to avoid Yahoo throttling
 
 ## Platform Support
 
@@ -62,6 +63,30 @@ clientResource.use { client =>
   }
 }
 ```
+
+## Rate Limiting
+
+Outbound requests to Yahoo Finance are paced by default to avoid 429 ("Too Many Requests") responses. The default
+allows 2 requests per second; a single limiter is shared across all components of a client instance, so the
+configured rate is the *combined* outbound rate (not a per-component multiplier).
+
+Configure via `YFinanceClientConfig.rateLimit`:
+
+```scala
+import org.coinductive.yfinance4s.models.RateLimitConfig
+
+// Custom rate for an aggressive backfill
+val backfillConfig = config.copy(
+  rateLimit = RateLimitConfig.Enabled(maxRequestsPerSecond = 5)
+)
+
+// Disable entirely (e.g. tests, or callers with their own throttle)
+val unthrottledConfig = config.copy(rateLimit = RateLimitConfig.Disabled)
+```
+
+Pacing is interval-based: requests are spaced no closer than `1.second / maxRequestsPerSecond` apart, with no burst
+capacity. A long idle period does not earn credit toward subsequent bursts. Concurrency (e.g. `parTraverseN`) and
+pacing compose independently - both limits apply.
 
 ## Client API Overview
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -42,6 +42,19 @@
 | `Quarterly` | Quarterly financial data (up to 5 quarters of history) |
 | `Trailing` | Trailing twelve months (TTM) data |
 
+## Configuration
+
+**YFinanceClientConfig** - Client configuration:
+- `connectTimeout`: HTTP connection timeout
+- `readTimeout`: HTTP read timeout
+- `retries`: Number of retry attempts for failed requests
+- `rateLimit`: Outbound request pacing (default: `RateLimitConfig.Enabled(maxRequestsPerSecond = 2)`)
+
+**RateLimitConfig** - Outbound request pacing applied at the single HTTP chokepoint, shared across all components of one client:
+- `Disabled` - no rate limiting
+- `Enabled(maxRequestsPerSecond)` - interval-based pacing; request starts are spaced no closer than `1.second / maxRequestsPerSecond` apart, with no burst capacity
+- `Default` - `Enabled(maxRequestsPerSecond = 2)`
+
 ## Data Models
 
 ### Charts


### PR DESCRIPTION
Wiring a shared request-pacing limiter into `HTTPBase.sendRequest` to prevent Yahoo's 429 throttling on multi-ticker backfills. Public surface: `RateLimitConfig.{Disabled, Enabled(maxRequestsPerSecond)}` with `Default = Enabled(2)`, exposed on `YFinanceClientConfig.rateLimit`. Backed by `org.systemfw.upperbound` (interval-based pacing, no burst).